### PR TITLE
fix: Remove path and roles from being mandatory in arapp.json schema

### DIFF
--- a/schemas/arapp.schema.json
+++ b/schemas/arapp.schema.json
@@ -13,8 +13,7 @@
       "type": "array",
       "items": {
         "$ref": "#/definitions/role"
-      },
-      "minItems": 1
+      }
     },
     "environments": {
       "description": "An object containing deploy environment configurations.",
@@ -77,7 +76,6 @@
     }
   },
   "required": [
-    "path",
     "roles",
     "environments"
   ]

--- a/schemas/arapp.schema.json
+++ b/schemas/arapp.schema.json
@@ -76,7 +76,6 @@
     }
   },
   "required": [
-    "roles",
     "environments"
   ]
 }

--- a/scripts/extract-roles
+++ b/scripts/extract-roles
@@ -7,28 +7,27 @@ const getAppNPMPackage = appName => `@aragon/apps-${appName}`
 const knownApps = ['voting', 'token-manager', 'vault', 'finance']
 
 const getAppRoles = app => {
-	const arapp = require(`${getAppNPMPackage(app)}/arapp`)
-	return arapp.roles.map(({ name, id }) => ({ name, id }))
+  const arapp = require(`${getAppNPMPackage(app)}/arapp`)
+  return arapp.roles.map(({ name, id }) => ({ name, id }))
 }
 
-const flatten = list => list.reduce(
-    (a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []
-)
+const flatten = list =>
+  list.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
 
 const aOSRoles = [
-	{ id: 'CREATE_PERMISSIONS_ROLE', name: 'Create new permissions'},
-	{ id: 'APP_MANAGER_ROLE', name: 'Manage DAO apps'}
+  { id: 'CREATE_PERMISSIONS_ROLE', name: 'Create new permissions' },
+  { id: 'APP_MANAGER_ROLE', name: 'Manage DAO apps' },
 ]
 
 // TODO: Add support for user apps
 const rolesForDefaultApps = () => {
-	const allRoles = flatten(knownApps.map(app => getAppRoles(app))).concat(aOSRoles)
+  const allRoles = flatten(knownApps.map(app => getAppRoles(app))).concat(
+    aOSRoles
+  )
 
-	return allRoles
+  return allRoles
 }
 
-writeJson(
-    path.resolve('.', 'src/knownRoles.json'),
-    rolesForDefaultApps(),
-    { spaces: '\t' }
-  )
+writeJson(path.resolve('.', 'src/knownRoles.json'), rolesForDefaultApps(), {
+  spaces: '\t',
+})

--- a/scripts/extract-roles
+++ b/scripts/extract-roles
@@ -8,7 +8,8 @@ const knownApps = ['voting', 'token-manager', 'vault', 'finance']
 
 const getAppRoles = app => {
   const arapp = require(`${getAppNPMPackage(app)}/arapp`)
-  return arapp.roles.map(({ name, id }) => ({ name, id }))
+  const roles = arapp.roles || []
+  return roles.map(({ name, id }) => ({ name, id }))
 }
 
 const flatten = list =>

--- a/src/commands/apm_cmds/publish.js
+++ b/src/commands/apm_cmds/publish.js
@@ -144,9 +144,11 @@ async function generateApplicationArtifact(
   // > [{ sig: 'transfer(address)', role: 'X_ROLE', notice: 'Transfers..'}]
   artifact.functions = await extract(path.resolve(cwd, artifact.path))
 
-  artifact.roles = artifact.roles.map(role =>
-    Object.assign(role, { bytes: '0x' + keccak256(role.id) })
-  )
+  if (artifact.roles) {
+    artifact.roles = artifact.roles.map(role =>
+      Object.assign(role, { bytes: '0x' + keccak256(role.id) })
+    )
+  }
 
   // Save artifact
   await writeJson(path.resolve(outputPath, 'artifact.json'), artifact, {

--- a/src/commands/dao_cmds/acl_cmds/utils/knownRoles.js
+++ b/src/commands/dao_cmds/acl_cmds/utils/knownRoles.js
@@ -7,7 +7,7 @@ const defaultAppsRoles = require('../../../../knownRoles.json')
 const currentAppRoles = () => {
   try {
     const arappPath = path.resolve(findProjectRoot(), 'arapp.json')
-    return require(arappPath).roles
+    return require(arappPath).roles || []
   } catch (_) {
     return []
   }

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -207,7 +207,9 @@ exports.handler = function({
       {
         title: 'Create DAO',
         task: ctx => {
-          const roles = ctx.repo.roles.map(role => role.bytes)
+          const roles = ctx.repo.roles || []
+          const rolesBytes = roles.map(role => role.bytes)
+
           let fnArgs
 
           if (ctx.contractInstance) {
@@ -226,7 +228,7 @@ exports.handler = function({
               ctx.notInitialized = true
             }
 
-            fnArgs = [ctx.repo.appId, roles, ctx.accounts[0], initPayload]
+            fnArgs = [ctx.repo.appId, rolesBytes, ctx.accounts[0], initPayload]
           }
 
           const newDAOParams = {


### PR DESCRIPTION
In cases where you may not want to publish a repo with a contract (e.g. [`aragon/aragon`](https://github.com/aragon/aragon/blob/master/arapp.json#L29)), the `roles` should be optional and allowed to be empty, and `path` should be optional.