### PR TITLE
Fix opening IPFS documentation URL

### DIFF
--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -1,3 +1,4 @@
+const opn = require('opn')
 const path = require('path')
 const TaskList = require('listr')
 const {


### PR DESCRIPTION
Import of `opn` module was missing.

Fixes call to `opn('https://ipfs.io/docs/install')` in:

https://github.com/aragon/aragon-cli/blob/bacfdf97ca8c91d1f2cb9ee437e46c3964cbe657/src/commands/ipfs.js#L26
