### PR TITLE
296 Minime Deployment from CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -250,10 +250,9 @@
       }
     },
     "@aragon/apps-shared-minime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.0.tgz",
-      "integrity": "sha512-DC0ylnEcsqED8eQIxriDbRTmSmqdUYWJrGmysI/UTuHvdSfsAy9awbx4Ea6To1Acd3F6kca5oPn6m9WjCAhlxQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.1.tgz",
+      "integrity": "sha512-DJAhj68hJLeZ6/KKKch9G3VAZT0SBoNN9JB6AETAy6M/Iiw0ZQZiCVltw8pJgeH2dvVlEC1y1XiG2rnG9RNhJA=="
     },
     "@aragon/apps-token-manager": {
       "version": "2.0.0",
@@ -265,6 +264,12 @@
         "@aragon/os": "4.0.0"
       },
       "dependencies": {
+        "@aragon/apps-shared-minime": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.0.tgz",
+          "integrity": "sha512-DC0ylnEcsqED8eQIxriDbRTmSmqdUYWJrGmysI/UTuHvdSfsAy9awbx4Ea6To1Acd3F6kca5oPn6m9WjCAhlxQ==",
+          "dev": true
+        },
         "@aragon/os": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@aragon/os/-/os-4.0.0.tgz",
@@ -472,6 +477,12 @@
         "@aragon/os": "4.0.0"
       },
       "dependencies": {
+        "@aragon/apps-shared-minime": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@aragon/apps-shared-minime/-/apps-shared-minime-1.0.0.tgz",
+          "integrity": "sha512-DC0ylnEcsqED8eQIxriDbRTmSmqdUYWJrGmysI/UTuHvdSfsAy9awbx4Ea6To1Acd3F6kca5oPn6m9WjCAhlxQ==",
+          "dev": true
+        },
         "@aragon/os": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@aragon/os/-/os-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/aragon/aragon-dev-cli#readme",
   "dependencies": {
     "@aragon/apm": "^2.0.2",
+    "@aragon/apps-shared-minime": "^1.0.1",
     "@aragon/aragen": "^2.0.3",
     "@aragon/os": "^4.0.0",
     "@aragon/templates-beta": "^1.1.3",

--- a/src/commands/dao_cmds/token_cmds/change-controller.js
+++ b/src/commands/dao_cmds/token_cmds/change-controller.js
@@ -28,7 +28,10 @@ exports.task = async ({ web3, tokenAddress, newController, silent, debug }) => {
       {
         title: 'Changing the MiniMe token controller',
         task: async (ctx, task) => {
-          let artifact = getContract('@aragon/os', 'MiniMeToken')
+          let artifact = getContract(
+            '@aragon/apps-shared-minime',
+            'MiniMeToken'
+          )
           let contract = new web3.eth.Contract(artifact.abi, tokenAddress)
 
           const tx = contract.methods.changeController(newController)

--- a/src/commands/dao_cmds/token_cmds/new.js
+++ b/src/commands/dao_cmds/token_cmds/new.js
@@ -47,7 +47,10 @@ exports.task = async ({
       {
         title: 'Deploy the MiniMeTokenFactory contract',
         task: async (ctx, task) => {
-          let artifact = getContract('@aragon/os', 'MiniMeTokenFactory')
+          let artifact = getContract(
+            '@aragon/apps-shared-minime',
+            'MiniMeTokenFactory'
+          )
           let contract = new web3.eth.Contract(artifact.abi)
 
           const deployTx = contract.deploy({ data: artifact.bytecode })
@@ -72,7 +75,10 @@ exports.task = async ({
       {
         title: 'Deploy the MiniMeToken contract',
         task: async (ctx, task) => {
-          let artifact = getContract('@aragon/os', 'MiniMeToken')
+          let artifact = getContract(
+            '@aragon/apps-shared-minime',
+            'MiniMeToken'
+          )
           let contract = new web3.eth.Contract(artifact.abi)
 
           const deployTx = contract.deploy({


### PR DESCRIPTION
There's probably too much in the task right now, some of it should probably be split into utils, mainly like the two deploys but I'm not sure how re-usable they would be so didn't bother for now.

Might be a better way to handle the 'from' but this seems to work for the time being. Also, I'm not sure if there are any differences between the NPM minimetoken and the one in aragonOS but currently using the aragonOS one. I'm fairly sure they're the same.

Addresses issue #296 