### PR TITLE
Install go-ipfs as dependency, remove the need for manual install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
     },
     "@aragon/apps-finance": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/@aragon/apps-finance/-/apps-finance-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@aragon/apps-finance/-/apps-finance-1.0.1.tgz",
       "integrity": "sha512-8h+LExLnNQyEtImHtdcJo4howKI4tE4zU6+Fppw0u5nJIkXYIjRmtXPnXVZGKR7V5KYw9ujUOWgOm7a3BcpCPw==",
       "requires": {
         "@aragon/apps-vault": "^2.0.0",
@@ -87,7 +87,7 @@
     },
     "@aragon/apps-token-manager": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/@aragon/apps-token-manager/-/apps-token-manager-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aragon/apps-token-manager/-/apps-token-manager-1.0.0.tgz",
       "integrity": "sha512-ospkQLAqH8OZ5VtIyy9vqZ8lNt7OwvnngtMMz5a2caZVi9CmsODoqzSRjpCcBRm/aEFW4sixr7L6O9TYtvBvqw==",
       "requires": {
         "@aragon/os": "^3.0.8"
@@ -107,7 +107,7 @@
     },
     "@aragon/apps-vault": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/@aragon/apps-vault/-/apps-vault-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@aragon/apps-vault/-/apps-vault-2.0.1.tgz",
       "integrity": "sha512-SRUNbLrS+fEf7FhNb1Gt5x1lQieIsWUggwcsDyI+sy+XQ2e8J83vjgqUWPUSwQvXK3e2S7QJ/j/czZ9NrFtWxA==",
       "requires": {
         "@aragon/os": "^3.1.1"
@@ -127,7 +127,7 @@
     },
     "@aragon/apps-voting": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/@aragon/apps-voting/-/apps-voting-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aragon/apps-voting/-/apps-voting-1.0.0.tgz",
       "integrity": "sha512-+Z1o6rSdXrRbDYRoSaoh3PaNzHQt+u7YY0BLUL55/nlZct+tkZM7uIq8Qsk33IZDxr0S58jDB6zNsiR5yXE5TA==",
       "requires": {
         "@aragon/os": "^3.0.8"
@@ -171,7 +171,7 @@
     },
     "@aragon/templates-beta": {
       "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/@aragon/templates-beta/-/templates-beta-1.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@aragon/templates-beta/-/templates-beta-1.1.3.tgz",
       "integrity": "sha512-RBpvibf3pabIFKPARfu+dZNFesYDoH4R/6EuuBtqQGVrWiR3FbHKg8heyjn8o6s/Sw/DehbHFpA6xro3aKzb6g==",
       "requires": {
         "@aragon/apps-finance": "^1.0.0",
@@ -183,7 +183,7 @@
       "dependencies": {
         "@aragon/apps-vault": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/@aragon/apps-vault/-/apps-vault-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aragon/apps-vault/-/apps-vault-1.0.0.tgz",
           "integrity": "sha512-XJPT399unNjxnr+F8uZTmMzp/KP+Y5vTjjEUBmfHN1TyD4VuBPZ+bbGixKkK8E4WjMmVlo4gfsuYkCpJJ/G8cQ==",
           "requires": {
             "@aragon/os": "^3.0.8"
@@ -227,7 +227,7 @@
       "dependencies": {
         "web3": {
           "version": "1.0.0-beta.33",
-          "resolved": "http://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
           "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
           "requires": {
             "web3-bzz": "1.0.0-beta.33",
@@ -2067,7 +2067,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2285,12 +2285,12 @@
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
-      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
       "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
     },
     "babel-plugin-syntax-trailing-function-commas": {
@@ -2665,7 +2665,7 @@
     },
     "babelify": {
       "version": "7.3.0",
-      "resolved": "http://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
       "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
       "requires": {
         "babel-core": "^6.0.14",
@@ -2768,6 +2768,15 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -3056,6 +3065,21 @@
         "parse-asn1": "^5.0.0"
       }
     },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "requires": {
+        "pako": "~0.2.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        }
+      }
+    },
     "browserslist": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
@@ -3141,6 +3165,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
       "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -3279,6 +3308,21 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "dependencies": {
+        "traverse": {
+          "version": "0.3.9",
+          "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+          "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+        }
+      }
+    },
     "chalk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
@@ -3336,6 +3380,11 @@
         "readdirp": "^2.0.0",
         "upath": "^1.0.5"
       }
+    },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE="
     },
     "ci-info": {
       "version": "1.4.0",
@@ -4205,6 +4254,17 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
+    "duplexify": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4463,7 +4523,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -5283,7 +5343,7 @@
     },
     "express": {
       "version": "4.16.3",
-      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "requires": {
         "accepts": "~1.3.5",
@@ -11835,6 +11895,36 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "go-ipfs": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.4.17.tgz",
+      "integrity": "sha512-5/YLMMq+/1fmeMMwDjX+nPPsUpN3BtpHWNhrx0l7q69lvgr1y8sF+j7RVbMU5YkDW5cP5swd+9OZ2lhOxLhlEA==",
+      "requires": {
+        "go-ipfs-dep": "0.4.17",
+        "go-platform": "^1.0.0",
+        "gunzip-maybe": "^1.4.1",
+        "request": "^2.87.0",
+        "tar-fs": "^1.16.3",
+        "unzip": "^0.1.11"
+      }
+    },
+    "go-ipfs-dep": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/go-ipfs-dep/-/go-ipfs-dep-0.4.17.tgz",
+      "integrity": "sha512-zEYDcU2uFmWTQ3iph8vbq3dkob+rGJ/yJcSX3aYovl2mNeBeTF/dEoXGh9IdJA7tCAEfRQVWhLVuRIYwGZxdVQ==",
+      "requires": {
+        "go-platform": "^1.0.0",
+        "gunzip-maybe": "^1.4.1",
+        "request": "^2.87.0",
+        "tar-fs": "^1.16.3",
+        "unzip-stream": "^0.3.0"
+      }
+    },
+    "go-platform": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
+      "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc="
+    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -11870,6 +11960,19 @@
       "version": "1.10.3",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
       "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q=="
+    },
+    "gunzip-maybe": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+      "requires": {
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -11968,21 +12071,6 @@
       "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-1.0.0.tgz",
       "integrity": "sha1-ieJdtgS3Jcj1l2//Ct3JIbgopac=",
       "dev": true
-    },
-    "hasbin": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
-      "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
-      "requires": {
-        "async": "~1.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
-      }
     },
     "hash-base": {
       "version": "3.0.4",
@@ -12243,7 +12331,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -12676,6 +12764,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-deflate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+      "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -12769,6 +12862,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-gzip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
     },
     "is-hex-prefixed": {
       "version": "1.0.0",
@@ -13419,7 +13517,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13467,7 +13565,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13506,7 +13604,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13674,7 +13772,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -13820,6 +13918,28 @@
       "dev": true,
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "match-stream": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/match-stream/-/match-stream-0.0.2.tgz",
+      "integrity": "sha1-mesFAJOzTf+t5CG5rAtBCpz6F88=",
+      "requires": {
+        "buffers": "~0.1.1",
+        "readable-stream": "~1.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
       }
     },
     "matcher": {
@@ -14039,7 +14159,7 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mixin-deep": {
@@ -14065,7 +14185,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -14073,7 +14193,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -14272,6 +14392,11 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "natives": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.4.tgz",
+      "integrity": "sha512-Q29yeg9aFKwhLVdkTAejM/HvYG0Y1Am1+HUkFQGn5k2j8GS+v60TVmZh6nujpEAj/qql+wGUrlryO8bF+b1jEg=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -14590,7 +14715,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "requires": {
         "chalk": "^1.1.1",
@@ -14601,7 +14726,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -14625,7 +14750,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -14646,6 +14771,11 @@
         "is-plain-obj": "^1.1.0",
         "mkdirp": "^0.5.1"
       }
+    },
+    "over": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/over/-/over-0.0.5.tgz",
+      "integrity": "sha1-8phS5w/X4l82DgE6jsRMgq7bVwg="
     },
     "p-cancelable": {
       "version": "0.3.0",
@@ -14717,7 +14847,7 @@
       "dependencies": {
         "got": {
           "version": "6.7.1",
-          "resolved": "http://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
@@ -14895,6 +15025,16 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
       }
     },
     "peer-id": {
@@ -15246,6 +15386,30 @@
       "resolved": "https://registry.npmjs.org/pull-traverse/-/pull-traverse-1.0.3.tgz",
       "integrity": "sha1-dPtde+f6a9enjpeTPhmbeUWGaTg="
     },
+    "pullstream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pullstream/-/pullstream-0.4.1.tgz",
+      "integrity": "sha1-1vs79a7Wl+gxFQ6xACwlo/iuExQ=",
+      "requires": {
+        "over": ">= 0.0.5 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.2 < 2",
+        "slice-stream": ">= 1.0.0 < 2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -15253,6 +15417,16 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -16069,6 +16243,27 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
+    "slice-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slice-stream/-/slice-stream-1.0.0.tgz",
+      "integrity": "sha1-WzO9ZvATsaf4ZGCwPUY97DmtPqA=",
+      "requires": {
+        "readable-stream": "~1.0.31"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -16208,7 +16403,7 @@
         },
         "yargs": {
           "version": "4.8.1",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "requires": {
             "cliui": "^3.2.0",
@@ -16430,6 +16625,11 @@
         "xtend": "^4.0.0"
       }
     },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
     "stream-to-observable": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
@@ -16586,7 +16786,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -16616,7 +16816,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -16686,6 +16886,28 @@
         "inherits": "2"
       }
     },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "tar-stream": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
@@ -16714,7 +16936,7 @@
       "dependencies": {
         "bluebird": {
           "version": "2.11.0",
-          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
           "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
         }
       }
@@ -16817,7 +17039,7 @@
         },
         "chalk": {
           "version": "0.4.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
@@ -17152,7 +17374,7 @@
         },
         "buffer": {
           "version": "3.6.0",
-          "resolved": "http://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
           "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
           "requires": {
             "base64-js": "0.0.8",
@@ -17322,11 +17544,65 @@
         }
       }
     },
+    "unzip": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/unzip/-/unzip-0.1.11.tgz",
+      "integrity": "sha1-iXScY7BY19kNYZ+GuYqhU107l/A=",
+      "requires": {
+        "binary": ">= 0.3.0 < 1",
+        "fstream": ">= 0.1.30 < 1",
+        "match-stream": ">= 0.0.2 < 1",
+        "pullstream": ">= 0.4.1 < 1",
+        "readable-stream": "~1.0.31",
+        "setimmediate": ">= 1.0.1 < 2"
+      },
+      "dependencies": {
+        "fstream": {
+          "version": "0.1.31",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+          "integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
+          "requires": {
+            "graceful-fs": "~3.0.2",
+            "inherits": "~2.0.0",
+            "mkdirp": "0.5",
+            "rimraf": "2"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "requires": {
+            "natives": "^1.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        }
+      }
+    },
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
       "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
       "dev": true
+    },
+    "unzip-stream": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unzip-stream/-/unzip-stream-0.3.0.tgz",
+      "integrity": "sha512-NG1h/MdGIX3HzyqMjyj1laBCmlPYhcO4xEy7gEqqzGiSLw7XqDQCnY4nYSn5XSaH8mQ6TFkaujrO8d/PIZN85A==",
+      "requires": {
+        "binary": "^0.3.0",
+        "mkdirp": "^0.5.1"
+      }
     },
     "upath": {
       "version": "1.1.0",
@@ -18181,7 +18457,7 @@
         },
         "web3": {
           "version": "0.16.0",
-          "resolved": "http://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
             "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
@@ -18369,7 +18645,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "fs-extra": "^4.0.2",
     "ganache-core": "^2.1.6",
     "git-clone": "^0.1.0",
-    "hasbin": "^1.2.3",
+    "go-ipfs": "^0.4.17",
     "homedir": "^0.6.0",
     "ignore": "^3.3.7",
     "ipfs-api": "^21.0.0",

--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -30,7 +30,7 @@ exports.task = ({ apmOptions }) => {
 					} else {
 						task.output = 'IPFS is started, checking CORS config'
 						await setIPFSCORS(apmOptions.ipfs.rpc)
-						return 'Connected to IPFS daemon ar port: '+ apmOptions.ipfs.rpc.port 
+						return 'Connected to IPFS daemon at port: '+ apmOptions.ipfs.rpc.port 
 					}
 		    } else {
 		      await isIPFSCORS(apmOptions.ipfs.rpc)

--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -2,7 +2,6 @@ const opn = require('opn')
 const path = require('path')
 const TaskList = require('listr')
 const {
-  isIPFSInstalled,
   startIPFSDaemon,
   isIPFSCORS,
   setIPFSCORS
@@ -22,25 +21,17 @@ exports.task = ({ apmOptions }) => {
 	  	task: async (ctx, task) => {
 		    // If the dev manually set their IPFS node, skip install and running check
 		    if (apmOptions.ipfs.rpc.default) {
-		      const installed = await isIPFSInstalled()
-		      if (!installed) {
-		        setTimeout(() => opn('https://ipfs.io/docs/install'), 2500)
-		        throw new Error(`
-		          Running your app requires IPFS. Opening install instructions in your browser`
-		        )
-		      } else {
-		        const running = await isPortTaken(apmOptions.ipfs.rpc.port)
-		        if (!running) {
-		          task.output = 'Starting IPFS at port: ' + apmOptions.ipfs.rpc.port
-		          await startIPFSDaemon()
-		          ctx.started = true
-		          await setIPFSCORS(apmOptions.ipfs.rpc)
-		        } else {
-		          task.output = 'IPFS is started, checking CORS config'
-		          await setIPFSCORS(apmOptions.ipfs.rpc)
-		          return 'Connected to IPFS daemon ar port: '+ apmOptions.ipfs.rpc.port 
-		        }
-		      }
+					const running = await isPortTaken(apmOptions.ipfs.rpc.port)
+					if (!running) {
+						task.output = 'Starting IPFS at port: ' + apmOptions.ipfs.rpc.port
+						await startIPFSDaemon()
+						ctx.started = true
+						await setIPFSCORS(apmOptions.ipfs.rpc)
+					} else {
+						task.output = 'IPFS is started, checking CORS config'
+						await setIPFSCORS(apmOptions.ipfs.rpc)
+						return 'Connected to IPFS daemon ar port: '+ apmOptions.ipfs.rpc.port 
+					}
 		    } else {
 		      await isIPFSCORS(apmOptions.ipfs.rpc)
 		      return 'Connecting to provided IPFS daemon'

--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -1,4 +1,3 @@
-const opn = require('opn')
 const path = require('path')
 const TaskList = require('listr')
 const {
@@ -16,54 +15,54 @@ exports.describe = 'Start IPFS daemon configured to work with Aragon'
 
 exports.task = ({ apmOptions }) => {
   return new TaskList([
-  	{
-	  	title: 'Start IPFS',
-	  	task: async (ctx, task) => {
-		    // If the dev manually set their IPFS node, skip install and running check
-		    if (apmOptions.ipfs.rpc.default) {
-					const running = await isPortTaken(apmOptions.ipfs.rpc.port)
-					if (!running) {
-						task.output = 'Starting IPFS at port: ' + apmOptions.ipfs.rpc.port
-						await startIPFSDaemon()
-						ctx.started = true
-						await setIPFSCORS(apmOptions.ipfs.rpc)
-					} else {
-						task.output = 'IPFS is started, checking CORS config'
-						await setIPFSCORS(apmOptions.ipfs.rpc)
-						return 'Connected to IPFS daemon at port: '+ apmOptions.ipfs.rpc.port 
-					}
-		    } else {
-		      await isIPFSCORS(apmOptions.ipfs.rpc)
-		      return 'Connecting to provided IPFS daemon'
-		    }
-			}
-		},
-		{
-			title: 'Add local files',
-			task: (ctx) => {
-				const ipfs = IPFS('localhost', '5001', { protocol: 'http' })
-				const files = path.resolve(require.resolve('@aragon/aragen'), '../ipfs-cache')
+    {
+      title: 'Start IPFS',
+      task: async (ctx, task) => {
+        // If the dev manually set their IPFS node, skip install and running check
+        if (apmOptions.ipfs.rpc.default) {
+          const running = await isPortTaken(apmOptions.ipfs.rpc.port)
+          if (!running) {
+            task.output = 'Starting IPFS at port: ' + apmOptions.ipfs.rpc.port
+            await startIPFSDaemon()
+            ctx.started = true
+            await setIPFSCORS(apmOptions.ipfs.rpc)
+          } else {
+            task.output = 'IPFS is started, checking CORS config'
+            await setIPFSCORS(apmOptions.ipfs.rpc)
+            return 'Connected to IPFS daemon at port: '+ apmOptions.ipfs.rpc.port 
+          }
+        } else {
+          await isIPFSCORS(apmOptions.ipfs.rpc)
+          return 'Connecting to provided IPFS daemon'
+        }
+      }
+    },
+    {
+      title: 'Add local files',
+      task: (ctx) => {
+        const ipfs = IPFS('localhost', '5001', { protocol: 'http' })
+        const files = path.resolve(require.resolve('@aragon/aragen'), '../ipfs-cache')
 
-				return new Promise((resolve, reject) => {
-					ipfs.util.addFromFs(files, { recursive: true, ignore: 'node_modules' }, (err, files) => {
-						if (err) return reject(err)
-						resolve(files)
-					})
-				})
-			}
-		}
-	])
+        return new Promise((resolve, reject) => {
+          ipfs.util.addFromFs(files, { recursive: true, ignore: 'node_modules' }, (err, files) => {
+            if (err) return reject(err)
+            resolve(files)
+          })
+        })
+      }
+    }
+  ])
 }
 
 exports.handler = function ({ reporter, apm: apmOptions }) {
   const task = exports.task({ apmOptions })
 
   task.run().then(ctx => {
-  	if (ctx.started) {
-  		reporter.info('IPFS daemon is now running. Stopping this process will stop IPFS')
-  	} else {
-  		reporter.warning('Didnt start IPFS, port busy')
-  		process.exit()
-  	}
+    if (ctx.started) {
+      reporter.info('IPFS daemon is now running. Stopping this process will stop IPFS')
+    } else {
+      reporter.warning('Didnt start IPFS, port busy')
+      process.exit()
+    }
   })
 }

--- a/src/helpers/ipfs-daemon.js
+++ b/src/helpers/ipfs-daemon.js
@@ -1,20 +1,14 @@
-const { hasBin, isPortTaken } = require('../util')
 const execa = require('execa')
 const fs = require('fs')
 const path = require('path')
 const homedir = require('homedir')()
 const ipfsAPI = require('ipfs-api')
 
-const isIPFSInstalled = async () => {
-  return await hasBin('ipfs')
-}
-
 const ensureIPFSInitialized = async () => {
   if (fs.existsSync(path.join(homedir, '.ipfs'))) {
     return true
   }
-  const ipfsInit = await execa('ipfs', ['init'])
-  return true
+  await execa('ipfs', ['init'])
 }
 
 const startIPFSDaemon = () => (
@@ -61,4 +55,4 @@ const setIPFSCORS = (ipfsRpc) => {
   )
 }
 
-module.exports = { isIPFSInstalled, startIPFSDaemon, isIPFSCORS, setIPFSCORS }
+module.exports = { startIPFSDaemon, isIPFSCORS, setIPFSCORS }

--- a/src/helpers/ipfs-daemon.js
+++ b/src/helpers/ipfs-daemon.js
@@ -5,10 +5,9 @@ const homedir = require('homedir')()
 const ipfsAPI = require('ipfs-api')
 
 const ensureIPFSInitialized = async () => {
-  if (fs.existsSync(path.join(homedir, '.ipfs'))) {
-    return true
+  if (!fs.existsSync(path.join(homedir, '.ipfs'))) {
+    await execa('ipfs', ['init'])
   }
-  await execa('ipfs', ['init'])
 }
 
 const startIPFSDaemon = () => (

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,5 @@
 const findUp = require('find-up')
 const path = require('path')
-const hasbin = require('hasbin')
 const { promisify } = require('util')
 const execa = require('execa')
 const net = require('net')
@@ -20,8 +19,6 @@ const findProjectRoot = () => {
   }
   return cachedProjectRoot
 }
-
-const hasBin = (bin) => new Promise((resolve, reject) => hasbin(bin, resolve))
 
 const isPortTaken = async (port, opts) => {
   opts = Object.assign({timeout: 1000}, opts)
@@ -69,4 +66,4 @@ const getContract = (pkg, contract) => {
 
 const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
 
-module.exports = { findProjectRoot, hasBin, isPortTaken, installDeps, getNodePackageManager, getContract, ANY_ENTITY }
+module.exports = { findProjectRoot, isPortTaken, installDeps, getNodePackageManager, getContract, ANY_ENTITY }


### PR DESCRIPTION
Addresses the 4th point at https://github.com/aragon/aragon-cli/issues/203, and removes the need for manually installing IPFS.