### PR TITLE
Publish: fix ignore taking into consideration full path rather than relative path from root dir

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -110,8 +110,10 @@ async function prepareFilesForPublishing (files = [], ignorePatterns = null) {
     }
   }
 
+  const replaceRootRegex = new RegExp(`^${projectRoot}`)
   function filterIgnoredFiles (src) {
-    return !filter.ignores(src)
+    const relativeSrc = src.replace(replaceRootRegex, '.')
+    return !filter.ignores(relativeSrc)
   }
 
   // Copy files


### PR DESCRIPTION
Fixes issues where a string included in the ignore file would be the same as the app's name (dir name), causing everything to be ignored.