### PR TITLE
feat(commands/run): introduce --client-path option

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -92,6 +92,9 @@ exports.builder = function (yargs) {
   }).option('client-port', {
     description: 'Port being used by Aragon client',
     default: DEFAULT_CLIENT_PORT
+  }).option('client-path', {
+    description: 'A path pointing to an existing Aragon client installation',
+    default: null
   })
 }
 
@@ -131,7 +134,8 @@ exports.handler = function ({
     appInit,
     appInitArgs,
     clientVersion,
-    clientPort
+    clientPort,
+    clientPath
   }) {
 
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
@@ -244,6 +248,7 @@ exports.handler = function ({
       task: (ctx, task) => new TaskList([
         {
           title: 'Download wrapper',
+          skip: () => !!clientPath,
           task: (ctx, task) => {
             clientVersion = clientVersion || DEFAULT_CLIENT_VERSION
             const CLIENT_PATH = `${os.homedir()}/.aragon/wrapper-${clientVersion}`
@@ -268,7 +273,7 @@ exports.handler = function ({
         {
           title: 'Install wrapper dependencies',
           task: async (ctx, task) => (await installDeps(ctx.wrapperPath, task)),
-          enabled: (ctx) => !ctx.wrapperAvailable
+          enabled: (ctx) => !ctx.wrapperAvailable && !clientPath
         },
         {
           title: 'Start Aragon client',
@@ -279,12 +284,13 @@ exports.handler = function ({
             }
             const bin = getNodePackageManager()
             const startArguments = {
-              cwd: ctx.wrapperPath,
+              cwd: clientPath || ctx.wrapperPath,
               env: {
                 REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens,
                 BROWSER: 'none',
               }
             }
+
             execa(bin, ['run', 'start:local'], startArguments).catch((err) => { throw new Error(err) })
           }
         },


### PR DESCRIPTION
This commit enables users to pass a `--client-path` to the `run` command.
The path specifies the location to an already existing installation of the
Aragon client on the local machine, allowing developers to test custom versions
of the app.

Closes #199