### PR TITLE
fix: update error message when installing app without roles

### DIFF
--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -166,7 +166,7 @@ exports.task = async ({
         task: async (ctx, task) => {
           if (!ctx.repo.roles || ctx.repo.roles.length === 0) {
             throw new Error(
-              'You have no permissions defined in your arapp.json\nThis is required for your app to properly show up.'
+              'You have no roles defined in your arapp.json.\nThis is required for your app to be properly installed.\nSee https://hack.aragon.org/docs/cli-usage.html#global-configuration for more information.'
             )
           }
 


### PR DESCRIPTION
Uses "roles" as its the key in the `arapp.json` and gives a bit more guidance as to what it's used for.