### PR TITLE
Fix setPermissions in dao install

### DIFF
--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -196,6 +196,10 @@ exports.task = async ({
             role.bytes,
           ])
 
+          if (!ctx.accounts) {
+            ctx.accounts = await web3.eth.getAccounts()
+          }
+
           // TODO: setPermissions should use ACL functions with transaction pathing
           return setPermissionsWithoutTransactionPathing(
             web3,


### PR DESCRIPTION
Fixing dao install on local rpc:
```
 % dao install 0x5b6a3301a67A4bfda9D3a528CaD34cac6e7F8070 foo.aragonpm.eth 
 ✔ Fetching foo.aragonpm.eth@latest
 ✔ Fetching foo.aragonpm.eth@latest
 ✔ Checking installed version
 ✔ Deploying app instance
 ✔ Fetching deployed app
 ✖ Set permissions
   → Cannot read property '0' of undefined
 ✖ Cannot read property '0' of undefined
```

This was introduced in https://github.com/aragon/aragon-cli/pull/270 (my bad, I only tested it on rinkeby  :sweat_smile:)