### PR TITLE
Fix app install command

### DIFF
--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -7,23 +7,8 @@ const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
 const encodeInitPayload = require('./utils/encodeInitPayload')
 const upgrade = require('./upgrade')
-const { getContract, ANY_ENTITY } = require('../../util')
+const { getContract } = require('../../util')
 const listrOpts = require('../../helpers/listr-options')
-
-const setPermissions = async (web3, sender, aclAddress, permissions) => {
-  const acl = new web3.eth.Contract(
-    getContract('@aragon/os', 'ACL').abi,
-    aclAddress
-  )
-  return Promise.all(
-    permissions.map(([who, where, what]) =>
-      acl.methods.createPermission(who, where, what, who).send({
-        from: sender,
-        gasLimit: 1e6,
-      })
-    )
-  )
-}
 
 exports.command = 'install <dao> <apmRepo> [apmRepoVersion]'
 
@@ -120,29 +105,6 @@ exports.task = async ({
             })
 
           ctx.appAddress = events['NewAppProxy'].returnValues.proxy
-        },
-      },
-      {
-        title: 'Set permissions',
-        task: async (ctx, task) => {
-          if (!ctx.repo.roles || ctx.repo.roles.length === 0) {
-            throw new Error(
-              'You have no permissions defined in your arapp.json\nThis is required for your app to properly show up.'
-            )
-          }
-
-          const permissions = ctx.repo.roles.map(role => [
-            ANY_ENTITY,
-            ctx.appAddress,
-            role.bytes,
-          ])
-
-          return setPermissions(
-            web3,
-            ctx.accounts[0],
-            ctx.aclAddress,
-            permissions
-          )
         },
       },
     ],


### PR DESCRIPTION
Don't assign permissions on app installation. Before permissions were
created completely open (ANY_ENTITY) but with a wrong manager so no
change was possible.
To choose between this one, #287 or #288