### PR TITLE
Improve error message when provider is unaccessible and support provider lazy loading

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,7 +88,11 @@ cmd.option('network', {
     }
     let provider
     if (truffleNetwork.provider) {
-      provider = truffleNetwork.provider
+      if (typeof truffleNetwork.provider === 'function') {
+        provider = truffleNetwork.provider()
+      } else {
+        provider = truffleNetwork.provider
+      }
     } else if (truffleNetwork.host && truffleNetwork.port) {
       provider = new Web3.providers.WebsocketProvider(`ws://${truffleNetwork.host}:${truffleNetwork.port}`)
     } else {

--- a/src/helpers/web3-fallback.js
+++ b/src/helpers/web3-fallback.js
@@ -8,7 +8,11 @@ const ensureWeb3 = async (network) => {
     const connected = await web3.eth.net.isListening()
     if (connected) return web3
   } catch (err) {
-    throw new Error(`Web3 cannot connect using the network provider. Make sure 'aragon devchain' is running or your provider settings are correct.`)
+    throw new Error(`Web3 cannot connect using the network provider.
+
+Make sure 'aragon devchain' is running or your provider settings are correct.
+
+For more info you can check the Truffle docs on network configuration: https://truffleframework.com/docs/truffle/reference/configuration#networks`)
   }
 }
 

--- a/src/helpers/web3-fallback.js
+++ b/src/helpers/web3-fallback.js
@@ -8,7 +8,7 @@ const ensureWeb3 = async (network) => {
     const connected = await web3.eth.net.isListening()
     if (connected) return web3
   } catch (err) {
-    throw new Error(`Please execute aragon run or aragon devchain before running this`)
+    throw new Error(`Web3 cannot connect using the network provider. Make sure 'aragon devchain' is running or your provider settings are correct.`)
   }
 }
 


### PR DESCRIPTION
Change to a more descriptive error when the CLI fails to connect with the provider.

Also adding support for lazily loading providers from truffle config files.