### PR TITLE
Add apm.js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "requires": true,
   "dependencies": {
     "@aragon/apm": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-1.1.6.tgz",
-      "integrity": "sha512-xT3mEa+rn8pSoqmvMAkKWN1QqiiXYRqvAByhSiiGNNjKIEn4z/kH6GTMg0Crqo/57UguzA443d0uFVvBQo4VIg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-2.0.0.tgz",
+      "integrity": "sha512-FvOQzQnHZSCBtVAsCxAi0hnj6wcBnGM+H46UJnBqXDxhSeNeR5NyQ/FMzR6dqfqcCd1u6Hs/8Pw4yemb99UAaQ==",
       "requires": {
         "@aragon/os": "^3.1.2",
+        "axios": "^0.18.0",
         "ethjs-ens": "^2.0.1",
-        "got": "^8.3.0",
         "ipfs-api": "^17.5.0",
         "semver": "^5.5.0"
       },
@@ -180,6 +180,18 @@
         "web3-eth-abi": "1.0.0-beta.33"
       },
       "dependencies": {
+        "@aragon/apm": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-1.1.6.tgz",
+          "integrity": "sha512-xT3mEa+rn8pSoqmvMAkKWN1QqiiXYRqvAByhSiiGNNjKIEn4z/kH6GTMg0Crqo/57UguzA443d0uFVvBQo4VIg==",
+          "requires": {
+            "@aragon/os": "^3.1.2",
+            "ethjs-ens": "^2.0.1",
+            "got": "^8.3.0",
+            "ipfs-api": "^17.5.0",
+            "semver": "^5.5.0"
+          }
+        },
         "base-x": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
@@ -2208,6 +2220,15 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -5541,6 +5562,24 @@
       "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
       "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
+      "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+      "requires": {
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-each": {
       "version": "0.3.3",
@@ -11663,9 +11702,9 @@
       }
     },
     "got": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-8.3.1.tgz",
-      "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
       "requires": {
         "@sindresorhus/is": "^0.7.0",
         "cacheable-request": "^2.1.1",
@@ -12479,8 +12518,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/aragon/aragon-dev-cli#readme",
   "dependencies": {
+    "@aragon/apm": "^2.0.0",
     "@aragon/apps-finance": "^1.0.1",
     "@aragon/apps-token-manager": "^1.0.0",
     "@aragon/apps-vault": "^2.0.1",


### PR DESCRIPTION
Even though `@aragon/apm` (npm package for`apm.js`) is used directly within the CLI, we didn't have it as a dependency and were just relying on `@aragon/wrapper` that does have `@aragon/apm` as a dependency.

