### PR TITLE
This commit adds ipfs-check to 'aragon new dao'

### DIFF
--- a/src/commands/dao_cmds/new.js
+++ b/src/commands/dao_cmds/new.js
@@ -70,7 +70,7 @@ exports.task = async ({
   kit = defaultAPMName(kit)
 
   const tasks = new TaskList(
-    [ 
+    [
       {
         title: 'Check IPFS',
         task: () => startIPFS.task({ apmOptions }),

--- a/src/commands/dao_cmds/new.js
+++ b/src/commands/dao_cmds/new.js
@@ -74,7 +74,7 @@ exports.task = async ({
       {
         title: 'Check IPFS',
         task: () => startIPFS.task({ apmOptions }),
-        enabled: () => !http && ipfsCheck,
+        enabled: () => ipfsCheck,
       },
       {
         title: `Fetching kit ${chalk.bold(kit)}@${kitVersion}`,

--- a/src/commands/dao_cmds/new.js
+++ b/src/commands/dao_cmds/new.js
@@ -43,7 +43,7 @@ exports.builder = yargs => {
       default: exports.BARE_KIT_DEPLOY_EVENT,
     })
     .option('ipfs-check', {
-      description: 'Whether to have publish start IPFS if not started',
+      description: 'Whether to have new start IPFS if not started',
       boolean: true,
       default: true,
     })
@@ -72,6 +72,7 @@ exports.task = async ({
   const tasks = new TaskList(
     [
       {
+        // IPFS is a dependency of getRepoTask which uses IPFS to fetch the contract ABI
         title: 'Check IPFS',
         task: () => startIPFS.task({ apmOptions }),
         enabled: () => ipfsCheck,


### PR DESCRIPTION
This change was based on the available 'check-ipfs' located in the apm commands publish file.

This resolve #237