### PR TITLE
Use tx pathing for setPermissions

### DIFF
--- a/src/commands/dao_cmds/acl_cmds/create.js
+++ b/src/commands/dao_cmds/acl_cmds/create.js
@@ -22,6 +22,8 @@ exports.handler = async function({
   entity,
   manager,
   wsProvider,
+  silent,
+  debug,
 }) {
   const method = 'createPermission'
   const params = [entity, app, role, manager]
@@ -31,5 +33,7 @@ exports.handler = async function({
     network,
     wsProvider,
     role,
+    silent,
+    debug,
   })
 }

--- a/src/commands/dao_cmds/acl_cmds/utils/aclExecHandler.js
+++ b/src/commands/dao_cmds/acl_cmds/utils/aclExecHandler.js
@@ -5,7 +5,7 @@ module.exports = async function(
   dao,
   method,
   params,
-  { reporter, apm, network, wsProvider, role }
+  { reporter, apm, network, wsProvider, role, silent, debug }
 ) {
   const getTransactionPath = async wrapper => {
     let processedParams
@@ -27,5 +27,7 @@ module.exports = async function(
     apm,
     wsProvider,
     network,
+    silent,
+    debug,
   })
 }

--- a/src/commands/dao_cmds/apps.js
+++ b/src/commands/dao_cmds/apps.js
@@ -131,16 +131,18 @@ exports.handler = async function({
     console.log(table.toString())
 
     // Print permisionless apps
-    const tableForPermissionlessApps = new Table({
-      head: ['Permissionless app', 'Proxy address'].map(x => chalk.white(x)),
-    })
-    ctx.appsWithoutPermissions.forEach(app =>
-      tableForPermissionlessApps.push([
-        printAppName(app.appId).replace('.aragonpm.eth', ''),
-        app.proxyAddress,
-      ])
-    )
-    console.log(tableForPermissionlessApps.toString())
+    if (ctx.appsWithoutPermissions) {
+      const tableForPermissionlessApps = new Table({
+        head: ['Permissionless app', 'Proxy address'].map(x => chalk.white(x)),
+      })
+      ctx.appsWithoutPermissions.forEach(app =>
+        tableForPermissionlessApps.push([
+          printAppName(app.appId).replace('.aragonpm.eth', ''),
+          app.proxyAddress,
+        ])
+      )
+      console.log(tableForPermissionlessApps.toString())
+    }
 
     process.exit() // force exit, as aragonjs hangs
   })

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -15,26 +15,6 @@ const listrOpts = require('../../helpers/listr-options')
 const addressesEqual = (a, b) => a.toLowerCase() === b.toLowerCase()
 const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
-const setPermissionsWithoutTransactionPathing = async (
-  web3,
-  sender,
-  aclAddress,
-  permissions
-) => {
-  const acl = new web3.eth.Contract(
-    getContract('@aragon/os', 'ACL').abi,
-    aclAddress
-  )
-  return Promise.all(
-    permissions.map(([who, where, what, manager]) =>
-      acl.methods.createPermission(who, where, what, manager).send({
-        from: sender,
-        gasLimit: 1e6,
-      })
-    )
-  )
-}
-
 exports.command = 'install <dao> <apmRepo> [apmRepoVersion]'
 
 exports.describe = 'Install an app into a DAO'
@@ -53,9 +33,9 @@ exports.builder = function(yargs) {
       default: [],
     })
     .options('set-permissions', {
-      description: 'Whether to set permissions in the app',
-      boolean: true,
-      default: true,
+      description:
+        'Whether to set permissions in the app. Set it to "open" to allow ANY_ENTITY on all roles.',
+      choices: ['open'],
     })
 }
 
@@ -180,10 +160,8 @@ exports.task = async ({
       },
       {
         title: 'Set permissions',
-        enabled: ctx => setPermissions && ctx.appAddress,
+        enabled: ctx => setPermissions === 'open' && ctx.appAddress,
         task: async (ctx, task) => {
-          const aclAddress = await kernel.methods.acl().call()
-
           if (!ctx.repo.roles || ctx.repo.roles.length === 0) {
             throw new Error(
               'You have no permissions defined in your arapp.json\nThis is required for your app to properly show up.'
@@ -201,12 +179,19 @@ exports.task = async ({
             ctx.accounts = await web3.eth.getAccounts()
           }
 
-          // TODO: setPermissions should use ACL functions with transaction pathing
-          return setPermissionsWithoutTransactionPathing(
-            web3,
-            ctx.accounts[0],
-            aclAddress,
-            permissions
+          return Promise.all(
+            permissions.map(params => {
+              const getTransactionPath = async wrapper => {
+                wrapper.getACLTransactionPath('createPermission', params)
+              }
+
+              return execTask(dao, getTransactionPath, {
+                reporter,
+                apm: apmOptions,
+                web3,
+                wsProvider,
+              })
+            })
           )
         },
       },

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -126,6 +126,8 @@ exports.task = async ({
             apm: apmOptions,
             web3,
             wsProvider,
+            silent,
+            debug,
           })
         },
       },
@@ -182,15 +184,21 @@ exports.task = async ({
           return Promise.all(
             permissions.map(params => {
               const getTransactionPath = async wrapper => {
-                wrapper.getACLTransactionPath('createPermission', params)
+                return wrapper.getACLTransactionPath('createPermission', params)
               }
 
-              return execTask(dao, getTransactionPath, {
-                reporter,
-                apm: apmOptions,
-                web3,
-                wsProvider,
-              })
+              return (
+                execTask(dao, getTransactionPath, {
+                  reporter,
+                  apm: apmOptions,
+                  web3,
+                  wsProvider,
+                  silent,
+                  debug,
+                })
+                  // execTask returns a TaskList not a promise
+                  .then(tasks => tasks.run())
+              )
             })
           )
         },

--- a/src/commands/dao_cmds/utils/execHandler.js
+++ b/src/commands/dao_cmds/utils/execHandler.js
@@ -6,7 +6,7 @@ const listrOpts = require('../../../helpers/listr-options')
 exports.task = async function(
   dao,
   getTransactionPath,
-  { reporter, apm, web3, wsProvider, network, silent, debug }
+  { reporter, apm, web3, wsProvider, silent, debug }
 ) {
   const accounts = await web3.eth.getAccounts()
   return new TaskList(


### PR DESCRIPTION
Closes #286 

This PR does not help if you don't have enough votes to reach quorum:
```
± % dao install showcase foo.open.aragonpm.eth --set-permissions open --environment staging   !10241
 ✔ Fetching foo.open.aragonpm.eth@latest
 ✔ Checking installed version
 ✔ Deploying app instance
 ↓ Fetching deployed app [skipped]
   → App wasn't deployed in transaction.
 ℹ Successfully executed: "Creates a vote to execute the desired action, and casts a support vote if possible"
 ⚠ After the app instance is created, you will need to assign permissions to it for it appear as an app in the DAO
```
After the vote passes you have to manually find the `NewAppProxy` event from the `Kernel` and call `dao acl create`.
