### PR TITLE
feat(commands/run): introduce --client-version and --client-port 

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
     "require": [
       "@babel/register"
     ]
+  },
+  "aragon": {
+    "clientVersion": "fcebf55d1af6c574a92587e2a1d3ac8c00804d16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     ]
   },
   "aragon": {
-    "clientVersion": "fcebf55d1af6c574a92587e2a1d3ac8c00804d16"
+    "clientVersion": "fcebf55d1af6c574a92587e2a1d3ac8c00804d16",
+    "clientPort": "3000"
   }
 }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -18,6 +18,7 @@ const os = require('os')
 const fs = require('fs-extra')
 const opn = require('opn')
 const execa = require('execa')
+const pkg = require('../../package.json')
 
 const {
   findProjectRoot,
@@ -34,7 +35,7 @@ const url = require('url')
 const TX_MIN_GAS = 10e6
 const WRAPPER_PORT = 3000
 
-const WRAPPER_COMMIT = 'fcebf55d1af6c574a92587e2a1d3ac8c00804d16'
+const aragonClientVersion = pkg.aragon.clientVersion;
 
 exports.command = 'run'
 
@@ -231,8 +232,7 @@ exports.handler = function ({
         {
           title: 'Download wrapper',
           task: (ctx, task) => {
-            const WRAPPER_PATH = `${os.homedir()}/.aragon/wrapper-${WRAPPER_COMMIT}`
-            ctx.wrapperPath = WRAPPER_PATH
+            const WRAPPER_PATH = `${os.homedir()}/.aragon/wrapper-${aragonClientVersion}`
 
             // Make sure we haven't already downloaded the wrapper
             if (fs.existsSync(path.resolve(WRAPPER_PATH))) {
@@ -248,7 +248,7 @@ exports.handler = function ({
             return clone(
               'https://github.com/aragon/aragon',
               WRAPPER_PATH,
-              { checkout: WRAPPER_COMMIT }
+              { checkout: aragonClientVersion }
             )
           },
         },


### PR DESCRIPTION
The important commit here is the third one. It might make sense to squash them all into a single one, in case you want to preserve the refactoring in the commit history.