### PR TITLE
Show more info when content cannot be found

### DIFF
--- a/src/commands/apm_cmds/versions.js
+++ b/src/commands/apm_cmds/versions.js
@@ -30,7 +30,11 @@ exports.handler = async function({
         `${version.version}: ${version.contractAddress} ${version.error}`
       )
     } else {
-      reporter.error('Version not found in provider')
+      reporter.error(
+        `${version.version}: ${
+          version.contractAddress
+        } Version not found in provider`
+      )
     }
   })
   process.exit()


### PR DESCRIPTION
Before:
```
% aragon apm versions --environment staging                                                                                                                                                        
 ℹ pomodoro-counter.open.aragonpm.eth has 10 published versions
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✔ 0.3.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae ipfs:QmeURKNo41Chv33haYZEsA126VUWdNanKoRf4Yy7s413ez
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✖ Version not found in provider
 ✔ 1.0.0: 0x7F9c870e707893e4C8A6C1EFabC11812edBB806e ipfs:QmXMRJnBxxXyk1DaiZJvhGZdycAC5zxwt5i4mEvkLjbo1R
```

After:
```
 ✖ 0.1.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.2.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.2.1: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✔ 0.3.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae ipfs:QmeURKNo41Chv33haYZEsA126VUWdNanKoRf4Yy7s413ez
 ✖ 0.4.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.4.1: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.5.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.6.0: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✖ 0.6.1: 0x12137D5da5529E26235f421Be5D79807CB6C5cae Version not found in provider
 ✔ 1.0.0: 0x7F9c870e707893e4C8A6C1EFabC11812edBB806e ipfs:QmXMRJnBxxXyk1DaiZJvhGZdycAC5zxwt5i4mEvkLjbo1R
```