### PR TITLE
apm publish: Improve publish feedback

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -486,6 +486,7 @@ exports.handler = async (args) => {
       }
 
       reporter.info(`Transaction hash: ${transactionHash}`)
+      reporter.debug(`Published directory: ${ctx.pathToPublish}`)
       process.exit(status ? 0 : 1)
     })
     .catch(() => { process.exit(1) })


### PR DESCRIPTION
Makes documenting deploys much more pleasant!

```
$ aragon apm publish --network rpc --no-build --only-content
 ✔ Preflight checks for publishing to APM
 ✔ Determine contract address for version
 ✔ Check IPFS
 ✔ Prepare files for publishing
 ↓ Generate application artifact [skipped]
   → Using existent artifact
 ✔ Publish finance.aragonpm.eth
 ✔ Fetch published repo

 ✔ Successfully published finance.aragonpm.eth 5.0.2:
 ℹ Content (ipfs): QmTsyoSosfo7GUsCAav8k6Cqd3UN5H1XEWYpMrbF17h7AZ
 ℹ Transaction hash: 0xb0cbbc08d9573a4c6377104745cd7ce972f597c4370a9ffbc57cb62492dca76c
```