### PR TITLE
Create a new ganache db for each version

### DIFF
--- a/src/commands/devchain.js
+++ b/src/commands/devchain.js
@@ -10,6 +10,7 @@ const mkdirp = require('mkdirp')
 const chalk = require('chalk')
 const fs = require('fs')
 const listrOpts = require('../helpers/listr-options')
+const pjson = require('../../package.json')
 
 const { BLOCK_GAS_LIMIT, MNEMONIC } = require('../helpers/ganache-vars')
 
@@ -43,7 +44,10 @@ exports.task = async function({
   const mkDir = promisify(mkdirp)
   const recursiveCopy = promisify(ncp)
 
-  const snapshotPath = path.join(os.homedir(), `.aragon/ganache-db-${port}`)
+  const snapshotPath = path.join(
+    os.homedir(),
+    `.aragon/ganache-db-${pjson.version}`
+  )
 
   const tasks = new TaskList(
     [


### PR DESCRIPTION
Fixes https://github.com/aragon/aragon-cli/issues/137

I opted for the quick way of appending the cli version to the snapshot directory instead of doing a full wipe because: it allows to go back to a previous snapshot when downgrading and the disk footprint seems negligible.

![image](https://user-images.githubusercontent.com/26041347/50733233-8ec9d480-1192-11e9-94a0-7d317b083aff.png)

I also removed the port from the db name, was there an usecase for it? :thinking: 
