### PR TITLE
Change defaults to vars in add files to ipfs

### DIFF
--- a/src/commands/ipfs.js
+++ b/src/commands/ipfs.js
@@ -41,7 +41,7 @@ exports.task = ({ apmOptions, silent, debug }) => {
     {
       title: 'Add local files',
       task: (ctx) => {
-        const ipfs = IPFS('localhost', '5001', { protocol: 'http' })
+        const ipfs = IPFS(apmOptions.ipfs.rpc)
         const files = path.resolve(require.resolve('@aragon/aragen'), '../ipfs-cache')
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
I looked at the 4th example of: https://github.com/ipfs/js-ipfs-api/blob/master/README.md#importing-the-module-and-usage

And noticed that the keys match so now it just passes the whole object.