### PR TITLE
refactor: move init command functions into lib and introduce tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
   "ava": {
     "require": [
       "@babel/register"
+    ],
+    "files": [
+      "test/**/*.js"
     ]
   }
 }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -6,6 +6,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const { installDeps } = require('../util')
 const defaultAPMName = require('../helpers/default-apm')
+import { checkProjectExists, prepareTemplate } from '../lib/init';
 
 exports.command = 'init <name> [template]'
 
@@ -43,52 +44,32 @@ exports.builder = (yargs) => {
 
 exports.handler = function ({ reporter, name, template }) {
   name = defaultAPMName(name)
-  
   const basename = name.split('.')[0]
+
   const tasks = new TaskList([
     {
-      title: 'Checking project existence',
+      title: 'Preparing initialization',
       task: async (ctx, task) => {
-        const projectPath = path.resolve(process.cwd(), basename)
-        const exists = await fs.pathExists(projectPath)
-        if (exists) {
-          throw new Error(`Couldn't initialize project. Project with name ${basename} already exists in ${projectPath}. Use different <name> or rename existing project folder.`)
-        }
+        task.output = 'Checking if project folder already exists...'
+        await checkProjectExists(basename)
       }
     },
     {
-      title: 'Clone template',
+      title: 'Cloning app template',
       task: async (ctx, task) => {
         task.output = `Cloning ${template} into ${basename}...`
-
-        const repo = await clone(template, basename, { shallow: true })
+        await clone(template, basename, { shallow: true })
       }
     },
     {
       title: 'Preparing template',
       task: async (ctx, task) => {
-        // Set `appName` in arapp
-        const arappPath = path.resolve(
-          basename,
-          'arapp.json'
-        )
-        const arapp = await fs.readJson(arappPath)
-        arapp.appName = name
-
-        // Delete .git folder
-        const gitFolderPath = path.resolve(
-          basename,
-          '.git'
-        )
-
-        return Promise.all([
-          fs.writeJson(arappPath, arapp, { spaces: 2 }),
-          fs.remove(gitFolderPath)
-        ])
+        task.output = 'Initiliazing arapp.json and removing Git repository';
+        await prepareTemplate(basename, name)
       }
     },
     {
-      title: 'Install package dependencies',
+      title: 'Installing package dependencies',
       task: async (ctx, task) => (await installDeps(basename, task)),
     }
   ])

--- a/src/lib/init/check-project-exists.js
+++ b/src/lib/init/check-project-exists.js
@@ -1,0 +1,11 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+export async function checkProjectExists(basename) {
+  const projectPath = path.resolve(process.cwd(), basename)
+  const exists = await fs.pathExists(projectPath)
+
+  if (exists) {
+    throw new Error(`Couldn't initialize project. Project with name ${basename} already exists in ${projectPath}. Use different <name> or rename existing project folder.`)
+  }
+}

--- a/src/lib/init/index.js
+++ b/src/lib/init/index.js
@@ -1,0 +1,2 @@
+export * from './check-project-exists';
+export * from './prepare-template';

--- a/src/lib/init/prepare-template.js
+++ b/src/lib/init/prepare-template.js
@@ -1,0 +1,16 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+export async function prepareTemplate(basename, appName) {
+  const arappPath = path.resolve(basename, 'arapp.json')
+  const arapp = await fs.readJson(arappPath)
+
+  arapp.appName = appName
+
+  const gitFolderPath = path.resolve(basename, '.git')
+
+  return Promise.all([
+    fs.writeJson(arappPath, arapp, { spaces: 2 }),
+    fs.remove(gitFolderPath)
+  ])
+}

--- a/test/commands/init.js
+++ b/test/commands/init.js
@@ -1,0 +1,43 @@
+import test from 'ava';
+import fs from 'fs-extra';
+
+import { checkProjectExists, prepareTemplate } from '../../src/lib/init';
+
+const projectPath = './.tmp/aragon-app'
+
+test.beforeEach(t => {
+  fs.ensureDirSync(projectPath)
+})
+
+test.afterEach(t => {
+  fs.removeSync(projectPath)
+})
+
+test('check if project folder already exists', async t => {
+  try {
+    await checkProjectExists(projectPath)
+    t.fail()
+  } catch (err) {
+    t.pass()
+  }
+})
+
+test('prepare project template', async t => {
+
+  const repoPath = `${projectPath}/.git`
+  const arappPath = `${projectPath}/arapp.json`
+  const appName = 'TestApp'
+
+  await fs.ensureDir(repoPath)
+  await fs.ensureFile(arappPath)
+  await fs.writeJson(arappPath, {
+    appName: 'boilerplate-placeholder'
+  })
+
+  await prepareTemplate(projectPath, appName)
+  const project = await fs.readJson(arappPath)
+
+  t.falsy(await fs.pathExists(repoPath))
+  t.is(appName, project.appName)
+})
+


### PR DESCRIPTION


@izqui @sohkai here's a first POC that shows what I was aiming for. Notice how the individual tasks have been extracted from the TaskList, so they can be imported individually and therefore be tested in isolation.

I added some inline comments with some additional thoughts as well. 

This is definitely not the most beautiful architecture, but I think it takes us one step further towards a testable code base.

Let me know what you think.