### PR TITLE
Pass contract name specified in publish to deploy

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -65,17 +65,17 @@ cmd.option('network', {
     }
 
     // Catch commands that dont require network and return
-    const skipNetworkSubcommands = ['version', 'new']
+    const skipNetworkSubcommands = new Set(['version']) // 'aragon apm version'
     if (process.argv.length >= 4) {
-      if (skipNetworkSubcommands.indexOf(process.argv[3]) >= 0) {
+      if (skipNetworkSubcommands.has(process.argv[3])) {
         return {}
       }
     }
 
-    const skipNetworkCommands = ['init', 'devchain', 'ipfs']
+    const skipNetworkCommands = new Set(['init', 'devchain', 'ipfs'])
 
     if (process.argv.length >= 3) {
-      if (skipNetworkCommands.indexOf(process.argv[2]) >= 0) {
+      if (skipNetworkCommands.has(process.argv[2])) {
         return {}
       }
     }

--- a/src/cli.js
+++ b/src/cli.js
@@ -45,15 +45,29 @@ cmd.option('cwd', {
   }
 })
 
+/*
+  yargs will coerce this function multiple times while executing one command for unknown
+  reasons. When a positional optional argument is present, it will go as far as coercing the
+  default network, causing a crash in case the default network is not defined, even if explicitely
+  specifying another network.
+
+  caching the network also helps performance as we don't need to reinitialize the web3 provider
+*/
+let cachedNetwork
+
 // Ethereum
 cmd.option('network', {
   description: 'The network in your truffle.js that you want to use',
   default: 'development',
   coerce: (network) => {
+    if (cachedNetwork) {
+      return cachedNetwork
+    }
+
     // Catch commands that dont require network and return
     const skipNetworkSubcommands = ['version', 'new']
     if (process.argv.length >= 4) {
-      if (skipNetworkSubcommands.indexOf(process.argv[3]) >= 'version') {
+      if (skipNetworkSubcommands.indexOf(process.argv[3]) >= 0) {
         return {}
       }
     }
@@ -82,6 +96,9 @@ cmd.option('network', {
     }
     truffleNetwork.provider = provider
     truffleNetwork.name = network
+
+    cachedNetwork = truffleNetwork
+
     return truffleNetwork   
   }
   // conflicts: 'init'

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -256,7 +256,7 @@ exports.task = function ({
     {
       title: 'Deploy contract',
       task: async (ctx) => {
-        const deployTaskParams = { contract: deploy.arappContract(), init, reporter, network, cwd, web3, apmOptions }
+        const deployTaskParams = { contract, init, reporter, network, cwd, web3, apmOptions }
         
         return await deploy.task(deployTaskParams)
       },

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -141,6 +141,7 @@ exports.handler = function ({
           module,
           buildScript,
           build: true,
+          contract: deploy.arappContract(),
           web3: ctx.web3,
           apm: apmOptions,
           automaticallyBump: true,


### PR DESCRIPTION
Close #138 

While working on this issue, I run into an old issue regarding yargs re-coercing the network flag. The observed behavior was: when using a command with an optional positional argument, if no argument is passed then it was fine, but if the argument is specified, a bug in yargs would try to coerce the network flag with the default 'development' flag, which in case it wasn't present it would throw an error (but continue execution), and make the positional argument undefined, even if explicitly defined. 

So this also finally fixes #121

(Also fixes #142, a stupid typo that caused a bug not detected until now https://github.com/aragon/aragon-cli/pull/145/files#diff-d9d9214113dea1c364abd4ba3c70be11R70)