### PR TITLE
fix(commands/apm/grant): use updated CREATE_VERSION_ROLE hash

### DIFF
--- a/src/acl/index.js
+++ b/src/acl/index.js
@@ -8,11 +8,16 @@ module.exports = (web3) => {
     return new web3.eth.Contract(require('@aragon/os/build/contracts/ACL').abi, aclAddr)
   }
 
+  const getRoleId = async (repoAddr) => {
+    const repo = new web3.eth.Contract(require('@aragon/os/build/contracts/Repo').abi, repoAddr)
+    return await repo.methods.CREATE_VERSION_ROLE().call()
+  }
+
   return {
     grant: async (repoAddr, grantee) => {
       const acl = await getACL(repoAddr)
 
-      const roleId = '0x0000000000000000000000000000000000000000000000000000000000000001'
+      const roleId = await getRoleId(repoAddr)
 
       const call = acl.methods.grantPermission(grantee, repoAddr, roleId)
       return {

--- a/src/commands/apm_cmds/grant.js
+++ b/src/commands/apm_cmds/grant.js
@@ -20,10 +20,10 @@ exports.handler = async function ({
   network,
   module,
   apm: apmOptions,
-
   // Arguments
   address
 }) {
+
   const web3 = await ensureWeb3(network)
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
 

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -29,7 +29,7 @@ exports.describe = 'Publish a new version of the application'
 exports.builder = function (yargs) {
   return deploy.builder(yargs) // inherit deploy options
     .positional('contract', {
-      description: 'The address or name of the contract to publish in this version. If it isn\' provided, it will default to the current version\'s contract.'
+      description: 'The address or name of the contract to publish in this version. If it isn\'t provided, it will default to the current version\'s contract.'
     }).option('only-artifacts', {
       description: 'Whether just generate artifacts file without publishing',
       default: false,


### PR DESCRIPTION

As discussed in #158, `apm grant 0xsomeAddress` uses a create version
role id hash that is no longer be used by Repo contracts. This commit
ensures that the new role id is used by fetching it from the dedicated
repo address.

Also, this might be considered a breaking change as the new default for the role id, is `keccak256('CREATE_VERSION_ROLE')` and no longer `0x....01`

Fixes #158