### PR TITLE
Add default ignore list for publishing to IPFS

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -20,6 +20,7 @@ const deploy = require('../deploy')
 const startIPFS = require('../ipfs')
 
 const MANIFEST_FILE = 'manifest.json'
+const DEFAULT_IGNORE_LIST = ['node_modules', '.git']
 
 exports.command = 'publish [contract]'
 
@@ -96,7 +97,7 @@ async function prepareFilesForPublishing (files = [], ignorePatterns = null) {
   const { path: tmpDir } = await tmp.dir()
 
   // Ignored files filter
-  const filter = ignore().add(ignorePatterns)
+  const filter = ignore().add(DEFAULT_IGNORE_LIST).add(ignorePatterns)
   const projectRoot = findProjectRoot()
 
   const ipfsignorePath = path.resolve(projectRoot, '.ipfsignore')

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -128,7 +128,6 @@ exports.handler = function ({
           alreadyCompiled: true,
           provider: 'ipfs',
           files,
-          ignore: ['node_modules'],
           reporter,
           cwd,
           network,


### PR DESCRIPTION
Sets it to always ignore `node_modules` and `.git`, which I'm assuming nobody wants.

We could make it a default setting, but then if anyone wants to change it, they'd have to re-include the default list.

Seems to fix the issue with the `.ipfsignore` file, but not really sure why... (I think IPFS ignores the .gitignore dir anyway).