### PR TITLE
New commands (dao new, dao install, dao upgrade, aragon ipfs) + aragon run refactor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@aragon/apm": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-1.0.0.tgz",
-      "integrity": "sha512-RzER6bmJOeB+bk/MXI+B++NAkusY8jJfqfUkzmoO43UX+o7uJeP8M5OCdguHMwxVx9I6JauIAO/OIeUrizbAmg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-1.1.1.tgz",
+      "integrity": "sha512-x0H9sSr3bsdjVZieBwKDAhb9D3Cvpe6YTU9F97IjFg7ew5u35E+8u87UWKvuocb1+xEVF3JvLVDcPI2ewYnC+g==",
       "requires": {
         "@aragon/os": "^3.1.2",
         "ethjs-ens": "^2.0.1",
@@ -17,11 +17,11 @@
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "^4.14.0"
+            "lodash": "^4.17.10"
           }
         },
         "base-x": {
@@ -112,6 +112,11 @@
             "streamifier": "^0.1.1",
             "tar-stream": "^1.5.5"
           }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "lru-cache": {
           "version": "4.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2684,6 +2684,11 @@
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.0.3.tgz",
       "integrity": "sha512-av8LNZGBl4cg2r4ZhWqghJOxi2P8UCcWhdmrFgcHPMmUJ6jx1FbnyxjwL4URYzMK3QJg60qeMefQhv9G14oYKA=="
     },
+    "bignumber.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.1.0.tgz",
+      "integrity": "sha512-ioirFr31dV5NwDdw6bFYCi9a62dBhGHohVmWYh0VS84GGbQsb69kIZ1wyqXNqFaPJmvIt9EXpqenk/0hc8tiTQ=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/aragon/aragon-dev-cli#readme",
   "dependencies": {
-    "@aragon/apm": "^1.1.0",
+    "@aragon/apm": "^1.1.1",
     "@aragon/apps-finance": "^1.0.1",
     "@aragon/apps-token-manager": "^1.0.0",
     "@aragon/apps-vault": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/aragon/aragon-dev-cli#readme",
   "dependencies": {
-    "@aragon/apm": "^1.0.0",
+    "@aragon/apm": "^1.1.0",
     "@aragon/apps-finance": "^1.0.1",
     "@aragon/apps-token-manager": "^1.0.0",
     "@aragon/apps-vault": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@aragon/os": "3.1.4",
     "@aragon/templates-beta": "^1.1.3",
     "@aragon/wrapper": "^2.0.0-beta.33",
+    "bignumber.js": "^7.1.0",
     "chalk": "^2.1.0",
     "cli-table": "^0.3.1",
     "colors": "^1.2.4",

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -17,6 +17,7 @@ const execa = require('execa')
 const { compileContracts } = require('../../helpers/truffle-runner')
 const web3Utils = require('web3-utils')
 const deploy = require('../deploy')
+const startIPFS = require('../ipfs')
 
 exports.command = 'publish [contract]'
 
@@ -288,6 +289,10 @@ exports.task = function ({
             throw new Error(`${err.message}\n${err.stderr}\n\nFailed to build. See above output.`)
           })
       }
+    },
+    {
+      title: 'Check IPFS',
+      task: () => startIPFS.task({ apmOptions }),
     },
     {
       title: 'Prepare files for publishing',

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -326,7 +326,8 @@ exports.task = function ({
             ctx.version,
             provider,
             ctx.pathToPublish,
-            ctx.contract
+            ctx.contract,
+            from
           )
           // Fix because APM.js gas comes with decimals and from doesn't work
           transaction.from = from

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -207,13 +207,11 @@ exports.task = function ({
       enabled: () => web3Utils.isAddress(contract)
     },
     {
-      title: 'Deploying contract',
+      title: 'Deploy contract',
       task: async (ctx) => {
         const deployTaskParams = { contract: deploy.arappContract(), reporter, network, cwd, web3 }
         
-        const { deployedContract } = await deploy.task(deployTaskParams)
-
-        ctx.contract = deployedContract
+        return await deploy.task(deployTaskParams)
       },
       enabled: ctx => (contract && !web3Utils.isAddress(contract)) || (!contract && ctx.isMajor && !reuse) || automaticallyBump
     },

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -58,7 +58,6 @@ async function generateApplicationArtifact (web3, cwd, outputPath, module, contr
 
   // Set `appId`
   artifact.appId = namehash.hash(artifact.appName)
-  delete artifact.appName
 
   // Set ABI
   const contractInterface = await readJson(contractInterfacePath)

--- a/src/commands/dao_cmds/apps.js
+++ b/src/commands/dao_cmds/apps.js
@@ -30,7 +30,7 @@ const printContent = (content) => {
   return `${content.provider}:${content.location}`.slice(0,25) + '...'
 }
 
-exports.handler = async function ({ reporter, dao, network, apm }) {
+exports.handler = async function ({ reporter, dao, network, apm: apmOptions }) {
   knownApps = listApps()
   const web3 = await ensureWeb3(network)
 
@@ -41,7 +41,7 @@ exports.handler = async function ({ reporter, dao, network, apm }) {
         task.output = `Fetching apps for ${dao}...`
 
         return new Promise((resolve, reject) => {
-          initAragonJS(dao, apm['ens-registry'], {
+          initAragonJS(dao, apmOptions['ens-registry'], {
             provider: web3.currentProvider,
             onApps: apps => {
               ctx.apps = apps

--- a/src/commands/dao_cmds/apps.js
+++ b/src/commands/dao_cmds/apps.js
@@ -62,17 +62,23 @@ exports.handler = async function ({ reporter, dao, network, apm: apmOptions }) {
   return tasks.run()
     .then((ctx) => {
       reporter.success(`Successfully fetched DAO apps for ${ctx.daoAddress}`)
-
       const appsContent = ctx.apps.map(
-        ({ appId, proxyAddress, codeAddress, content }) => 
-        ([ printAppName(appId), proxyAddress, printContent(content)])
+        ({ appId, proxyAddress, codeAddress, content, appName, version }) => 
+        ([ appName ? `${appName}@v${version}`: printAppName(appId), proxyAddress, printContent(content)])
       )
+
+      // filter registry name to make it shorter
+      // TODO: Add flag to turn off
+      const filteredContent = appsContent.map((row) => {
+        row[0] = row[0].replace('.aragonpm.eth', '')
+        return row
+      })
 
       const table = new Table({
         head: ['App', 'Proxy address', 'Content'].map(x => x.white),
       })
 
-      appsContent.forEach(row => table.push(row))
+      filteredContent.forEach(row => table.push(row))
 
       console.log(table.toString())
       process.exit() // force exit, as aragonjs hangs

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -31,7 +31,7 @@ const setPermissions = async (web3, sender, aclAddress, permissions) => {
   )
 }
 
-exports.command = 'install <apmRepo> <dao> [apmRepoVersion]'
+exports.command = 'install <dao> <apmRepo> [apmRepoVersion]'
 
 exports.describe = 'Install an app into a DAO'
 

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -1,0 +1,120 @@
+const TaskList = require('listr')
+const Web3 = require('web3')
+const daoArg = require('./utils/daoArg')
+import initAragonJS from './utils/aragonjs-wrapper'
+const { ensureWeb3 } = require('../../helpers/web3-fallback')
+const path = require('path')
+const APM = require('@aragon/apm')
+const defaultAPMName = require('../../helpers/default-apm')
+const chalk = require('chalk')
+
+const LATEST_VERSION = 'latest'
+const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
+
+const getContract = (pkg, contract) => {
+  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
+  return artifact
+}
+
+const setPermissions = async (web3, sender, aclAddress, permissions) => {
+  const acl = new web3.eth.Contract(
+    getContract('@aragon/os', 'ACL').abi,
+    aclAddress
+  )
+  return Promise.all(
+    permissions.map(([who, where, what]) =>
+      acl.methods.createPermission(who, where, what, who).send({
+        from: sender,
+        gasLimit: 1e6
+      })
+    )
+  )
+}
+
+exports.command = 'install <apmRepo> <dao> [apmRepoVersion]'
+
+exports.describe = 'Install an app into a DAO'
+
+exports.builder = function (yargs) {
+  return daoArg(yargs)
+}
+
+exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion = LATEST_VERSION }) => {
+  const apm = await APM(web3, apmOptions)
+
+  apmRepo = defaultAPMName(apmRepo)
+  // TODO: Resolve DAO ens name
+
+  const tasks = new TaskList([
+    {
+      title: `Fetching ${chalk.bold(apmRepo)}@${apmRepoVersion}`,
+      task: async (ctx, task) => {
+        if (apmRepoVersion == LATEST_VERSION) {
+          ctx.repo = await apm.getLatestVersion(apmRepo)
+        } else {
+          ctx.repo = await apm.getVersion(apmRepo, apmRepoVersion.split('.'))
+        }
+
+        // appId is loaded from artifact.json in IPFS
+        if (!ctx.repo.appId) {
+          throw new Error("Cannot find artifacts in APM repo. Please make sure the package is published and IPFS running.")
+        }
+      }
+    },
+    {
+      title: 'Deploying app instance',
+      task: async (ctx) => {
+        const kernel = new web3.eth.Contract(
+          getContract('@aragon/os', 'Kernel').abi,
+          dao
+        )
+
+        ctx.aclAddress = await kernel.methods.acl().call()
+        if (!ctx.accounts) {
+          ctx.accounts = await web3.eth.getAccounts()
+        }
+
+        const { events } = await kernel.methods.newAppInstance(
+          ctx.repo.appId,
+          ctx.repo.contractAddress
+        ).send({
+          from: ctx.accounts[0],
+          gasLimit: 1e6
+        })
+        
+        ctx.appAddress = events['NewAppProxy'].returnValues.proxy
+      }
+    },
+    {
+      title: 'Set permissions',
+      task: async (ctx, task) => {
+        if (!ctx.repo.roles || ctx.repo.roles.length === 0) {
+          throw new Error('You have no permissions defined in your arapp.json\nThis is required for your app to properly show up.')
+          return
+        }
+
+        const permissions = ctx.repo.roles
+          .map((role) => [ANY_ENTITY, ctx.appAddress, role.bytes])
+
+        return setPermissions(
+          web3,
+          ctx.accounts[0],
+          ctx.aclAddress,
+          permissions
+        )
+      }
+    }
+  ])
+
+  return tasks.run()
+    .then((ctx) => {
+      reporter.success(`Installed ${apmRepo} at: ${chalk.bold(ctx.appAddress)}`)
+    })
+}
+
+exports.handler = async function ({ reporter, dao, network, apm: apmOptions, apmRepo, apmRepoVersion }) {
+  const web3 = await ensureWeb3(network)
+  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
+
+  return exports.task({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion })
+}

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -9,13 +9,7 @@ const defaultAPMName = require('../../helpers/default-apm')
 const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
 const upgrade = require('./upgrade')
-
-const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
-
-const getContract = (pkg, contract) => {
-  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
-  return artifact
-}
+const { getContract, ANY_ENTITY } = require('../../util')
 
 const setPermissions = async (web3, sender, aclAddress, permissions) => {
   const acl = new web3.eth.Contract(

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -41,6 +41,7 @@ exports.builder = function (yargs) {
 }
 
 exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion }) => {
+  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
   const apm = await APM(web3, apmOptions)
 
   apmRepo = defaultAPMName(apmRepo)
@@ -105,7 +106,6 @@ exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRe
 
 exports.handler = async function ({ reporter, dao, network, apm: apmOptions, apmRepo, apmRepoVersion }) {
   const web3 = await ensureWeb3(network)
-  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
 
   const task = await exports.task({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion })
   return task.run()

--- a/src/commands/dao_cmds/new.js
+++ b/src/commands/dao_cmds/new.js
@@ -7,17 +7,13 @@ const path = require('path')
 const APM = require('@aragon/apm')
 const defaultAPMName = require('../../helpers/default-apm')
 const chalk = require('chalk')
+const { getContract } = require('../../util')
 
 const BASE_TEMPLATE_REPO = 'democracy-template.aragonpm.eth'
 
 exports.command = 'new'
 
 exports.describe = 'Create a new DAO'
-
-const getContract = (pkg, contract) => {
-  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
-  return artifact
-}
 
 exports.task = async ({ web3, reporter, apmOptions }) => {
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']

--- a/src/commands/dao_cmds/new.js
+++ b/src/commands/dao_cmds/new.js
@@ -1,0 +1,92 @@
+const TaskList = require('listr')
+const Web3 = require('web3')
+const daoArg = require('./utils/daoArg')
+import initAragonJS from './utils/aragonjs-wrapper'
+const { ensureWeb3 } = require('../../helpers/web3-fallback')
+const path = require('path')
+const APM = require('@aragon/apm')
+const defaultAPMName = require('../../helpers/default-apm')
+const chalk = require('chalk')
+
+const BASE_TEMPLATE_REPO = 'democracy-template.aragonpm.eth'
+
+exports.command = 'new'
+
+exports.describe = 'Create a new DAO'
+
+const getContract = (pkg, contract) => {
+  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
+  return artifact
+}
+
+exports.task = async ({ web3, reporter, apmOptions }) => {
+  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
+  const apm = await APM(web3, apmOptions)
+
+  const tasks = new TaskList([
+    {
+      title: 'Fetch template from APM',
+      task: async (ctx) => {
+        ctx.repo = { contractAddress: await apm.getLatestVersionContract(BASE_TEMPLATE_REPO) }
+      },
+    },
+    {
+      title: 'Fetching DAOFactory from on-chain template',
+      task: async(ctx, task) => {
+        try {
+          const fac = await new web3.eth.Contract(
+            getContract('@aragon/templates-beta', 'DemocracyTemplate').abi,
+            ctx.repo.contractAddress
+          ).methods.fac().call()
+          try {
+            ctx.contracts['DAOFactory'] = fac
+          } catch (e) {
+            ctx.contracts = { ['DAOFactory']: fac }
+          }
+          
+        } catch (err) {
+          console.error(`${err}\nCall failed, try using 'aragon run' or 'aragon devchain'`)
+          process.exit()
+        }
+      },
+    },
+    {
+      title: 'Deploy DAO',
+      task: async (ctx, task) => {
+        if (!ctx.accounts) {
+          ctx.accounts = await web3.eth.getAccounts()
+        }
+
+        const factory = new web3.eth.Contract(
+          getContract('@aragon/os', 'DAOFactory').abi,
+          ctx.contracts['DAOFactory']
+        )
+
+        const { events } = await factory.methods.newDAO(ctx.accounts[0]).send({
+          from: ctx.accounts[0],
+          gas: 5e6
+        })
+        ctx.daoAddress = events['DeployDAO'].returnValues.dao
+
+        const kernel = new web3.eth.Contract(
+          getContract('@aragon/os', 'Kernel').abi, ctx.daoAddress
+        )
+        ctx.aclAddress = await kernel.methods.acl().call()
+        ctx.appManagerRole = await kernel.methods.APP_MANAGER_ROLE().call()
+      }
+    }
+  ])
+
+  return tasks
+}
+
+exports.handler = async function ({ reporter, network, apm: apmOptions }) {
+  const web3 = await ensureWeb3(network)
+
+  const task = await exports.task({ web3, reporter, network, apmOptions })
+  return task.run()
+    .then((ctx) => {
+      reporter.success(`Created DAO: ${chalk.bold(ctx.daoAddress)}`)
+      process.exit()
+    })
+}

--- a/src/commands/dao_cmds/upgrade.js
+++ b/src/commands/dao_cmds/upgrade.js
@@ -8,6 +8,7 @@ const APM = require('@aragon/apm')
 const defaultAPMName = require('../../helpers/default-apm')
 const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
+const { getContract } = require('../../util')
 
 const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
 
@@ -17,11 +18,6 @@ exports.describe = 'Upgrade an app into a DAO'
 
 exports.builder = function (yargs) {
   return getRepoTask.args(daoArg(yargs))
-}
-
-const getContract = (pkg, contract) => {
-  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
-  return artifact
 }
 
 exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion, repo }) => {

--- a/src/commands/dao_cmds/upgrade.js
+++ b/src/commands/dao_cmds/upgrade.js
@@ -1,0 +1,79 @@
+const TaskList = require('listr')
+const Web3 = require('web3')
+const daoArg = require('./utils/daoArg')
+import initAragonJS from './utils/aragonjs-wrapper'
+const { ensureWeb3 } = require('../../helpers/web3-fallback')
+const path = require('path')
+const APM = require('@aragon/apm')
+const defaultAPMName = require('../../helpers/default-apm')
+const chalk = require('chalk')
+const getRepoTask = require('./utils/getRepoTask')
+
+const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
+
+exports.command = 'upgrade <dao> <apmRepo> [apmRepoVersion]'
+
+exports.describe = 'Upgrade an app into a DAO'
+
+exports.builder = function (yargs) {
+  return daoArg(yargs)
+    .option('apmRepo', {
+      describe: 'Name of the APM repo'
+    })
+    .option('apmRepoVersion', {
+      describe: 'Version of the package upgrading to',
+      default: 'latest'
+    })
+}
+
+const getContract = (pkg, contract) => {
+  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
+  return artifact
+}
+
+exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion, repo }) => {
+  const apm = await APM(web3, apmOptions)
+
+  apmRepo = defaultAPMName(apmRepo)
+  // TODO: Resolve DAO ens name
+
+  const tasks = new TaskList([
+    {
+      title: `Fetching ${chalk.bold(apmRepo)}@${apmRepoVersion}`,
+      skip: ctx => ctx.repo, // only run if repo isn't passed
+      task: getRepoTask({ apm, apmRepo, apmRepoVersion }),
+    },
+    {
+      title: 'Upgrading app',
+      task: async (ctx) => {
+        const kernel = new web3.eth.Contract(
+          getContract('@aragon/os', 'Kernel').abi,
+          dao
+        )
+
+        if (!ctx.accounts) {
+          ctx.accounts = await web3.eth.getAccounts()
+        }
+
+        const basesNamespace = await kernel.methods.APP_BASES_NAMESPACE().call()
+
+        const setApp = kernel.methods.setApp(basesNamespace, ctx.repo.appId, ctx.repo.contractAddress)
+        
+        return setApp.send({ from: ctx.accounts[0], gasLimit: 1e6 })
+      }
+    },
+  ], { repo })
+
+  return tasks.run()
+    .then((ctx) => {
+      reporter.success(`Upgraded ${apmRepo} to ${chalk.bold(ctx.repo.version)}`)
+    })
+}
+
+exports.handler = async function ({ reporter, dao, network, apm: apmOptions, apmRepo, apmRepoVersion }) {
+  const web3 = await ensureWeb3(network)
+  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
+
+  await exports.task({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion })
+  process.exit()
+}

--- a/src/commands/dao_cmds/upgrade.js
+++ b/src/commands/dao_cmds/upgrade.js
@@ -25,6 +25,7 @@ const getContract = (pkg, contract) => {
 }
 
 exports.task = async ({ web3, reporter, dao, network, apmOptions, apmRepo, apmRepoVersion, repo }) => {
+  apmOptions.ensRegistryAddress = apmOptions['ens-registry']
   const apm = await APM(web3, apmOptions)
 
   apmRepo = defaultAPMName(apmRepo)

--- a/src/commands/dao_cmds/utils/getRepoTask.js
+++ b/src/commands/dao_cmds/utils/getRepoTask.js
@@ -10,7 +10,7 @@ module.exports = {
       default: 'latest'
     })
 	},
-	task: ({ apm, apmRepo, apmRepoVersion }) => {
+	task: ({ apm, apmRepo, apmRepoVersion = LATEST_VERSION}) => {
 		return async (ctx) => {
 			if (apmRepoVersion == LATEST_VERSION) {
 			  	ctx.repo = await apm.getLatestVersion(apmRepo)

--- a/src/commands/dao_cmds/utils/getRepoTask.js
+++ b/src/commands/dao_cmds/utils/getRepoTask.js
@@ -1,16 +1,27 @@
 const LATEST_VERSION = 'latest'
 
-module.exports = ({ apm, apmRepo, apmRepoVersion }) => {
-	return async (ctx) => {
-		if (apmRepoVersion == LATEST_VERSION) {
-		  	ctx.repo = await apm.getLatestVersion(apmRepo)
-		} else {
-		  	ctx.repo = await apm.getVersion(apmRepo, apmRepoVersion.split('.'))
-		}
+module.exports = {
+	args: yargs => {
+		return yargs.option('apmRepo', {
+      describe: 'Name of the APM repo'
+    })
+    .option('apmRepoVersion', {
+      describe: 'Version of the package upgrading to',
+      default: 'latest'
+    })
+	},
+	task: ({ apm, apmRepo, apmRepoVersion }) => {
+		return async (ctx) => {
+			if (apmRepoVersion == LATEST_VERSION) {
+			  	ctx.repo = await apm.getLatestVersion(apmRepo)
+			} else {
+			  	ctx.repo = await apm.getVersion(apmRepo, apmRepoVersion.split('.'))
+			}
 
-		// appId is loaded from artifact.json in IPFS
-		if (!ctx.repo.appId) {
-		  	throw new Error("Cannot find artifacts in APM repo. Please make sure the package is published and IPFS running.")
+			// appId is loaded from artifact.json in IPFS
+			if (!ctx.repo.appId) {
+			  	throw new Error("Cannot find artifacts in APM repo. Please make sure the package is published and IPFS running.")
+			}
 		}
 	}
 }

--- a/src/commands/dao_cmds/utils/getRepoTask.js
+++ b/src/commands/dao_cmds/utils/getRepoTask.js
@@ -1,0 +1,16 @@
+const LATEST_VERSION = 'latest'
+
+module.exports = ({ apm, apmRepo, apmRepoVersion }) => {
+	return async (ctx) => {
+		if (apmRepoVersion == LATEST_VERSION) {
+		  	ctx.repo = await apm.getLatestVersion(apmRepo)
+		} else {
+		  	ctx.repo = await apm.getVersion(apmRepo, apmRepoVersion.split('.'))
+		}
+
+		// appId is loaded from artifact.json in IPFS
+		if (!ctx.repo.appId) {
+		  	throw new Error("Cannot find artifacts in APM repo. Please make sure the package is published and IPFS running.")
+		}
+	}
+}

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -24,7 +24,10 @@ exports.builder = yargs => {
 	})
 }
 
-exports.task = ({ reporter, network, cwd, contract, web3 }) => {
+exports.task = async ({ reporter, network, cwd, contract, web3 }) => {
+	if (!web3) {
+		web3 = await ensureWeb3(network)
+	}
 	const contractName = contract
 	const tasks = new TaskList([
 		{
@@ -59,17 +62,18 @@ exports.task = ({ reporter, network, cwd, contract, web3 }) => {
 					throw new Error("Contract deployment failed")
 				}
 
-				ctx.deployedContract = instance.options.address
-				return ctx.deployedContract
+				ctx.contract = instance.options.address
+				return ctx.contract
 			}
 		}
 	])
-	return tasks.run()
+	return tasks
 }
 
 exports.handler = async ({ reporter, network, cwd, contract }) => {
-		const ctx = await exports.task({ reporter, network, cwd, contract })
+	const task = await exports.task({ reporter, network, cwd, contract })
+	const ctx = await task.run()
 
-    reporter.success(`Successfully deployed ${contract} at: ${chalk.bold(ctx.deployedContract)}`)
+    reporter.success(`Successfully deployed ${contract} at: ${chalk.bold(ctx.contract)}`)
     process.exit()
 }

--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -82,7 +82,7 @@ exports.task = async function ({ port = 8545, reset = false, showAccounts = 2 })
     }
   }])
 
-  return tasks.run()
+  return tasks
 }
 
 exports.printAccounts = (reporter, privateKeys) => {
@@ -97,7 +97,8 @@ exports.printAccounts = (reporter, privateKeys) => {
 }
 
 exports.handler = async ({ reporter, port, reset, accounts }) => {
-  const { privateKeys } = await exports.task({ port, reset, showAccounts: accounts })
+  const task = await exports.task({ port, reset, showAccounts: accounts })
+  const { privateKeys } = await task.run()
   exports.printAccounts(reporter, privateKeys)  
 
   reporter.info(`Devchain running: ${chalk.bold('http://localhost:'+port)}.`)

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,6 +5,7 @@ const execa = require('execa')
 const path = require('path')
 const fs = require('fs-extra')
 const { installDeps } = require('../util')
+const defaultAPMName = require('../helpers/default-apm')
 
 exports.command = 'init <name> [template]'
 
@@ -41,9 +42,7 @@ exports.builder = (yargs) => {
 }
 
 exports.handler = function ({ reporter, name, template }) {
-  if (name.split('.').length == 1) {
-    name = name + '.aragonpm.eth'
-  }
+  name = defaultAPMName(name)
   
   const basename = name.split('.')[0]
   const tasks = new TaskList([

--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -1,0 +1,61 @@
+const TaskList = require('listr')
+const {
+  isIPFSInstalled,
+  startIPFSDaemon,
+  isIPFSCORS,
+  setIPFSCORS
+} = require('../helpers/ipfs-daemon')
+
+const { isPortTaken } = require('../util')
+
+exports.command = 'ipfs'
+
+exports.describe = 'Start IPFS daemon configured to work with Aragon'
+
+exports.task = ({ apmOptions }) => {
+  return new TaskList([
+  	{
+	  	title: 'Start IPFS',
+	  	task: async (ctx, task) => {
+		    // If the dev manually set their IPFS node, skip install and running check
+		    if (apmOptions.ipfs.rpc.default) {
+		      const installed = await isIPFSInstalled()
+		      if (!installed) {
+		        setTimeout(() => opn('https://ipfs.io/docs/install'), 2500)
+		        throw new Error(`
+		          Running your app requires IPFS. Opening install instructions in your browser`
+		        )
+		      } else {
+		        const running = await isPortTaken(apmOptions.ipfs.rpc.port)
+		        if (!running) {
+		          task.output = 'Starting IPFS at port: ' + apmOptions.ipfs.rpc.port
+		          await startIPFSDaemon()
+		          ctx.started = true
+		          await setIPFSCORS(apmOptions.ipfs.rpc)
+		        } else {
+		          task.output = 'IPFS is started, checking CORS config'
+		          await setIPFSCORS(apmOptions.ipfs.rpc)
+		          return 'Connected to IPFS daemon ar port: '+ apmOptions.ipfs.rpc.port 
+		        }
+		      }
+		    } else {
+		      await isIPFSCORS(apmOptions.ipfs.rpc)
+		      return 'Connecting to provided IPFS daemon'
+		    }
+		  }
+		}
+	])
+}
+
+exports.handler = function ({ reporter, apm: apmOptions }) {
+  const task = exports.task({ apmOptions })
+
+  task.run().then(ctx => {
+  	if (ctx.started) {
+  		reporter.info('IPFS daemon is now running. Stopping this process will stop IPFS')
+  	} else {
+  		reporter.warning('Didnt start IPFS, port busy')
+  		process.exit()
+  	}
+  })
+}

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -23,8 +23,11 @@ const {
   findProjectRoot,
   isPortTaken,
   installDeps,
-  getNodePackageManager
+  getNodePackageManager,
+  getContract,
+  ANY_ENTITY
 } = require('../util')
+
 const { Writable } = require('stream')
 const url = require('url')
 
@@ -57,11 +60,6 @@ exports.builder = function (yargs) {
   })
 }
 
-const getContract = (pkg, contract) => {
-  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
-  return artifact
-}
-
 const setPermissions = async (web3, sender, aclAddress, permissions) => {
   const acl = new web3.eth.Contract(
     getContract('@aragon/os', 'ACL').abi,
@@ -76,8 +74,6 @@ const setPermissions = async (web3, sender, aclAddress, permissions) => {
     )
   )
 }
-
-const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
 
 exports.handler = function ({
     // Globals

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -260,7 +260,8 @@ exports.handler = function ({
 
     const registry = module.appName.split('.').slice(1).join('.')
 
-    reporter.info(`\nThis is the configuration for your development deployment:
+    console.log()
+    reporter.info(`This is the configuration for your development deployment:
     ${chalk.bold('Ethereum Node')}: ${network.provider.connection._url}
     ${chalk.bold('ENS registry')}: ${ctx.ens}
     ${chalk.bold(`APM registry`)}: ${registry}

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -160,8 +160,8 @@ exports.handler = function ({
         {
           title: 'Download wrapper',
           task: (ctx, task) => {
-            const WRAPPER_COMMIT = '5e4bb9f803ab274db190ebc98b1e3ac77be8ba1f'
-            const WRAPPER_BRANCH = 'remotes/origin/master'
+            const WRAPPER_COMMIT = '4c098adefc3ad5dca002b1d656703ea1f2aab15d'
+            const WRAPPER_BRANCH = 'remotes/origin/local-environment'
             const WRAPPER_PATH = `${os.homedir()}/.aragon/wrapper-${WRAPPER_COMMIT}`
             ctx.wrapperPath = WRAPPER_PATH
 
@@ -197,26 +197,13 @@ exports.handler = function ({
               return
             }
             const bin = await getNodePackageManager()
-            execa(
-              bin,
-              ['start'],
-              {
-                cwd: ctx.wrapperPath,
-                env: {
-                  BROWSER: 'none',
-                  REACT_APP_IPFS_GATEWAY: `http://${apmOptions.ipfs.rpc.host}:8080/ipfs`,
-                  REACT_APP_IPFS_RPC: url.format({
-                    protocol: apmOptions.ipfs.rpc.protocol,
-                    hostname: apmOptions.ipfs.rpc.host,
-                    port: apmOptions.ipfs.rpc.port
-                  }),
-                  REACT_APP_DEFAULT_ETH_NODE: network.provider.connection._url,
-                  REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens
-                }
+            const startArguments = {
+              cwd: ctx.wrapperPath,
+              env: {
+                REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens
               }
-            ).catch((err) => {
-              throw new Error(err)
-            })
+            }
+            execa(bin, ['run', 'start:local'], startArguments).catch((err) => { throw new Error(err) })
           }
         },
         {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -109,12 +109,7 @@ exports.handler = function ({
         }
       },
       task: async (ctx, task) => {
-        const { web3, accounts, privateKeys } = await devchain.task({ port, reset, showAccounts })
-        ctx.web3 = web3
-        ctx.accounts = accounts
-        ctx.privateKeys = privateKeys
-
-        if (ctx.accounts.length == 0) throw new Error("Devchain started with no accounts")
+        return await devchain.task({ port, reset, showAccounts })
       }
     },
     {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -191,6 +191,7 @@ exports.handler = function ({
         {
           title: 'Start Aragon client',
           task: async (ctx, task) => {
+            ctx.ens = apmOptions['ens-registry']
             if (await isPortTaken(WRAPPER_PORT)) {
               ctx.portOpen = true
               return

--- a/src/helpers/default-apm.js
+++ b/src/helpers/default-apm.js
@@ -1,4 +1,5 @@
 const DEFAULT_APM_REGISTRY = 'aragonpm.eth'
 
+// insert default apm if the provided name doesnt have the suffix
 module.exports = name => 
 	name.split('.').length > 1 ? name : `${name}.${DEFAULT_APM_REGISTRY}`

--- a/src/helpers/default-apm.js
+++ b/src/helpers/default-apm.js
@@ -1,0 +1,4 @@
+const DEFAULT_APM_REGISTRY = 'aragonpm.eth'
+
+module.exports = name => 
+	name.split('.').length > 1 ? name : `${name}.${DEFAULT_APM_REGISTRY}`

--- a/src/util.js
+++ b/src/util.js
@@ -65,4 +65,11 @@ const installDeps = async (cwd, task) => {
   })
 }
 
-module.exports = { findProjectRoot, hasBin, isPortTaken, installDeps, getNodePackageManager }
+const getContract = (pkg, contract) => {
+  const artifact = require(`${pkg}/build/contracts/${contract}.json`)
+  return artifact
+}
+
+const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
+
+module.exports = { findProjectRoot, hasBin, isPortTaken, installDeps, getNodePackageManager, getContract, ANY_ENTITY }


### PR DESCRIPTION
Another monster PR with a lot of fun stuff:

- Implements the `dao new` command to create a fresh DAO.
- Implements the `dao install` command to install an app in a DAO.
- Implements the `dao upgrade` command to upgrade an APM package in a DAO.
- Implements the `aragon ipfs` command to start an IPFS daemon and configure it with CORS.
- Refactors `aragon run` and `apm publish` to use sub-tasks properly. 👋 flashing.
- Removed a huge amount of dup logic in `aragon run` which now just plugs into other commands.
- `dao apps` now displays the version of the apps and gets the app name from APM artifacts.