### PR TITLE
Fix solidity extractor

### DIFF
--- a/src/helpers/solidity-extractor.js
+++ b/src/helpers/solidity-extractor.js
@@ -2,12 +2,9 @@ const fs = require('fs')
 const { promisify } = require('util')
 const readFile = promisify(fs.readFile)
 
-const modifiesStateAndIsPublic = (declaration) => {
-  const blacklist = ['internal', 'private', 'view', 'pure']
-
-  // space words to ensure they are not part of another word
-  return blacklist.filter((w) => declaration.indexOf(` ${w} `) != -1).length == 0
-}
+const modifiesStateAndIsPublic = (declaration) => (
+  !declaration.match(/\b(internal|private|view|pure|constant)\b/)
+)
 
 const typeOrAddress = type => {
   const types = ['address', 'byte', 'uint', 'int', 'bool', 'string']

--- a/src/helpers/solidity-extractor.js
+++ b/src/helpers/solidity-extractor.js
@@ -19,8 +19,12 @@ const typeOrAddress = type => {
 
 // extracts function signature from function declaration
 const getSignature = (declaration) => {
-  const name = declaration.match(/function ([^]*?)\(/)[0].replace('function ', '')
-  let params = declaration.match(/\(([^]*?)\)/)[0].replace('(', '').replace(')', '')
+  let [ name, params ] = declaration.match(/function ([^]*?)\)/)[1].split('(')
+
+  if (!name) {
+    return 'fallback'
+  }
+
   if (params) {
     // Has parameters
     params = params
@@ -32,7 +36,7 @@ const getSignature = (declaration) => {
       .join(',')
   }
 
-  return name + params + ')'
+  return `${name}(${params})`
 }
 
 const getNotice = (declaration) => {

--- a/src/helpers/solidity-extractor.js
+++ b/src/helpers/solidity-extractor.js
@@ -10,7 +10,7 @@ const modifiesStateAndIsPublic = (declaration) => {
 }
 
 const typeOrAddress = type => {
-  const types = ['address', 'byte', 'uint', 'int', 'bool']
+  const types = ['address', 'byte', 'uint', 'int', 'bool', 'string']
 
   // check if the type starts with any of the above types, otherwise it is probably
   // a typed contract, so we need to return address for the signature


### PR DESCRIPTION
While we wait for #133 (to eradicate solidity-extractor for good), added some fixes to the solidity extractor that was getting confused when a radspec string had a function call. This fixes artifact generation for Aragon's Finance app.

Bonus:
- 0b523d9 closes #43