### PR TITLE
Deprecate aragon init

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -8,7 +8,8 @@ const listrOpts = require('../helpers/listr-options')
 
 exports.command = 'init <name> [template]'
 
-exports.describe = 'Initialise a new application'
+exports.describe =
+  '(deprecated) Initialise a new application. Deprecated in favor of `npx create-aragon-app <name> [template]`'
 
 exports.builder = yargs => {
   return yargs
@@ -76,9 +77,10 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
     listrOpts(silent, debug)
   )
 
-  return tasks
-    .run()
-    .then(() =>
-      reporter.success(`Created new application ${name} in ${basename}`)
+  return tasks.run().then(() => {
+    reporter.success(`Created new application ${name} in ${basename}.`)
+    reporter.info(
+      `Use of \`aragon init\` is deprecated and has been replaced with \`npx create-aragon-app\`.`
     )
+  })
 }

--- a/src/middleware/environment.js
+++ b/src/middleware/environment.js
@@ -12,7 +12,7 @@ const configureNetwork = (argv, network) => {
       return {}
     }
   }
-
+  // TODO remove init when commmand not longer supported
   const skipNetworkCommands = new Set(['init', 'devchain', 'ipfs', 'contracts'])
 
   if (argv._.length >= 1) {


### PR DESCRIPTION
In favor of [create-aragon-app](https://github.com/AragonDAC/create-aragon-app)