### PR TITLE
fix: don't use yarn for aragon init

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -312,7 +312,7 @@ exports.task = function ({
           return
         }
 
-        const bin = await getNodePackageManager()
+        const bin = getNodePackageManager()
         const buildTask = execa(bin, ['run', 'build'])
         buildTask.stdout.on('data', (log) => {
           if (!log) return

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -221,7 +221,7 @@ exports.handler = function ({
               ctx.portOpen = true
               return
             }
-            const bin = await getNodePackageManager()
+            const bin = getNodePackageManager()
             const startArguments = {
               cwd: ctx.wrapperPath,
               env: {

--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,8 @@ const execa = require('execa')
 const net = require('net')
 
 let cachedProjectRoot
-let cachedNodePackageManager
+
+const PGK_MANAGER_BIN_NPM = 'npm';
 
 const findProjectRoot = () => {
   if (!cachedProjectRoot) {
@@ -44,16 +45,12 @@ const isPortTaken = async (port, opts) => {
   }))
 }
 
-const getNodePackageManager = async () => {
-  if (!cachedNodePackageManager) {
-    const hasYarn = await hasBin('yarn')
-    cachedNodePackageManager = (hasYarn) ? 'yarn' : 'npm'
-  }
-  return cachedNodePackageManager
+const getNodePackageManager = () => {
+  return PGK_MANAGER_BIN_NPM
 }
 
-const installDeps = async (cwd, task) => {
-  const bin = await getNodePackageManager()
+const installDeps = (cwd, task) => {
+  const bin = getNodePackageManager()
   const installTask = execa(bin, ['install'], { cwd })
   installTask.stdout.on('data', (log) => {
     if (!log) return


### PR DESCRIPTION
As mentioned in #129, Web3.js has issues with being installed using yarn.
This commit defaults to the npm as package manager to install dependencies
in `aragon init`.

Notice that this commit can be reverted once the issues with yarn in Web3.js
have been resolved.

Closes #129