### PR TITLE
Add deployment artifacts to artifact.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "semver": "^5.4.1",
     "tmp-promise": "^1.0.4",
     "truffle": "4.1.14",
+    "truffle-flattener": "^1.2.9",
     "web3": "^1.0.0-beta.34",
     "yargs": "^10.1.0"
   },

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -94,13 +94,16 @@ async function generateApplicationArtifact (cwd, outputPath, module, deployArtif
   // Set ABI
   const contractInterface = await readJson(contractInterfacePath)
   artifact.abi = contractInterface.abi
-  artifact.deployment = deployArtifacts
-  if (deployArtifacts.flattenedCode) {
-    fs.writeFileSync(
-      path.resolve(outputPath, SOLIDITY_FILE),
-      artifact.deployment.flattenedCode
-    )
-    artifact.deployment.flattenedCode = `./${SOLIDITY_FILE}`
+
+  if (deployArtifacts) {
+    artifact.deployment = deployArtifacts
+    if (deployArtifacts.flattenedCode) {
+      fs.writeFileSync(
+        path.resolve(outputPath, SOLIDITY_FILE),
+        artifact.deployment.flattenedCode
+      )
+      artifact.deployment.flattenedCode = `./${SOLIDITY_FILE}`
+    }
   }
 
   // Analyse contract functions and returns an array
@@ -118,6 +121,46 @@ async function generateApplicationArtifact (cwd, outputPath, module, deployArtif
   )
 
   return artifact
+}
+
+async function copyCurrentApplicationArtifacts (outputPath, apm, repo, newVersion) {
+  const copyingFiles = [ARTIFACT_FILE, SOLIDITY_FILE]
+  const { content } = repo
+  const uri = `${content.provider}:${content.location}`
+
+  const copy = await Promise.all(copyingFiles.map(async (file) => {
+    try {
+      return {
+        filePath: path.resolve(outputPath, file),
+        fileContent: await apm.getFile(uri, file),
+        fileName: file
+      }
+    } catch (e) {
+      // Only throw if fetching artifact fails, if code can't be found
+      // continue as it could be fetched from previous versions
+      if (file === ARTIFACT_FILE) {
+        throw e
+      }
+    }
+  }))
+
+  const updateArtifactVersion = (file, version) => {
+    const newContent = JSON.parse(file.fileContent)
+    newContent.version = version
+    return { ...file, fileContent: JSON.stringify(newContent, null, 2) }
+  }
+
+  copy
+    .filter(item => item)
+    .map((file) => {
+      if (file.fileName === ARTIFACT_FILE) {
+        return updateArtifactVersion(file, newVersion)
+      }
+      return file
+    })
+    .forEach(({ fileName, filePath, fileContent }) =>
+      fs.writeFileSync(filePath, fileContent)
+  )
 }
 
 /**
@@ -246,9 +289,9 @@ exports.task = function ({
         {
           title: 'Checking version bump',
           task: async (ctx) => {
-            let repo = { version: '0.0.0' }
+            ctx.repo = { version: '0.0.0' }
             try {
-              repo = await apm.getLatestVersion(module.appName)
+              ctx.repo = await apm.getLatestVersion(module.appName)
             } catch (e) {
               if (e.message.indexOf('Invalid content URI') === 0) {
                 return
@@ -261,18 +304,18 @@ exports.task = function ({
               }
             }
 
-            if (ctx.version === repo.version) {
+            if (ctx.version === ctx.repo.version) {
               throw new Error('Version is already published, please bump it using `aragon apm version [major, minor, patch]`')
             }
 
-            const isValid = await apm.isValidBump(module.appName, repo.version, ctx.version)
+            const isValid = await apm.isValidBump(module.appName, ctx.repo.version, ctx.version)
 
             if (!isValid) {
               throw new Error('Version bump is not valid, you have to respect APM bumps policy. Check version upgrade rules in documentation https://hack.aragon.org/docs/aragonos-ref.html#631-version-upgrade-rules')
             }
 
             const getMajor = version => version.split('.')[0]
-            ctx.isMajor = getMajor(repo.version) !== getMajor(ctx.version)
+            ctx.isMajor = getMajor(ctx.repo.version) !== getMajor(ctx.version)
           }
         }
       ])
@@ -417,19 +460,24 @@ exports.task = function ({
         }
 
         if (onlyContent) {
-          return taskInput('Couldn\'t find artifact.json, do you want to generate one? [y]es/[a]bort', {
-            validate: value => {
-              return ANSWERS.indexOf(value) > -1
-            },
-            done: async (answer) => {
-              if (POSITIVE_ANSWERS.indexOf(answer) > -1) {
-                await generateApplicationArtifact(cwd, dir, module, ctx.deployArtifacts)
-                return `Saved artifact in ${dir}/artifact.json`
+          try {
+            task.output = 'Fetching artifacts from previous version'
+            await copyCurrentApplicationArtifacts(dir, apm, ctx.repo, ctx.version)
+            return task.skip(`Using artifacts from v${ctx.repo.version}`)
+          } catch (e) {
+            return taskInput('Couldn\'t find artifacts in published version, generate one now? [y]es/[a]bort', {
+              validate: value => {
+                return ANSWERS.indexOf(value) > -1
+              },
+              done: async (answer) => {
+                if (POSITIVE_ANSWERS.indexOf(answer) > -1) {
+                  await generateApplicationArtifact(cwd, dir, module, ctx.deployArtifacts)
+                  return `Saved artifact in ${dir}/artifact.json`
+                }
+                throw new Error('Aborting publication...')
               }
-              // TODO: Should use artifact file from current version, just changing version number
-              throw new Error('Aborting publication...')
-            }
-          })
+            })
+          }
         }
         await generateApplicationArtifact(cwd, dir, module, ctx.deployArtifacts)
         return `Saved artifact in ${dir}/artifact.json`

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -79,7 +79,7 @@ exports.builder = function (yargs) {
     })
 }
 
-async function generateApplicationArtifact (web3, cwd, outputPath, module, deployArtifacts, reporter) {
+async function generateApplicationArtifact (cwd, outputPath, module, deployArtifacts) {
   let artifact = Object.assign({}, module)
   const contractPath = artifact.path
   const contractInterfacePath = path.resolve(
@@ -95,11 +95,13 @@ async function generateApplicationArtifact (web3, cwd, outputPath, module, deplo
   const contractInterface = await readJson(contractInterfacePath)
   artifact.abi = contractInterface.abi
   artifact.deployment = deployArtifacts
-  fs.writeFileSync(
-    path.resolve(outputPath, SOLIDITY_FILE),
-    artifact.deployment.flattenedCode
-  )
-  artifact.deployment.flattenedCode = `./${SOLIDITY_FILE}`
+  if (deployArtifacts.flattenedCode) {
+    fs.writeFileSync(
+      path.resolve(outputPath, SOLIDITY_FILE),
+      artifact.deployment.flattenedCode
+    )
+    artifact.deployment.flattenedCode = `./${SOLIDITY_FILE}`
+  }
 
   // Analyse contract functions and returns an array
   // > [{ sig: 'transfer(address)', role: 'X_ROLE', notice: 'Transfers..'}]
@@ -421,7 +423,7 @@ exports.task = function ({
             },
             done: async (answer) => {
               if (POSITIVE_ANSWERS.indexOf(answer) > -1) {
-                await generateApplicationArtifact(web3, cwd, dir, module, ctx.deployArtifacts, reporter)
+                await generateApplicationArtifact(cwd, dir, module, ctx.deployArtifacts)
                 return `Saved artifact in ${dir}/artifact.json`
               }
               // TODO: Should use artifact file from current version, just changing version number
@@ -429,7 +431,7 @@ exports.task = function ({
             }
           })
         }
-        await generateApplicationArtifact(web3, cwd, dir, module, ctx.deployArtifacts, ctx.reporter)
+        await generateApplicationArtifact(cwd, dir, module, ctx.deployArtifacts)
         return `Saved artifact in ${dir}/artifact.json`
       }
     },

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -5,6 +5,7 @@ const chalk = require('chalk')
 const { compileContracts } = require('../helpers/truffle-runner')
 const { findProjectRoot } = require('../util')
 const { ensureWeb3 } = require('../helpers/web3-fallback')
+const deployArtifacts = require('../helpers/truffle-deploy-artifacts')
 
 exports.command = 'deploy [contract]'
 
@@ -58,14 +59,13 @@ exports.task = async ({ reporter, network, cwd, contract, init, web3, apmOptions
       title: `Deploy '${contractName}' to network`,
       task: async (ctx, task) => {
         ctx.contractName = contractName
-        let contractArtifacts
         try {
-          contractArtifacts = require(path.join(cwd, 'build/contracts', contractName))
+          ctx.contractArtifacts = require(path.join(cwd, 'build/contracts', contractName))
         } catch (e) {
           throw new Error('Contract artifact couldnt be found. Please ensure your contract name is the same as the filename.')
         }
 
-        const { abi, bytecode } = contractArtifacts
+        const { abi, bytecode } = ctx.contractArtifacts
 
         if (!bytecode || bytecode === '0x') {
           throw new Error('Contract bytecode couldnt be generated. Contracts that dont implement all interface methods cant be deployed')
@@ -78,7 +78,9 @@ exports.task = async ({ reporter, network, cwd, contract, init, web3, apmOptions
         const deployTx = contract.deploy({ arguments: processedInit })
         const gas = await deployTx.estimateGas()
 
-        const instance = await deployTx.send({ from: accounts[0], gas, gasPrice: '19000000000' }) // 19 gwei
+        const deployPromise = deployTx.send({ from: accounts[0], gas, gasPrice: '19000000000' }) // 19 gwei
+        deployPromise.on('transactionHash', (transactionHash) => ctx.transactionHash = transactionHash)
+        const instance = await deployPromise
 
         if (!instance.options.address) {
           throw new Error('Contract deployment failed')
@@ -87,6 +89,14 @@ exports.task = async ({ reporter, network, cwd, contract, init, web3, apmOptions
         ctx.contractInstance = instance
         ctx.contract = instance.options.address
         return ctx.contract
+      }
+    },
+    {
+      title: 'Generate deployment artifacts',
+      task: async (ctx, task) => {
+        ctx.deployArtifacts = await deployArtifacts(ctx.contractArtifacts)
+        ctx.deployArtifacts.transactionHash = ctx.transactionHash
+        delete ctx.transactionHash
       }
     }
   ])
@@ -98,5 +108,7 @@ exports.handler = async ({ reporter, network, cwd, contract, init, apm: apmOptio
   const ctx = await task.run()
 
   reporter.success(`Successfully deployed ${ctx.contractName} at: ${chalk.bold(ctx.contract)}`)
+  reporter.info(`Transaction hash: ${ctx.deployArtifacts.transactionHash}`)
+
   process.exit()
 }

--- a/src/helpers/truffle-deploy-artifacts.js
+++ b/src/helpers/truffle-deploy-artifacts.js
@@ -9,7 +9,8 @@ module.exports = async (contractArtifacts) => {
     compiler
   } = contractArtifacts
 
-  compiler.optimizer = getTruffleConfig().solc.optimizer
+  const solcConfig = getTruffleConfig().solc
+  compiler.optimizer = solcConfig ? solcConfig.optimizer : { enabled: false }
   const flattenedCode = await flatten([ sourcePath ])
 
   return {

--- a/src/helpers/truffle-deploy-artifacts.js
+++ b/src/helpers/truffle-deploy-artifacts.js
@@ -1,0 +1,21 @@
+const flatten = require('truffle-flattener')
+const { getTruffleConfig } = require('./truffle-config')
+
+module.exports = async (contractArtifacts) => {
+  const {
+    contractName,
+    sourcePath,
+    updatedAt: compiledAt,
+    compiler
+  } = contractArtifacts
+
+  compiler.optimizer = getTruffleConfig().solc.optimizer
+  const flattenedCode = await flatten([ sourcePath ])
+
+  return {
+    contractName,
+    compiledAt,
+    compiler,
+    flattenedCode
+  }
+}


### PR DESCRIPTION
Builds on #231 

It adds the following to the `artifact.json` file and saves the flattended contract code as `code.sol`:

```json
  "deployment": {
    "contractName": "Finance",
    "compiledAt": "2018-10-19T07:34:57.100Z",
    "compiler": {
      "name": "solc",
      "version": "0.4.24+commit.e67f0147.Emscripten.clang",
      "optimizer": {
        "enabled": true,
        "runs": 10000
      }
    },
    "flattenedCode": "./code.sol",
    "transactionHash": "0xb9e11259c228b6c626989d02ff99681a5b5a09b85e408f8d55871415918fdd03"
  }
```