### PR TITLE
Remove unnecessary BROWSER env var in aragon run

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -287,7 +287,6 @@ exports.handler = function ({
               cwd: clientPath || ctx.wrapperPath,
               env: {
                 REACT_APP_ENS_REGISTRY_ADDRESS: ctx.ens,
-                BROWSER: 'none',
                 REACT_APP_PORT: clientPort
               }
             }


### PR DESCRIPTION
`BROWSER` was a hook for react-scripts, but now that we're using parcel, this is obsolete. Parcel doesn't automatically launch a browser by default.