### PR TITLE
Don't require artifact to exist after publishing

### DIFF
--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -483,7 +483,7 @@ exports.task = function ({
     },
     {
       title: 'Fetch published repo',
-      task: getRepoTask.task({ apmRepo: module.appName, apm })
+      task: getRepoTask.task({ artifactRequired: false, apmRepo: module.appName, apm })
     }
   ])
 }


### PR DESCRIPTION
Otherwise it seems publishing fails with APM repos that don't have contract code, such as `aragon.aragonpm.eth`.