### PR TITLE
Add help text to `aragon dao install --app-init` option

### DIFF
--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -44,7 +44,7 @@ exports.builder = function(yargs) {
     .args(daoArg(yargs))
     .option('app-init', {
       description:
-        'Name of the function that will be called to initialize an app',
+        'Name of the function that will be called to initialize an app. Set it to "none" to skip initialization',
       default: 'initialize',
     })
     .option('app-init-args', {


### PR DESCRIPTION
If install command doesn't find initialization method, it won't
initialize the newly installed app, but this is not obvious from the
help instructions.
Although it's "dangerous", sometimes it's useful to install an app
without initializing. For instance, Token Manager: to initialize it
the token must be provided, and this token must have this new Token
Manager app as controller. Therefore token controller must be changed
in between creation and initialization of Token Manager app.