### PR TITLE
Improve experience around devchain resets

### DIFF
--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -108,7 +108,7 @@ exports.printMnemonic = (reporter, mnemonic) => {
 
 exports.printResetNotice = (reporter, reset) => {
   if (reset) {
-    reporter.warning(`The devchain was reset, some steps need to be done to provent issues:
+    reporter.warning(`The devchain was reset, some steps need to be done to prevent issues:
     - Reset the application cache in Aragon Core by going to Settings > Troubleshooting.
     - If using Metamask: switch to a different network, and then switch back to the 'Private Network' (this will clear the nonce cache and prevent errors when sending transactions)  
   `)

--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -52,10 +52,12 @@ exports.task = async function ({ port = 8545, reset = false, showAccounts = 2 })
     title: 'Starting a local chain from snapshot',
     task: async (ctx, task) => {
       const server = ganache.server({
+        // Start on a different networkID every time to avoid Metamask nonce caching issue:
+        // https://github.com/aragon/aragon-cli/issues/156
+        network_id: parseInt(1e8 * Math.random()), 
         gasLimit: BLOCK_GAS_LIMIT,
         mnemonic: MNEMONIC,
         db_path: snapshotPath,
-        network_id: 15, // aragen uses network_id 15 when creating snapshot https://github.com/aragon/aragen/blob/3df0d65a9de7bbdeeea763a444e0ab367db366a0/scripts/start-ganache#L6
       })
       const listen = () => (
         new Promise((resolve, reject) => {

--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -90,8 +90,10 @@ exports.task = async function ({ port = 8545, reset = false, showAccounts = 2 })
 }
 
 exports.printAccounts = (reporter, privateKeys) => {
+  const firstAccountComment = '(this account is used to deploy DAOs, it has more permissions)'
+
   const formattedAccounts = privateKeys.map(({ address, key }, i) => 
-    chalk.bold(`Address #${i + 1}: ${address}\nPrivate key: `) + key
+    chalk.bold(`Address #${i + 1}:  ${address} ${ i == 0 ? firstAccountComment : ''}\nPrivate key: `) + key
   )
 
   reporter.info(`Here are some Ethereum accounts you can use.
@@ -101,13 +103,24 @@ exports.printAccounts = (reporter, privateKeys) => {
 }
 
 exports.printMnemonic = (reporter, mnemonic) => {
-  reporter.info(`The accounts were generated from the following mnemonic phrase: ${mnemonic}\n.`)
+  reporter.info(`The accounts were generated from the following mnemonic phrase:\n${mnemonic}\n`)
+}
+
+exports.printResetNotice = (reporter, reset) => {
+  if (reset) {
+    reporter.warning(`The devchain was reset, some steps need to be done to provent issues:
+    - Reset the application cache in Aragon Core by going to Settings > Troubleshooting.
+    - If using Metamask: switch to a different network, and then switch back to the 'Private Network' (this will clear the nonce cache and prevent errors when sending transactions)  
+  `)
+  }
 }
 
 exports.handler = async ({ reporter, port, reset, accounts }) => {
   const task = await exports.task({ port, reset, showAccounts: accounts })
-  const { privateKeys } = await task.run()
-  exports.printAccounts(reporter, privateKeys)  
+  const { privateKeys, mnemonic } = await task.run()
+  exports.printAccounts(reporter, privateKeys)
+  exports.printMnemonic(reporter, mnemonic)
+  exports.printResetNotice(reporter, reset)
 
   reporter.info(`Devchain running: ${chalk.bold('http://localhost:'+port)}.`)
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -276,9 +276,12 @@ exports.handler = function ({
     if (ctx.privateKeys) {
       devchain.printAccounts(reporter, ctx.privateKeys)
     }
+
     if (ctx.mnemonic) {
       devchain.printMnemonic(reporter, ctx.mnemonic)
     }
+
+    devchain.printResetNotice(reporter, reset)
 
     const registry = module.appName.split('.').slice(1).join('.')
 


### PR DESCRIPTION
Close #156 

Starting the devchain with a different networkID every time doesn't appear to have any side effects, and it makes Metamask detect that the network has changed and prevents it from using a previously cached nonce when sending transactions. Sometimes you need to switch to another network and then switch back to the local dev network, but then it works without any problem.

Added some warning messages when resetting the chain, prompting users to do this so they don't have problems with it.