### PR TITLE
feat: upgrade aragon client

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     ]
   },
   "aragon": {
-    "clientVersion": "0.6.2",
+    "clientVersion": "1b5f5defbb58854f58c9d2731c4ad259c640100b",
     "clientPort": "3000",
     "defaultGasPrice": "10000000000"
   },


### PR DESCRIPTION
Oops, totally forgot `0.6.2` didn't include the windows-compatible scripting 😅.

This moves the commit up to [that commit](https://github.com/aragon/aragon/commit/1b5f5defbb58854f58c9d2731c4ad259c640100b).