### PR TITLE
Publish: add node_modules to default list

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -46,6 +46,7 @@ exports.builder = function (yargs) {
     array: true
   }).option('ignore', {
     description: 'A gitignore pattern of files to ignore. Specify multiple times to add multiple patterns.',
+    default: ['node_modules'],
     array: true
   })
 }


### PR DESCRIPTION
We should have this as a default in `aragon run` and `aragon apm publish`.