### PR TITLE
Always generate artifact if there is a contract linked in the arapp file

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -347,7 +347,7 @@ exports.task = function ({
     },
     {
       title: 'Generate application artifact',
-      skip: () => onlyContent,
+      skip: () => onlyContent && !module.path, // TODO: If onlyContent has been set, get previous version's artifact
       task: async (ctx, task) => {
         const dir = onlyArtifacts ? cwd : ctx.pathToPublish
         const artifact = await generateApplicationArtifact(web3, cwd, dir, module, contract, reporter)


### PR DESCRIPTION
This was causing an issue when publishing patch versions of apps of just the content, as it was uploading the content with no artifact.json at all, therefore making the app unable to be loaded.

Created issue https://github.com/aragon/aragon-cli/issues/143 for fetching the previous version of the artifact rather than forcing a regeneration
