### PR TITLE
Change dao exec to use wsRPC

### DIFF
--- a/src/commands/dao_cmds/exec.js
+++ b/src/commands/dao_cmds/exec.js
@@ -28,8 +28,14 @@ exports.handler = async function({
   proxyAddress,
   fn,
   fnArgs,
+  wsProvider,
 }) {
   const getTransactionPath = wrapper =>
     wrapper.getTransactionPath(proxyAddress, fn, fnArgs)
-  return execHandler(dao, getTransactionPath, { reporter, apm, network })
+  return execHandler(dao, getTransactionPath, {
+    reporter,
+    apm,
+    network,
+    wsProvider,
+  })
 }


### PR DESCRIPTION
It was getting stuck at reading data:
```
⠸ Generating transaction
 → Fetching DAO at showcase.aragonid.eth...
```

Now this should work nicely with environments.