### PR TITLE
Add --use-frame flag for using Frame as the web3 provider

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -44,6 +44,12 @@ cmd.option('cwd', {
   }
 })
 
+cmd.option('use-frame', {
+  description: 'Use frame as a signing provider and web3 provider',
+  boolean: true,
+  default: false
+})
+
 // network coerce is called multiple times, only warn once
 let warnedDeprecatedNetwork = false
 

--- a/src/middleware/environment.js
+++ b/src/middleware/environment.js
@@ -18,6 +18,13 @@ const configureNetwork = (argv, network) => {
     }
   }
 
+  if (argv.useFrame) {
+    return {
+      name: `frame-${network}`,
+      provider: new Web3.providers.WebsocketProvider('ws://localhost:1248')
+    }
+  }
+
   const truffleConfig = getTruffleConfig()
 
   const truffleNetwork = truffleConfig.networks[network]


### PR DESCRIPTION
Leverages https://frame.sh for allowing to perform any actions in the CLI from a Ledger or Trezor.

When the `--use-frame` flag is provided, the CLI will use frame as its provider ignoring the provider in the truffle config file. Network selection must be done in Frame.