### PR TITLE
uiux(commands/apm): show meaningful error messages

### DIFF
--- a/src/commands/apm_cmds/versions.js
+++ b/src/commands/apm_cmds/versions.js
@@ -10,12 +10,13 @@ exports.handler = async function ({ reporter, module, bump, cwd, network, apm: a
   const web3 = await ensureWeb3(network)
 
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
-
   const versions = await APM(web3, apmOptions).getAllVersions(module.appName)
   reporter.info(`${module.appName} has ${versions.length} published versions`)
   versions.map((version) => {
     if (version && version.content) {
       reporter.success(`${version.version}: ${version.contractAddress} ${version.content.provider}:${version.content.location}`)
+    } else if (version && version.error) {
+      reporter.warning(`${version.version}: ${version.contractAddress} ${version.error}`)
     } else {
       reporter.error('Version not found in provider')
     }


### PR DESCRIPTION
As discussed in #167, `apm versions` throws when any of the returned
content URIs are invalid. This behaviour will be fixed with https://github.com/aragon/apm.js/pull/26,
so now we're making use of that exposed error or warning message for
a better user experience.

Closes #167