### PR TITLE
Add BROWSER=none when starting aragon/aragon

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -199,7 +199,8 @@ exports.handler = function ({
             const startArguments = {
               cwd: ctx.wrapperPath,
               env: {
-                REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens
+                REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens,
+                BROWSER: 'none',
               }
             }
             execa(bin, ['run', 'start:local'], startArguments).catch((err) => { throw new Error(err) })


### PR DESCRIPTION
Fixes #109.

Starts `aragon/aragon`'s `start:local` with the flag [`BROWSER=none`](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#advanced-configuration) so that it doesn't open a browser instance.