### PR TITLE
Implement `dao act` command for Agent app integration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,11 @@
 {
   "presets": [
-    ["@babel/preset-env", {
-      "useBuiltIns": "entry"
-    }]
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": "entry"
+      }
+    ]
   ],
   "plugins": [
     "@babel/plugin-proposal-object-rest-spread"

--- a/package-lock.json
+++ b/package-lock.json
@@ -375,16 +375,6 @@
       "resolved": "https://registry.npmjs.org/@aragon/core/-/core-2.0.1.tgz",
       "integrity": "sha512-o2SPNW2H5HlWxgVK+jJ5cpMBjXUwZHbFytjJqySSJkX1mYX+6+9tgH3HAwCXWk7nc7yo/fE22NM60IcDPUZnfA=="
     },
-    "@aragon/messenger": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@aragon/messenger/-/messenger-1.0.0.tgz",
-      "integrity": "sha512-2YX3gSipHbDTuRLeVuCi3Lj9o3zpGZXELYKkiUgXmnCmed81oEBX6rmCjC7dGFzidIYD/NtEj2kOmoCFh5lKdw==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "rxjs": "^5.5.6",
-        "uuid": "^3.2.1"
-      }
-    },
     "@aragon/os": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@aragon/os/-/os-4.0.1.tgz",
@@ -532,11 +522,10 @@
     },
     "@aragon/wrapper": {
       "version": "3.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/@aragon/wrapper/-/wrapper-3.0.0-beta.3.tgz",
-      "integrity": "sha512-yg5MTbC6ceAoMlqnP48IjIvrbaL/8nDWx0XwQ/GmLis24eicYHk8NnwVTzZskTiGQnB96yqQ/fSYLzvu1x3F3A==",
       "requires": {
         "@aragon/apm": "^3.0.0",
         "@aragon/messenger": "^1.0.0",
+        "@aragon/os": "^4.0.1",
         "@babel/runtime": "^7.1.2",
         "dot-prop": "^4.2.0",
         "eth-ens-namehash": "^2.0.8",
@@ -544,8 +533,9 @@
         "ethjs-ens": "^2.0.1",
         "homedir": "^0.6.0",
         "js-sha3": "^0.7.0",
-        "lowdb": "^1.0.0",
-        "radspec": "^1.1.3",
+        "localforage": "^1.7.3",
+        "localforage-memoryStorageDriver": "^0.9.2",
+        "radspec": "^1.1.4",
         "rxjs": "^5.5.6",
         "uuid": "^3.2.1",
         "web3": "1.0.0-beta.33",
@@ -555,8 +545,7 @@
       "dependencies": {
         "@aragon/apm": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@aragon/apm/-/apm-3.0.0.tgz",
-          "integrity": "sha512-QlRKV4SIGdzeZ0YbRvoBxiu+5usLq6xZe5P3GXS9BpSYu2szo0gNAiZ784ituhRXu/aasTJqnrall5x625M86Q==",
+          "bundled": true,
           "requires": {
             "@aragon/os": "^4.0.0",
             "axios": "^0.18.0",
@@ -565,10 +554,6319 @@
             "semver": "^5.5.0"
           }
         },
+        "@aragon/messenger": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "rxjs": "^5.5.6",
+            "uuid": "^3.2.1"
+          }
+        },
+        "@aragon/os": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "homedir": "^0.6.0",
+            "mkdirp": "^0.5.1",
+            "truffle-flattener": "^1.2.9",
+            "truffle-hdwallet-provider": "0.0.3",
+            "truffle-hdwallet-provider-privkey": "0.3.0"
+          }
+        },
+        "@ava/babel-plugin-throws-helper": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "@ava/babel-preset-stage-4": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/plugin-proposal-async-generator-functions": "^7.0.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.0.0",
+            "@babel/plugin-transform-async-to-generator": "^7.0.0",
+            "@babel/plugin-transform-dotall-regex": "^7.0.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.0.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.0.0"
+          }
+        },
+        "@ava/babel-preset-transform-test-files": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-plugin-throws-helper": "^3.0.0",
+            "babel-plugin-espower": "^3.0.1"
+          }
+        },
+        "@ava/write-file-atomic": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        },
+        "@babel/cli": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "chokidar": "^2.0.3",
+            "commander": "^2.8.1",
+            "convert-source-map": "^1.1.0",
+            "fs-readdir-recursive": "^1.1.0",
+            "glob": "^7.0.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "output-file-sync": "^2.0.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "slash": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/code-frame": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/highlight": "^7.0.0"
+          }
+        },
+        "@babel/core": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helpers": "^7.2.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/template": "^7.2.2",
+            "@babel/traverse": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "convert-source-map": "^1.1.0",
+            "debug": "^4.1.0",
+            "json5": "^2.1.0",
+            "lodash": "^4.17.10",
+            "resolve": "^1.3.2",
+            "semver": "^5.4.1",
+            "source-map": "^0.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "json5": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "minimist": "^1.2.0"
+              }
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/generator": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.3.2",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.10",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "2.5.2",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/helper-annotate-as-pure": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-binary-assignment-operator-visitor": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-explode-assignable-expression": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-builder-react-jsx": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.3.0",
+            "esutils": "^2.0.0"
+          }
+        },
+        "@babel/helper-call-delegate": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-create-class-features-plugin": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.2.3"
+          }
+        },
+        "@babel/helper-define-map": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/types": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-explode-assignable-expression": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/template": "^7.2.2",
+            "@babel/types": "^7.2.2",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-plugin-utils": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "@babel/helper-regex": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/helper-remap-async-to-generator": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.2.3",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.1.0",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.0",
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/types": "^7.0.0"
+          }
+        },
+        "@babel/helper-wrap-function": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/template": "^7.1.0",
+            "@babel/traverse": "^7.1.0",
+            "@babel/types": "^7.2.0"
+          }
+        },
+        "@babel/helpers": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "@babel/template": "^7.1.2",
+            "@babel/traverse": "^7.1.5",
+            "@babel/types": "^7.3.0"
+          }
+        },
+        "@babel/highlight": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.0",
+            "esutils": "^2.0.2",
+            "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "js-tokens": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@babel/parser": {
+          "version": "7.3.2",
+          "bundled": true
+        },
+        "@babel/plugin-proposal-async-generator-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-class-properties": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.3.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-proposal-decorators": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-create-class-features-plugin": "^7.3.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-decorators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-do-expressions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-do-expressions": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-export-default-from": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-export-default-from": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-export-namespace-from": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-export-namespace-from": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-function-bind": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-function-bind": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-function-sent": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-wrap-function": "^7.2.0",
+            "@babel/plugin-syntax-function-sent": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-logical-assignment-operators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-logical-assignment-operators": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-nullish-coalescing-operator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-numeric-separator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-numeric-separator": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-object-rest-spread": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-optional-chaining": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-pipeline-operator": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-pipeline-operator": "^7.3.0"
+          }
+        },
+        "@babel/plugin-proposal-throw-expressions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-throw-expressions": "^7.2.0"
+          }
+        },
+        "@babel/plugin-proposal-unicode-property-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.2.0"
+          },
+          "dependencies": {
+            "regexpu-core": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
+              }
+            },
+            "regjsgen": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              }
+            }
+          }
+        },
+        "@babel/plugin-syntax-async-generators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-decorators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-do-expressions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-dynamic-import": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-export-default-from": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-export-namespace-from": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-flow": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-function-bind": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-function-sent": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-import-meta": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-json-strings": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-jsx": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-logical-assignment-operators": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-nullish-coalescing-operator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-numeric-separator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-object-rest-spread": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-catch-binding": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-optional-chaining": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-pipeline-operator": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-syntax-throw-expressions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-arrow-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-async-to-generator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-remap-async-to-generator": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoped-functions": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-block-scoping": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "lodash": "^4.17.10"
+          }
+        },
+        "@babel/plugin-transform-classes": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-define-map": "^7.1.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "globals": "^11.1.0"
+          },
+          "dependencies": {
+            "globals": {
+              "version": "11.11.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/plugin-transform-computed-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-destructuring": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-dotall-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          },
+          "dependencies": {
+            "regexpu-core": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
+              }
+            },
+            "regjsgen": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              }
+            }
+          }
+        },
+        "@babel/plugin-transform-duplicate-keys": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-exponentiation-operator": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-flow": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-for-of": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-function-name": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-amd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-commonjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-simple-access": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-modules-systemjs": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-hoist-variables": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-modules-umd": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-transforms": "^7.1.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-named-capturing-groups-regex": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "regexp-tree": "^0.1.0"
+          }
+        },
+        "@babel/plugin-transform-new-target": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-object-super": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-replace-supers": "^7.1.0"
+          }
+        },
+        "@babel/plugin-transform-parameters": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-call-delegate": "^7.1.0",
+            "@babel/helper-get-function-arity": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-react-display-name": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-builder-react-jsx": "^7.3.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx-self": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-react-jsx-source": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-syntax-jsx": "^7.2.0"
+          }
+        },
+        "@babel/plugin-transform-regenerator": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.13.3"
+          },
+          "dependencies": {
+            "regenerator-transform": {
+              "version": "0.13.3",
+              "bundled": true,
+              "requires": {
+                "private": "^0.1.6"
+              }
+            }
+          }
+        },
+        "@babel/plugin-transform-runtime": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.1"
+          }
+        },
+        "@babel/plugin-transform-shorthand-properties": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-spread": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-sticky-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-template-literals": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-annotate-as-pure": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-typeof-symbol": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0"
+          }
+        },
+        "@babel/plugin-transform-unicode-regex": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/helper-regex": "^7.0.0",
+            "regexpu-core": "^4.1.3"
+          },
+          "dependencies": {
+            "regexpu-core": {
+              "version": "4.4.0",
+              "bundled": true,
+              "requires": {
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
+              }
+            },
+            "regjsgen": {
+              "version": "0.5.0",
+              "bundled": true
+            },
+            "regjsparser": {
+              "version": "0.6.0",
+              "bundled": true,
+              "requires": {
+                "jsesc": "~0.5.0"
+              }
+            }
+          }
+        },
+        "@babel/preset-env": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+            "@babel/plugin-proposal-json-strings": "^7.2.0",
+            "@babel/plugin-proposal-object-rest-spread": "^7.3.1",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0",
+            "@babel/plugin-syntax-json-strings": "^7.2.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+            "@babel/plugin-transform-arrow-functions": "^7.2.0",
+            "@babel/plugin-transform-async-to-generator": "^7.2.0",
+            "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+            "@babel/plugin-transform-block-scoping": "^7.2.0",
+            "@babel/plugin-transform-classes": "^7.2.0",
+            "@babel/plugin-transform-computed-properties": "^7.2.0",
+            "@babel/plugin-transform-destructuring": "^7.2.0",
+            "@babel/plugin-transform-dotall-regex": "^7.2.0",
+            "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+            "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+            "@babel/plugin-transform-for-of": "^7.2.0",
+            "@babel/plugin-transform-function-name": "^7.2.0",
+            "@babel/plugin-transform-literals": "^7.2.0",
+            "@babel/plugin-transform-modules-amd": "^7.2.0",
+            "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+            "@babel/plugin-transform-modules-systemjs": "^7.2.0",
+            "@babel/plugin-transform-modules-umd": "^7.2.0",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
+            "@babel/plugin-transform-new-target": "^7.0.0",
+            "@babel/plugin-transform-object-super": "^7.2.0",
+            "@babel/plugin-transform-parameters": "^7.2.0",
+            "@babel/plugin-transform-regenerator": "^7.0.0",
+            "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+            "@babel/plugin-transform-spread": "^7.2.0",
+            "@babel/plugin-transform-sticky-regex": "^7.2.0",
+            "@babel/plugin-transform-template-literals": "^7.2.0",
+            "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+            "@babel/plugin-transform-unicode-regex": "^7.2.0",
+            "browserslist": "^4.3.4",
+            "invariant": "^2.2.2",
+            "js-levenshtein": "^1.1.3",
+            "semver": "^5.3.0"
+          },
+          "dependencies": {
+            "browserslist": {
+              "version": "4.4.1",
+              "bundled": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30000929",
+                "electron-to-chromium": "^1.3.103",
+                "node-releases": "^1.1.3"
+              }
+            }
+          }
+        },
+        "@babel/preset-flow": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-transform-flow-strip-types": "^7.0.0"
+          }
+        },
+        "@babel/preset-react": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "@babel/plugin-transform-react-display-name": "^7.0.0",
+            "@babel/plugin-transform-react-jsx": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-self": "^7.0.0",
+            "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+          }
+        },
+        "@babel/preset-stage-0": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "@babel/register": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.5.7",
+            "find-cache-dir": "^1.0.0",
+            "home-or-tmp": "^3.0.0",
+            "lodash": "^4.17.10",
+            "mkdirp": "^0.5.1",
+            "pirates": "^4.0.0",
+            "source-map-support": "^0.5.9"
+          },
+          "dependencies": {
+            "home-or-tmp": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "source-map-support": {
+              "version": "0.5.10",
+              "bundled": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            }
+          }
+        },
+        "@babel/runtime": {
+          "version": "7.3.1",
+          "bundled": true,
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          },
+          "dependencies": {
+            "regenerator-runtime": {
+              "version": "0.12.1",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/template": {
+          "version": "7.2.2",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.2.2",
+            "@babel/types": "^7.2.2"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.2.3",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.2.2",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.0.0",
+            "@babel/parser": "^7.2.3",
+            "@babel/types": "^7.2.2",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.10"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "globals": {
+              "version": "11.11.0",
+              "bundled": true
+            }
+          }
+        },
+        "@babel/types": {
+          "version": "7.3.2",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.10",
+            "to-fast-properties": "^2.0.0"
+          },
+          "dependencies": {
+            "to-fast-properties": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "@concordance/react": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1"
+          }
+        },
+        "@resolver-engine/core": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.1.0",
+            "request": "^2.85.0"
+          }
+        },
+        "@resolver-engine/fs": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "@resolver-engine/core": "^0.2.1",
+            "debug": "^3.1.0"
+          }
+        },
+        "@resolver-engine/imports": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "@resolver-engine/core": "^0.2.1",
+            "debug": "^3.1.0",
+            "hosted-git-info": "^2.6.0"
+          }
+        },
+        "@resolver-engine/imports-fs": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "@resolver-engine/fs": "^0.2.1",
+            "@resolver-engine/imports": "^0.2.2",
+            "debug": "^3.1.0"
+          }
+        },
+        "@sinonjs/commons": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "type-detect": "4.0.8"
+          }
+        },
+        "@sinonjs/formatio": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/samsam": "^2 || ^3"
+          }
+        },
+        "@sinonjs/samsam": {
+          "version": "2.1.3",
+          "bundled": true
+        },
+        "JSONStream": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "^1.2.0",
+            "through": ">=2.2.7 <3"
+          }
+        },
+        "abstract-leveldown": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "accepts": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "mime-types": "~2.1.18",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "5.7.3",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "aes-js": {
+          "version": "3.1.2",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "6.9.1",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.4.0",
+          "bundled": true
+        },
+        "ansi-align": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "any-promise": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "append-buffer": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "buffer-equal": "^1.0.0"
+          }
+        },
+        "argparse": {
+          "version": "1.0.10",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "arr-diff": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "arr-flatten": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "arr-union": {
+          "version": "3.1.0",
+          "bundled": true
+        },
+        "array-differ": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "array-find-index": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "array-includes": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.7.0"
+          }
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "^1.0.1"
+          },
+          "dependencies": {
+            "array-uniq": {
+              "version": "1.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "array-uniq": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.3.2",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": "~2.1.0"
+          }
+        },
+        "asn1.js": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "assign-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "async": {
+          "version": "2.6.2",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.11"
+          }
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "async-eventemitter": {
+          "version": "0.2.4",
+          "bundled": true,
+          "requires": {
+            "async": "^2.4.0"
+          }
+        },
+        "async-limiter": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "atob": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "ava": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "@ava/babel-preset-stage-4": "^2.0.0",
+            "@ava/babel-preset-transform-test-files": "^4.0.1",
+            "@ava/write-file-atomic": "^2.2.0",
+            "@babel/core": "^7.2.2",
+            "@babel/generator": "^7.3.0",
+            "@babel/plugin-syntax-async-generators": "^7.2.0",
+            "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+            "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+            "@concordance/react": "^2.0.0",
+            "ansi-escapes": "^3.1.0",
+            "ansi-styles": "^3.2.1",
+            "arr-flatten": "^1.1.0",
+            "array-union": "^1.0.1",
+            "array-uniq": "^2.0.0",
+            "arrify": "^1.0.0",
+            "bluebird": "^3.5.3",
+            "chalk": "^2.4.2",
+            "chokidar": "^2.0.4",
+            "chunkd": "^1.0.0",
+            "ci-parallel-vars": "^1.0.0",
+            "clean-stack": "^2.0.0",
+            "clean-yaml-object": "^0.1.0",
+            "cli-cursor": "^2.1.0",
+            "cli-truncate": "^1.1.0",
+            "code-excerpt": "^2.1.1",
+            "common-path-prefix": "^1.0.0",
+            "concordance": "^4.0.0",
+            "convert-source-map": "^1.6.0",
+            "currently-unhandled": "^0.4.1",
+            "debug": "^4.1.1",
+            "del": "^3.0.0",
+            "dot-prop": "^4.2.0",
+            "emittery": "^0.4.1",
+            "empower-core": "^1.2.0",
+            "equal-length": "^1.0.0",
+            "escape-string-regexp": "^1.0.5",
+            "esm": "^3.1.3",
+            "figures": "^2.0.0",
+            "find-up": "^3.0.0",
+            "get-port": "^4.1.0",
+            "globby": "^7.1.1",
+            "ignore-by-default": "^1.0.0",
+            "import-local": "^2.0.0",
+            "indent-string": "^3.2.0",
+            "is-ci": "^2.0.0",
+            "is-error": "^2.2.1",
+            "is-observable": "^1.1.0",
+            "is-plain-object": "^2.0.4",
+            "is-promise": "^2.1.0",
+            "lodash.clone": "^4.5.0",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.clonedeepwith": "^4.5.0",
+            "lodash.debounce": "^4.0.3",
+            "lodash.difference": "^4.3.0",
+            "lodash.flatten": "^4.2.0",
+            "loud-rejection": "^1.2.0",
+            "make-dir": "^1.3.0",
+            "matcher": "^1.1.1",
+            "md5-hex": "^2.0.0",
+            "meow": "^5.0.0",
+            "ms": "^2.1.1",
+            "multimatch": "^3.0.0",
+            "observable-to-promise": "^0.5.0",
+            "ora": "^3.0.0",
+            "package-hash": "^3.0.0",
+            "pkg-conf": "^2.1.0",
+            "plur": "^3.0.1",
+            "pretty-ms": "^4.0.0",
+            "require-precompiled": "^0.1.0",
+            "resolve-cwd": "^2.0.0",
+            "slash": "^2.0.0",
+            "source-map-support": "^0.5.10",
+            "stack-utils": "^1.0.2",
+            "strip-ansi": "^5.0.0",
+            "strip-bom-buf": "^1.0.0",
+            "supertap": "^1.0.0",
+            "supports-color": "^6.1.0",
+            "trim-off-newlines": "^1.0.1",
+            "trim-right": "^1.0.1",
+            "unique-temp-dir": "^1.0.0",
+            "update-notifier": "^2.5.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "4.1.1",
+              "bundled": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "slash": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true
+            },
+            "source-map-support": {
+              "version": "0.5.10",
+              "bundled": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "axios": {
+          "version": "0.18.0",
+          "bundled": true,
+          "requires": {
+            "follow-redirects": "^1.3.0",
+            "is-buffer": "^1.1.5"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
+          }
+        },
+        "babel-core": {
+          "version": "6.26.3",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-eslint": {
+          "version": "10.0.1",
+          "bundled": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "@babel/traverse": "^7.0.0",
+            "@babel/types": "^7.0.0",
+            "eslint-scope": "3.7.1",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        },
+        "babel-generator": {
+          "version": "6.26.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-evaluate-path": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-flip-expressions": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-is-nodes-equiv": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "babel-helper-is-void-0": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-mark-eval-scopes": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-remove-or-void": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-helper-to-multiple-sequence-expressions": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-espower": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "@babel/generator": "^7.0.0",
+            "@babel/parser": "^7.0.0",
+            "call-matcher": "^1.0.0",
+            "core-js": "^2.0.0",
+            "espower-location-detector": "^1.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "babel-plugin-inline-json-import": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "decache": "^4.1.0"
+          }
+        },
+        "babel-plugin-minify-builtins": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-constant-folding": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-dead-code-elimination": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0",
+            "babel-helper-mark-eval-scopes": "^0.4.3",
+            "babel-helper-remove-or-void": "^0.4.3",
+            "lodash.some": "^4.6.0"
+          }
+        },
+        "babel-plugin-minify-flip-comparisons": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-guarded-expressions": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-infinity": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-mangle-names": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-mark-eval-scopes": "^0.4.3"
+          }
+        },
+        "babel-plugin-minify-numeric-literals": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-minify-replace": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "babel-plugin-minify-simplify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-flip-expressions": "^0.4.3",
+            "babel-helper-is-nodes-equiv": "^0.0.1",
+            "babel-helper-to-multiple-sequence-expressions": "^0.5.0"
+          }
+        },
+        "babel-plugin-minify-type-constructors": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "babel-helper-is-void-0": "^0.4.3"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.26.2",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
+          }
+        },
+        "babel-plugin-transform-inline-consecutive-adds": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-member-expression-literals": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-merge-sibling-variables": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-minify-booleans": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-property-literals": {
+          "version": "6.9.4",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "^0.10.0"
+          }
+        },
+        "babel-plugin-transform-regexp-constructors": {
+          "version": "0.4.3",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-console": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-debugger": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-remove-undefined": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-helper-evaluate-path": "^0.5.0"
+          }
+        },
+        "babel-plugin-transform-simplify-comparison-operators": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
+          }
+        },
+        "babel-plugin-transform-undefined-to-void": {
+          "version": "6.9.4",
+          "bundled": true
+        },
+        "babel-preset-env": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
+          }
+        },
+        "babel-preset-minify": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-minify-builtins": "^0.5.0",
+            "babel-plugin-minify-constant-folding": "^0.5.0",
+            "babel-plugin-minify-dead-code-elimination": "^0.5.0",
+            "babel-plugin-minify-flip-comparisons": "^0.4.3",
+            "babel-plugin-minify-guarded-expressions": "^0.4.3",
+            "babel-plugin-minify-infinity": "^0.4.3",
+            "babel-plugin-minify-mangle-names": "^0.5.0",
+            "babel-plugin-minify-numeric-literals": "^0.4.3",
+            "babel-plugin-minify-replace": "^0.5.0",
+            "babel-plugin-minify-simplify": "^0.5.0",
+            "babel-plugin-minify-type-constructors": "^0.4.3",
+            "babel-plugin-transform-inline-consecutive-adds": "^0.4.3",
+            "babel-plugin-transform-member-expression-literals": "^6.9.4",
+            "babel-plugin-transform-merge-sibling-variables": "^6.9.4",
+            "babel-plugin-transform-minify-booleans": "^6.9.4",
+            "babel-plugin-transform-property-literals": "^6.9.4",
+            "babel-plugin-transform-regexp-constructors": "^0.4.3",
+            "babel-plugin-transform-remove-console": "^6.9.4",
+            "babel-plugin-transform-remove-debugger": "^6.9.4",
+            "babel-plugin-transform-remove-undefined": "^0.5.0",
+            "babel-plugin-transform-simplify-comparison-operators": "^6.9.4",
+            "babel-plugin-transform-undefined-to-void": "^6.9.4",
+            "lodash.isplainobject": "^4.0.6"
+          }
+        },
+        "babel-register": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
+          }
+        },
+        "babel-template": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.26.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
+          }
+        },
+        "babelify": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "^6.0.14",
+            "object-assign": "^4.0.0"
+          }
+        },
+        "babylon": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "bail": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base": {
+          "version": "0.11.2",
+          "bundled": true,
+          "requires": {
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "base-x": {
+          "version": "3.0.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "base64-js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
+        },
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.13.0",
+          "bundled": true
+        },
+        "bindings": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        },
+        "bip39": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "unorm": "^1.3.3"
+          }
+        },
+        "bip66": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "bl": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "blakejs": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "~2.0.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.3",
+          "bundled": true
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "bundled": true
+        },
+        "body": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "continuable-cache": "^0.3.1",
+            "error": "^7.0.0",
+            "raw-body": "~1.1.0",
+            "safe-json-parse": "~1.0.1"
+          }
+        },
+        "body-parser": {
+          "version": "1.18.3",
+          "bundled": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
+            "iconv-lite": "0.4.23",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.2",
+            "raw-body": "2.3.3",
+            "type-is": "~1.6.16"
+          },
+          "dependencies": {
+            "bytes": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "iconv-lite": {
+              "version": "0.4.23",
+              "bundled": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "raw-body": {
+              "version": "2.3.3",
+              "bundled": true,
+              "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
+                "unpipe": "1.0.0"
+              }
+            }
+          }
+        },
+        "boxen": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "ansi-align": "^2.0.0",
+            "camelcase": "^4.0.0",
+            "chalk": "^2.0.1",
+            "cli-boxes": "^1.0.0",
+            "string-width": "^2.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-resolve": {
+          "version": "1.11.3",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.1.7",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-aes": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
+          }
+        },
+        "browserify-sha3": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "js-sha3": "^0.6.1",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.6.1",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
+          }
+        },
+        "browserslist": {
+          "version": "3.2.8",
+          "bundled": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
+          }
+        },
+        "bs58": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "base-x": "^3.0.2"
+          }
+        },
+        "bs58check": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "bs58": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "buffer": {
+          "version": "5.2.1",
+          "bundled": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "buffer-alloc": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "buffer-alloc-unsafe": "^1.1.0",
+            "buffer-fill": "^1.0.0"
+          }
+        },
+        "buffer-alloc-unsafe": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "buffer-crc32": {
+          "version": "0.2.13",
+          "bundled": true
+        },
+        "buffer-equal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-fill": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-from": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "buffer-loader": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-to-arraybuffer": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cache-base": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
+          }
+        },
+        "cached-path-relative": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "call-matcher": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0",
+            "deep-equal": "^1.0.0",
+            "espurify": "^1.6.0",
+            "estraverse": "^4.0.0"
+          }
+        },
+        "call-signature": {
+          "version": "0.0.2",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "^0.2.0"
+          }
+        },
+        "callsite": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "map-obj": "^2.0.0",
+            "quick-lru": "^1.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "caniuse-lite": {
+          "version": "1.0.30000938",
+          "bundled": true
+        },
+        "capture-stack-trace": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "ccount": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          }
+        },
+        "character-entities": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "character-entities-html4": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "character-entities-legacy": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "character-reference-invalid": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "chardet": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "checkpoint-store": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "functional-red-black-tree": "^1.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.0"
+          }
+        },
+        "chunkd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ci-info": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "ci-parallel-vars": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cids": {
+          "version": "0.5.7",
+          "bundled": true,
+          "requires": {
+            "class-is": "^1.1.0",
+            "multibase": "~0.6.0",
+            "multicodec": "~0.2.7",
+            "multihashes": "~0.4.14"
+          }
+        },
+        "cipher-base": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.3",
+          "bundled": true
+        },
+        "class-is": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "class-utils": {
+          "version": "0.3.6",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "clean-stack": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "clean-yaml-object": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "cli-boxes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "cli-table3": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "colors": "^1.1.2",
+            "object-assign": "^4.1.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-truncate": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "slice-ansi": "^1.0.0",
+            "string-width": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "cli-width": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cloneable-readable": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "process-nextick-args": "^2.0.0",
+            "readable-stream": "^2.3.5"
+          }
+        },
+        "code-excerpt": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "convert-to-spaces": "^1.0.1"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "coinstring": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "bs58": "^2.0.1",
+            "create-hash": "^1.1.1"
+          },
+          "dependencies": {
+            "bs58": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "collapse-white-space": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "collection-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "bundled": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "colors": {
+          "version": "1.3.3",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        },
+        "comma-separated-tokens": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "commander": {
+          "version": "2.19.0",
+          "bundled": true
+        },
+        "common-path-prefix": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "commondir": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "component-emitter": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "concordance": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "date-time": "^2.1.0",
+            "esutils": "^2.0.2",
+            "fast-diff": "^1.1.2",
+            "js-string-escape": "^1.0.1",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.flattendeep": "^4.4.0",
+            "lodash.islength": "^4.0.1",
+            "lodash.merge": "^4.6.1",
+            "md5-hex": "^2.0.0",
+            "semver": "^5.5.1",
+            "well-known-symbols": "^2.0.0"
+          }
+        },
+        "configstore": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "continuable-cache": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
+        },
+        "convert-to-spaces": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "cookiejar": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "copy-descriptor": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.6.5",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cors": {
+          "version": "2.8.5",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4",
+            "vary": "^1"
+          }
+        },
+        "create-ecdh": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
+          }
+        },
+        "create-error-class": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "capture-stack-trace": "^1.0.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "bundled": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "crypto-browserify": {
+          "version": "3.12.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
+          }
+        },
+        "crypto-js": {
+          "version": "3.1.8",
+          "bundled": true
+        },
+        "crypto-random-string": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "currently-unhandled": {
+          "version": "0.4.1",
+          "bundled": true,
+          "requires": {
+            "array-find-index": "^1.0.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "date-fns": {
+          "version": "2.0.0-alpha.22",
+          "bundled": true
+        },
+        "date-time": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "time-zone": "^1.0.0"
+          }
+        },
+        "de-indent": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "debug-log": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "decache": {
+          "version": "4.5.1",
+          "bundled": true,
+          "requires": {
+            "callsite": "^1.0.0"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "decamelize-keys": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "decamelize": "^1.1.0",
+            "map-obj": "^1.0.0"
+          },
+          "dependencies": {
+            "map-obj": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "decode-uri-component": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "decompress": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "^4.0.0",
+            "decompress-tarbz2": "^4.0.0",
+            "decompress-targz": "^4.0.0",
+            "decompress-unzip": "^4.0.1",
+            "graceful-fs": "^4.1.10",
+            "make-dir": "^1.0.0",
+            "pify": "^2.3.0",
+            "strip-dirs": "^2.0.0"
+          }
+        },
+        "decompress-response": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "mimic-response": "^1.0.0"
+          }
+        },
+        "decompress-tar": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0",
+            "tar-stream": "^1.5.2"
+          }
+        },
+        "decompress-tarbz2": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "^4.1.0",
+            "file-type": "^6.1.0",
+            "is-stream": "^1.1.0",
+            "seek-bzip": "^1.0.5",
+            "unbzip2-stream": "^1.0.9"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "6.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "decompress-targz": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "decompress-tar": "^4.1.1",
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0"
+          }
+        },
+        "decompress-unzip": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "file-type": "^3.8.0",
+            "get-stream": "^2.2.0",
+            "pify": "^2.3.0",
+            "yauzl": "^2.4.2"
+          },
+          "dependencies": {
+            "file-type": {
+              "version": "3.9.0",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "2.3.1",
+              "bundled": true,
+              "requires": {
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-extend": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "defaults": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "clone": "^1.0.2"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.4",
+              "bundled": true
+            }
+          }
+        },
+        "deferred-leveldown": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "abstract-leveldown": "~2.6.0"
+          }
+        },
+        "define-properties": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-keys": "^1.0.12"
+          },
+          "dependencies": {
+            "object-keys": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "define-property": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
+          },
+          "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "deglob": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "find-root": "^1.0.0",
+            "glob": "^7.0.5",
+            "ignore": "^3.0.9",
+            "pkg-config": "^1.1.0",
+            "run-parallel": "^1.1.2",
+            "uniq": "^1.0.1"
+          }
+        },
+        "del": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          },
+          "dependencies": {
+            "globby": {
+              "version": "6.1.0",
+              "bundled": true,
+              "requires": {
+                "array-union": "^1.0.1",
+                "glob": "^7.0.3",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                }
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detab": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "repeat-string": "^1.5.4"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "^2.0.0"
+          }
+        },
+        "detect-node": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "detective": {
+          "version": "4.7.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "^5.2.1",
+            "defined": "^1.0.0"
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
+          }
+        },
+        "dir-glob": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "path-type": "^3.0.0"
+          },
+          "dependencies": {
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "disparity": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^2.0.1",
+            "diff": "^1.3.2"
+          }
+        },
+        "doctrine": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "doctrine-temporary-fork": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "documentation": {
+          "version": "9.1.1",
+          "bundled": true,
+          "requires": {
+            "@babel/core": "^7.1.2",
+            "@babel/generator": "^7.1.3",
+            "@babel/parser": "7.1.3",
+            "@babel/plugin-proposal-class-properties": "^7.1.0",
+            "@babel/plugin-proposal-decorators": "^7.1.2",
+            "@babel/plugin-proposal-do-expressions": "^7.0.0",
+            "@babel/plugin-proposal-export-default-from": "^7.0.0",
+            "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
+            "@babel/plugin-proposal-function-bind": "^7.0.0",
+            "@babel/plugin-proposal-function-sent": "^7.1.0",
+            "@babel/plugin-proposal-json-strings": "^7.0.0",
+            "@babel/plugin-proposal-logical-assignment-operators": "^7.0.0",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
+            "@babel/plugin-proposal-numeric-separator": "^7.0.0",
+            "@babel/plugin-proposal-optional-chaining": "^7.0.0",
+            "@babel/plugin-proposal-pipeline-operator": "^7.0.0",
+            "@babel/plugin-proposal-throw-expressions": "^7.0.0",
+            "@babel/plugin-syntax-dynamic-import": "^7.0.0",
+            "@babel/plugin-syntax-import-meta": "^7.0.0",
+            "@babel/preset-env": "^7.1.0",
+            "@babel/preset-flow": "^7.0.0",
+            "@babel/preset-react": "^7.0.0",
+            "@babel/preset-stage-0": "^7.0.0",
+            "@babel/traverse": "^7.1.4",
+            "@babel/types": "^7.1.3",
+            "ansi-html": "^0.0.7",
+            "babelify": "^10.0.0",
+            "chalk": "^2.3.0",
+            "chokidar": "^2.0.4",
+            "concat-stream": "^1.6.0",
+            "disparity": "^2.0.0",
+            "doctrine-temporary-fork": "2.0.1",
+            "get-port": "^4.0.0",
+            "git-url-parse": "^10.0.1",
+            "github-slugger": "1.2.0",
+            "glob": "^7.1.2",
+            "globals-docs": "^2.4.0",
+            "highlight.js": "^9.12.0",
+            "js-yaml": "^3.10.0",
+            "lodash": "^4.17.10",
+            "mdast-util-inject": "^1.1.0",
+            "micromatch": "^3.1.5",
+            "mime": "^2.2.0",
+            "module-deps-sortable": "5.0.0",
+            "parse-filepath": "^1.0.2",
+            "pify": "^4.0.0",
+            "read-pkg-up": "^4.0.0",
+            "remark": "^9.0.0",
+            "remark-html": "^8.0.0",
+            "remark-reference-links": "^4.0.1",
+            "remark-toc": "^5.0.0",
+            "remote-origin-url": "0.4.0",
+            "resolve": "^1.8.1",
+            "stream-array": "^1.1.2",
+            "strip-json-comments": "^2.0.1",
+            "tiny-lr": "^1.1.0",
+            "unist-builder": "^1.0.2",
+            "unist-util-visit": "^1.3.0",
+            "vfile": "^3.0.0",
+            "vfile-reporter": "^5.0.0",
+            "vfile-sort": "^2.1.0",
+            "vinyl": "^2.1.0",
+            "vinyl-fs": "^3.0.2",
+            "vue-template-compiler": "^2.5.16",
+            "yargs": "^9.0.1"
+          },
+          "dependencies": {
+            "@babel/parser": {
+              "version": "7.1.3",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "babelify": {
+              "version": "10.0.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              },
+              "dependencies": {
+                "pify": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "pify": {
+              "version": "4.0.1",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^3.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "9.0.1",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0",
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "read-pkg-up": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^7.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "locate-path": "^2.0.0"
+                  }
+                },
+                "load-json-file": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "^4.1.2",
+                    "parse-json": "^2.2.0",
+                    "pify": "^2.0.0",
+                    "strip-bom": "^3.0.0"
+                  }
+                },
+                "locate-path": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-locate": "^2.0.0",
+                    "path-exists": "^3.0.0"
+                  }
+                },
+                "p-limit": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-try": "^1.0.0"
+                  }
+                },
+                "p-locate": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "p-limit": "^1.1.0"
+                  }
+                },
+                "p-try": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "parse-json": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "error-ex": "^1.2.0"
+                  }
+                },
+                "path-type": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "pify": "^2.0.0"
+                  }
+                },
+                "pify": {
+                  "version": "2.3.0",
+                  "bundled": true
+                },
+                "read-pkg": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "load-json-file": "^2.0.0",
+                    "normalize-package-data": "^2.3.2",
+                    "path-type": "^2.0.0"
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "2.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "find-up": "^2.0.0",
+                    "read-pkg": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "7.0.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "dom-walk": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "dot-prop": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "is-obj": "^1.0.0"
+          }
+        },
+        "drbg.js": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "^1.0.6",
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4"
+          }
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "duplexer3": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "duplexify": {
+          "version": "3.7.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.1.0"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.113",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
+          }
+        },
+        "emittery": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "6.1.1",
+          "bundled": true
+        },
+        "empower-core": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "call-signature": "0.0.2",
+            "core-js": "^2.0.0"
+          }
+        },
+        "encodeurl": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "~0.4.13"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "equal-length": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "errno": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "prr": "~1.0.1"
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "bundled": true,
+          "requires": {
+            "string-template": "~0.2.1",
+            "xtend": "~4.0.0"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "^0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.13.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "^1.2.0",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-keys": "^1.0.12"
+          },
+          "dependencies": {
+            "object-keys": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "eslint": {
+          "version": "5.4.0",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.0",
+            "babel-code-frame": "^6.26.0",
+            "chalk": "^2.1.0",
+            "cross-spawn": "^6.0.5",
+            "debug": "^3.1.0",
+            "doctrine": "^2.1.0",
+            "eslint-scope": "^4.0.0",
+            "eslint-utils": "^1.3.1",
+            "eslint-visitor-keys": "^1.0.0",
+            "espree": "^4.0.0",
+            "esquery": "^1.0.1",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^2.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob": "^7.1.2",
+            "globals": "^11.7.0",
+            "ignore": "^4.0.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^5.2.0",
+            "is-resolvable": "^1.1.0",
+            "js-yaml": "^3.11.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.3.0",
+            "lodash": "^4.17.5",
+            "minimatch": "^3.0.4",
+            "mkdirp": "^0.5.1",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.8.2",
+            "path-is-inside": "^1.0.2",
+            "pluralize": "^7.0.0",
+            "progress": "^2.0.0",
+            "regexpp": "^2.0.0",
+            "require-uncached": "^1.0.3",
+            "semver": "^5.5.0",
+            "strip-ansi": "^4.0.0",
+            "strip-json-comments": "^2.0.1",
+            "table": "^4.0.3",
+            "text-table": "^0.2.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "eslint-scope": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+              }
+            },
+            "globals": {
+              "version": "11.11.0",
+              "bundled": true
+            },
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "eslint-config-standard": {
+          "version": "12.0.0",
+          "bundled": true
+        },
+        "eslint-config-standard-jsx": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.9",
+            "resolve": "^1.5.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-module-utils": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.6.8",
+            "pkg-dir": "^2.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-es": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "eslint-utils": "^1.3.0",
+            "regexpp": "^2.0.1"
+          }
+        },
+        "eslint-plugin-flowtype": {
+          "version": "2.50.3",
+          "bundled": true,
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "2.14.0",
+          "bundled": true,
+          "requires": {
+            "contains-path": "^0.1.0",
+            "debug": "^2.6.8",
+            "doctrine": "1.5.0",
+            "eslint-import-resolver-node": "^0.3.1",
+            "eslint-module-utils": "^2.2.0",
+            "has": "^1.0.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.3",
+            "read-pkg-up": "^2.0.0",
+            "resolve": "^1.6.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "doctrine": {
+              "version": "1.5.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "^2.0.2",
+                "isarray": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "load-json-file": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^2.0.0"
+              }
+            },
+            "read-pkg": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-node": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint-plugin-es": "^1.3.1",
+            "eslint-utils": "^1.3.1",
+            "ignore": "^4.0.2",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.0"
+          },
+          "dependencies": {
+            "ignore": {
+              "version": "4.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "eslint-plugin-promise": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "eslint-plugin-react": {
+          "version": "7.11.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3",
+            "doctrine": "^2.1.0",
+            "has": "^1.0.3",
+            "jsx-ast-utils": "^2.0.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "eslint-plugin-standard": {
+          "version": "4.0.0",
+          "bundled": true
+        },
+        "eslint-scope": {
+          "version": "3.7.1",
+          "bundled": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "esm": {
+          "version": "3.2.4",
+          "bundled": true
+        },
+        "espower-location-detector": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-url": "^1.2.1",
+            "path-is-absolute": "^1.0.0",
+            "source-map": "^0.5.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "espree": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "6.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "esprima": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "espurify": {
+          "version": "1.8.1",
+          "bundled": true,
+          "requires": {
+            "core-js": "^2.0.0"
+          }
+        },
+        "esquery": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        },
+        "esrecurse": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "estraverse": "^4.1.0"
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.1",
+          "bundled": true
+        },
+        "eth-block-tracker": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+            "eth-query": "^2.1.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.3",
+            "ethjs-util": "^0.1.3",
+            "json-rpc-engine": "^3.6.0",
+            "pify": "^2.3.0",
+            "tape": "^4.6.3"
+          },
+          "dependencies": {
+            "async-eventemitter": {
+              "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+              "from": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+              "bundled": true,
+              "requires": {
+                "async": "^2.4.0"
+              }
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "eth-ens-namehash": {
+          "version": "2.0.8",
+          "bundled": true,
+          "requires": {
+            "idna-uts46-hx": "^2.3.1",
+            "js-sha3": "^0.5.7"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.5.7",
+              "bundled": true
+            }
+          }
+        },
+        "eth-lib": {
+          "version": "0.1.27",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
+          }
+        },
+        "eth-query": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "json-rpc-random-id": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "eth-sig-util": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+            "ethereumjs-util": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereum-common": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "ethereum-ens": {
+          "version": "0.7.4",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.4.7",
+            "eth-ens-namehash": "^2.0.0",
+            "js-sha3": "^0.5.7",
+            "pako": "^1.0.4",
+            "text-encoding": "^0.6.4",
+            "underscore": "^1.8.3",
+            "web3": "^0.19.1"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "js-sha3": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "utf8": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "web3": {
+              "version": "0.19.1",
+              "bundled": true,
+              "requires": {
+                "bignumber.js": "^4.0.2",
+                "crypto-js": "^3.1.4",
+                "utf8": "^2.1.1",
+                "xhr2": "*",
+                "xmlhttprequest": "*"
+              }
+            }
+          }
+        },
+        "ethereum-ens-network-map": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ethereumjs-abi": {
+          "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+          "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^5.0.0"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-account": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "ethereumjs-util": "^5.0.0",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-block": {
+          "version": "1.7.1",
+          "bundled": true,
+          "requires": {
+            "async": "^2.0.1",
+            "ethereum-common": "0.2.0",
+            "ethereumjs-tx": "^1.2.2",
+            "ethereumjs-util": "^5.0.0",
+            "merkle-patricia-tree": "^2.1.2"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-common": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "ethereumjs-tx": {
+          "version": "1.3.7",
+          "bundled": true,
+          "requires": {
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
+          },
+          "dependencies": {
+            "ethereum-common": {
+              "version": "0.0.18",
+              "bundled": true
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ethereumjs-util": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "0.1.6",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "ethereumjs-vm": {
+          "version": "2.6.0",
+          "bundled": true,
+          "requires": {
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
+            "ethereumjs-account": "^2.0.3",
+            "ethereumjs-block": "~2.2.0",
+            "ethereumjs-common": "^1.1.0",
+            "ethereumjs-util": "^6.0.0",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.3.2",
+            "rustbn.js": "~0.2.0",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "ethereumjs-block": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "async": "^2.0.1",
+                "ethereumjs-common": "^1.1.0",
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
+              },
+              "dependencies": {
+                "ethereumjs-util": {
+                  "version": "5.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "bn.js": "^4.11.0",
+                    "create-hash": "^1.1.2",
+                    "ethjs-util": "^0.1.3",
+                    "keccak": "^1.0.2",
+                    "rlp": "^2.0.0",
+                    "safe-buffer": "^5.1.1",
+                    "secp256k1": "^3.0.1"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "ethereumjs-wallet": {
+          "version": "0.6.3",
+          "bundled": true,
+          "requires": {
+            "aes-js": "^3.1.1",
+            "bs58check": "^2.1.2",
+            "ethereumjs-util": "^6.0.0",
+            "hdkey": "^1.1.0",
+            "randombytes": "^2.0.6",
+            "safe-buffer": "^5.1.2",
+            "scrypt.js": "^0.3.0",
+            "utf8": "^3.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "ethjs-abi": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "js-sha3": "0.5.5",
+            "number-to-bn": "1.7.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            },
+            "js-sha3": {
+              "version": "0.5.5",
+              "bundled": true
+            }
+          }
+        },
+        "ethjs-contract": {
+          "version": "0.1.9",
+          "bundled": true,
+          "requires": {
+            "ethjs-abi": "0.2.0",
+            "ethjs-filter": "0.1.5",
+            "ethjs-util": "0.1.3",
+            "js-sha3": "0.5.5"
+          },
+          "dependencies": {
+            "ethjs-util": {
+              "version": "0.1.3",
+              "bundled": true,
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            },
+            "js-sha3": {
+              "version": "0.5.5",
+              "bundled": true
+            }
+          }
+        },
+        "ethjs-ens": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "eth-ens-namehash": "^1.0.2",
+            "ethereum-ens-network-map": "^1.0.0",
+            "ethjs-contract": "^0.1.7",
+            "ethjs-query": "^0.2.4"
+          },
+          "dependencies": {
+            "eth-ens-namehash": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "idna-uts46": "^1.0.1",
+                "js-sha3": "^0.5.7"
+              }
+            },
+            "js-sha3": {
+              "version": "0.5.7",
+              "bundled": true
+            }
+          }
+        },
+        "ethjs-filter": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ethjs-format": {
+          "version": "0.2.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "ethjs-schema": "0.1.5",
+            "ethjs-util": "0.1.3",
+            "is-hex-prefixed": "1.0.0",
+            "number-to-bn": "1.7.0",
+            "strip-hex-prefix": "1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            },
+            "ethjs-util": {
+              "version": "0.1.3",
+              "bundled": true,
+              "requires": {
+                "is-hex-prefixed": "1.0.0",
+                "strip-hex-prefix": "1.0.0"
+              }
+            }
+          }
+        },
+        "ethjs-query": {
+          "version": "0.2.9",
+          "bundled": true,
+          "requires": {
+            "ethjs-format": "0.2.2",
+            "ethjs-rpc": "0.1.5"
+          }
+        },
+        "ethjs-rpc": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ethjs-schema": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "ethjs-unit": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "number-to-bn": "1.7.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            }
+          }
+        },
+        "ethjs-util": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-hex-prefixed": "1.0.0",
+            "strip-hex-prefix": "1.0.0"
+          }
+        },
+        "eventemitter3": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "events": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "evp_bytestokey": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "expand-brackets": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "express": {
+          "version": "4.16.4",
+          "bundled": true,
+          "requires": {
+            "accepts": "~1.3.5",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.3",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.1",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.4",
+            "qs": "6.5.2",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.2",
+            "send": "0.16.2",
+            "serve-static": "1.13.2",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "external-editor": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chardet": "^0.4.0",
+            "iconv-lite": "^0.4.17",
+            "tmp": "^0.0.33"
+          }
+        },
+        "extglob": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "extsprintf": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "fake-merkle-patricia-tree": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "checkpoint-store": "^1.1.0"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fast-diff": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        },
+        "fd-slicer": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "pend": "~1.2.0"
+          }
+        },
+        "fetch-ponyfill": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "~1.7.1"
+          }
+        },
+        "figures": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "file-type": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "file-uri-to-path": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fill-keys": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-object": "~1.0.1",
+            "merge-descriptors": "~1.0.0"
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "find-cache-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^2.0.0"
+          }
+        },
+        "find-root": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "circular-json": "^0.3.1",
+            "graceful-fs": "^4.1.2",
+            "rimraf": "~2.6.2",
+            "write": "^0.2.1"
+          }
+        },
+        "flatmap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "flow-bin": {
+          "version": "0.63.1",
+          "bundled": true
+        },
+        "flush-write-stream": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.3.6"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "debug": "^3.2.6"
+          }
+        },
+        "for-each": {
+          "version": "0.3.3",
+          "bundled": true,
+          "requires": {
+            "is-callable": "^1.1.3"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.3.3",
+          "bundled": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "fragment-cache": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "map-cache": "^0.2.2"
+          }
+        },
+        "fresh": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fs-extra": {
+          "version": "0.30.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "fs-mkdirp-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "through2": "^2.0.3"
+          }
+        },
+        "fs-promise": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "any-promise": "^1.3.0",
+            "fs-extra": "^2.0.0",
+            "mz": "^2.6.0",
+            "thenify-all": "^1.6.0"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "2.1.2",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
+              }
+            }
+          }
+        },
+        "fs-readdir-recursive": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
+          }
+        },
+        "function-bind": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "get-port": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "get-stdin": {
+          "version": "6.0.0",
+          "bundled": true
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "pump": "^3.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+              }
+            }
+          }
+        },
+        "get-value": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
+        },
+        "git-up": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "is-ssh": "^1.3.0",
+            "parse-url": "^3.0.2"
+          }
+        },
+        "git-url-parse": {
+          "version": "10.1.0",
+          "bundled": true,
+          "requires": {
+            "git-up": "^2.0.0"
+          }
+        },
+        "github-slugger": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": ">=6.0.0 <=6.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
+          }
+        },
+        "glob-stream": {
+          "version": "6.1.0",
+          "bundled": true,
+          "requires": {
+            "extend": "^3.0.0",
+            "glob": "^7.1.1",
+            "glob-parent": "^3.1.0",
+            "is-negated-glob": "^1.0.0",
+            "ordered-read-streams": "^1.0.0",
+            "pumpify": "^1.3.5",
+            "readable-stream": "^2.1.5",
+            "remove-trailing-separator": "^1.0.1",
+            "to-absolute-glob": "^2.0.0",
+            "unique-stream": "^2.0.2"
+          }
+        },
+        "global": {
+          "version": "4.3.2",
+          "bundled": true,
+          "requires": {
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
+          }
+        },
+        "global-dirs": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.4"
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "bundled": true
+        },
+        "globals-docs": {
+          "version": "2.4.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "array-union": "^1.0.1",
+            "dir-glob": "^2.0.0",
+            "glob": "^7.1.2",
+            "ignore": "^3.3.5",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "got": {
+          "version": "6.7.1",
+          "bundled": true,
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.15",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "5.1.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
+          }
+        },
+        "has": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "function-bind": "^1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "has-symbol-support-x": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "has-symbols": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "has-to-string-tag-x": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "has-symbol-support-x": "^1.4.1"
+          }
+        },
+        "has-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
+          }
+        },
+        "has-values": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "hash-base": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
+          }
+        },
+        "hasha": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "is-stream": "^1.0.1"
+          }
+        },
+        "hast-util-is-element": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "hast-util-sanitize": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "hast-util-to-html": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "ccount": "^1.0.0",
+            "comma-separated-tokens": "^1.0.1",
+            "hast-util-is-element": "^1.0.0",
+            "hast-util-whitespace": "^1.0.0",
+            "html-void-elements": "^1.0.0",
+            "property-information": "^4.0.0",
+            "space-separated-tokens": "^1.0.0",
+            "stringify-entities": "^1.0.1",
+            "unist-util-is": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "hast-util-whitespace": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "hdkey": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "coinstring": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        },
+        "he": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "highlight.js": {
+          "version": "9.14.2",
+          "bundled": true
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
+          }
+        },
+        "homedir": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "hosted-git-info": {
+          "version": "2.7.1",
+          "bundled": true
+        },
+        "html-void-elements": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "http-https": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "http-parser-js": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.24",
+          "bundled": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        },
+        "idna-uts46": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "idna-uts46-hx": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "2.1.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "ieee754": {
+          "version": "1.1.12",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "bundled": true
+        },
+        "ignore-by-default": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "immediate": {
+          "version": "3.2.3",
+          "bundled": true
+        },
+        "import-lazy": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "import-local": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "pkg-dir": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^3.0.0"
+              }
+            }
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.5",
+          "bundled": true
+        },
+        "inquirer": {
+          "version": "5.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.0",
+            "cli-cursor": "^2.1.0",
+            "cli-width": "^2.0.0",
+            "external-editor": "^2.1.0",
+            "figures": "^2.0.0",
+            "lodash": "^4.3.0",
+            "mute-stream": "0.0.7",
+            "run-async": "^2.2.0",
+            "rxjs": "^5.5.2",
+            "string-width": "^2.1.0",
+            "strip-ansi": "^4.0.0",
+            "through": "^2.3.6"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "invariant": {
+          "version": "2.2.4",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ip": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.8.0",
+          "bundled": true
+        },
         "ipfs-api": {
           "version": "17.5.0",
-          "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-17.5.0.tgz",
-          "integrity": "sha512-1LMao28nKBCUrvc6BUCsA3GEQ2TAoKx4Jy3BeUR3o5MVcx+dJDtXfEYDKg6WE/PWzfJF1uZGWgR9Dm2OLITR6w==",
+          "bundled": true,
           "requires": {
             "async": "^2.6.0",
             "bs58": "^4.0.1",
@@ -601,10 +6899,7187 @@
             "tar-stream": "^1.5.5"
           }
         },
+        "ipfs-block": {
+          "version": "0.6.1",
+          "bundled": true,
+          "requires": {
+            "cids": "^0.5.2"
+          }
+        },
+        "ipfs-unixfs": {
+          "version": "0.1.16",
+          "bundled": true,
+          "requires": {
+            "protons": "^1.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.11.4",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.0",
+            "bs58": "^4.0.1",
+            "buffer-loader": "0.0.1",
+            "cids": "~0.5.2",
+            "ipfs-block": "~0.6.1",
+            "is-ipfs": "~0.3.2",
+            "multihashes": "~0.4.12",
+            "multihashing-async": "~0.4.7",
+            "protons": "^1.0.0",
+            "pull-stream": "^3.6.1",
+            "pull-traverse": "^1.0.3",
+            "stable": "^0.1.6"
+          }
+        },
+        "irregular-plurals": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-absolute": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-relative": "^1.0.0",
+            "is-windows": "^1.0.1"
+          }
+        },
+        "is-accessor-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-alphabetical": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-alphanumeric": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-alphanumerical": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "^1.0.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "is-callable": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "is-ci": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ci-info": "^2.0.0"
+          }
+        },
+        "is-data-descriptor": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-decimal": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-descriptor": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "5.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "is-error": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-fn": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "is-function": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-hex-prefixed": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-hexadecimal": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-installed-globally": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "global-dirs": "^0.1.0",
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-ipfs": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "cids": "~0.5.1",
+            "multihashes": "~0.4.9"
+          }
+        },
+        "is-natural-number": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "is-negated-glob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-npm": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "is-obj": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-observable": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "^1.1.0"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "^1.0.1"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "is-promise": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-redirect": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "^1.0.1"
+          }
+        },
+        "is-relative": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-unc-path": "^1.0.0"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-retry-allowed": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-ssh": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "protocols": "^1.1.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "has-symbols": "^1.0.0"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-unc-path": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "unc-path-regex": "^0.1.2"
+          }
+        },
+        "is-url": {
+          "version": "1.2.4",
+          "bundled": true
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-valid-glob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-whitespace-character": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-word-character": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "^1.0.1",
+            "whatwg-fetch": ">=0.10.0"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "isurl": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
+          }
+        },
+        "js-levenshtein": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "js-sha3": {
+          "version": "0.7.0",
+          "bundled": true
+        },
+        "js-string-escape": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.12.1",
+          "bundled": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "jsesc": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "json-rpc-engine": {
+          "version": "3.8.0",
+          "bundled": true,
+          "requires": {
+            "async": "^2.0.1",
+            "babel-preset-env": "^1.7.0",
+            "babelify": "^7.3.0",
+            "json-rpc-error": "^2.0.0",
+            "promise-to-callback": "^1.0.0",
+            "safe-event-emitter": "^1.0.1"
+          }
+        },
+        "json-rpc-error": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1"
+          }
+        },
+        "json-rpc-random-id": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "~0.0.0"
+          }
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "jsprim": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "array-includes": "^3.0.3"
+          }
+        },
+        "just-extend": {
+          "version": "4.0.2",
+          "bundled": true
+        },
+        "keccak": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "keccakjs": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "browserify-sha3": "^0.0.4",
+            "sha3": "^1.2.2"
+          }
+        },
+        "keypair": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "kind-of": {
+          "version": "6.0.2",
+          "bundled": true
+        },
+        "klaw": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.9"
+          }
+        },
+        "latest-version": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "package-json": "^4.0.0"
+          }
+        },
+        "lazystream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.5"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "lead": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "flush-write-stream": "^1.0.2"
+          }
+        },
+        "level-codec": {
+          "version": "7.0.1",
+          "bundled": true
+        },
+        "level-errors": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "errno": "~0.1.1"
+          }
+        },
+        "level-iterator-stream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "level-errors": "^1.0.3",
+            "readable-stream": "^1.0.33",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.1.14",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            }
+          }
+        },
+        "level-ws": {
+          "version": "0.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "~1.0.15",
+            "xtend": "~2.1.1"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "bundled": true,
+              "requires": {
+                "object-keys": "~0.4.0"
+              }
+            }
+          }
+        },
+        "levelup": {
+          "version": "1.3.9",
+          "bundled": true,
+          "requires": {
+            "deferred-leveldown": "~1.2.1",
+            "level-codec": "~7.0.0",
+            "level-errors": "~1.0.3",
+            "level-iterator-stream": "~1.3.0",
+            "prr": "~1.0.1",
+            "semver": "~5.4.1",
+            "xtend": "~4.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "5.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.12.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^5.0.0",
+            "async": "^2.6.0",
+            "browserify-aes": "^1.1.1",
+            "bs58": "^4.0.1",
+            "keypair": "^1.0.1",
+            "libp2p-crypto-secp256k1": "~0.2.2",
+            "multihashing-async": "~0.4.7",
+            "node-forge": "^0.7.1",
+            "pem-jwk": "^1.5.1",
+            "protons": "^1.0.1",
+            "rsa-pem-to-jwk": "^1.1.3",
+            "tweetnacl": "^1.0.0",
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
+          },
+          "dependencies": {
+            "tweetnacl": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "libp2p-crypto-secp256k1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.1",
+            "multihashing-async": "~0.5.1",
+            "nodeify": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "secp256k1": "^3.6.1"
+          },
+          "dependencies": {
+            "js-sha3": {
+              "version": "0.8.0",
+              "bundled": true
+            },
+            "multihashing-async": {
+              "version": "0.5.2",
+              "bundled": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "js-sha3": "~0.8.0",
+                "multihashes": "~0.4.13",
+                "murmurhash3js": "^3.0.1",
+                "nodeify": "^1.0.1"
+              }
+            }
+          }
+        },
+        "lie": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "immediate": "~3.0.5"
+          },
+          "dependencies": {
+            "immediate": {
+              "version": "3.0.6",
+              "bundled": true
+            }
+          }
+        },
+        "livereload-js": {
+          "version": "2.4.0",
+          "bundled": true
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
+          }
+        },
+        "localforage": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "lie": "3.1.1"
+          }
+        },
+        "localforage-memoryStorageDriver": {
+          "version": "0.9.2",
+          "bundled": true,
+          "requires": {
+            "localforage": ">=1.4.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "lodash.clone": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.clonedeepwith": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.debounce": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "lodash.difference": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.filter": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.flatten": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "bundled": true
+        },
+        "lodash.islength": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "lodash.isplainobject": {
+          "version": "4.0.6",
+          "bundled": true
+        },
+        "lodash.map": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.merge": {
+          "version": "4.6.1",
+          "bundled": true
+        },
+        "lodash.some": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.uniqby": {
+          "version": "4.7.0",
+          "bundled": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "lolex": {
+          "version": "2.7.5",
+          "bundled": true
+        },
+        "longest-streak": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "looper": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "loud-rejection": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "currently-unhandled": "^0.4.1",
+            "signal-exit": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "bundled": true,
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "ltgt": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "map-visit": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "object-visit": "^1.0.0"
+          }
+        },
+        "markdown-escapes": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "markdown-table": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "matcher": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "^1.0.4"
+          }
+        },
+        "md5-hex": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "md5-o-matic": "^0.1.1"
+          }
+        },
+        "md5-o-matic": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "md5.js": {
+          "version": "1.3.5",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "mdast-util-compact": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "mdast-util-definitions": {
+          "version": "1.2.3",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "mdast-util-inject": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mdast-util-to-string": "^1.0.0"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "^1.0.0",
+            "detab": "^2.0.0",
+            "mdast-util-definitions": "^1.2.0",
+            "mdurl": "^1.0.1",
+            "trim": "0.0.1",
+            "trim-lines": "^1.0.0",
+            "unist-builder": "^1.0.1",
+            "unist-util-generated": "^1.1.0",
+            "unist-util-position": "^3.0.0",
+            "unist-util-visit": "^1.1.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "mdast-util-toc": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "^1.1.1",
+            "mdast-util-to-string": "^1.0.2",
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "mdurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "mem": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "memdown": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "abstract-leveldown": "~2.7.1",
+            "functional-red-black-tree": "^1.0.1",
+            "immediate": "^3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
+          },
+          "dependencies": {
+            "abstract-leveldown": {
+              "version": "2.7.2",
+              "bundled": true,
+              "requires": {
+                "xtend": "~4.0.0"
+              }
+            }
+          }
+        },
+        "memorystream": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "meow": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "camelcase-keys": "^4.0.0",
+            "decamelize-keys": "^1.0.0",
+            "loud-rejection": "^1.0.0",
+            "minimist-options": "^3.0.1",
+            "normalize-package-data": "^2.3.4",
+            "read-pkg-up": "^3.0.0",
+            "redent": "^2.0.0",
+            "trim-newlines": "^2.0.0",
+            "yargs-parser": "^10.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "4.1.0",
+              "bundled": true
+            },
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "path-type": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "yargs-parser": {
+              "version": "10.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              }
+            }
+          }
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merkle-patricia-tree": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "async": "^1.4.2",
+            "ethereumjs-util": "^5.0.0",
+            "level-ws": "0.0.0",
+            "levelup": "^1.2.1",
+            "memdown": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "rlp": "^2.0.0",
+            "semaphore": ">=1.0.1"
+          },
+          "dependencies": {
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.0",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.38.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.22",
+          "bundled": true,
+          "requires": {
+            "mime-db": "~1.38.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "mimic-response": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "min-document": {
+          "version": "2.19.0",
+          "bundled": true,
+          "requires": {
+            "dom-walk": "^0.1.0"
+          }
+        },
+        "minimalistic-assert": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "minimist-options": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "is-plain-obj": "^1.1.0"
+          }
+        },
+        "mixin-deep": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
+          },
+          "dependencies": {
+            "is-extendable": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "mkdirp-promise": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "*"
+          }
+        },
+        "mock-fs": {
+          "version": "4.8.0",
+          "bundled": true
+        },
+        "module-deps-sortable": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "JSONStream": "^1.0.3",
+            "browser-resolve": "^1.7.0",
+            "cached-path-relative": "^1.0.0",
+            "concat-stream": "~1.5.0",
+            "defined": "^1.0.0",
+            "detective": "^4.0.0",
+            "duplexer2": "^0.1.2",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.2",
+            "resolve": "^1.1.3",
+            "stream-combiner2": "^1.1.1",
+            "subarg": "^1.0.0",
+            "through2": "^2.0.0",
+            "xtend": "^4.0.0"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.5.2",
+              "bundled": true,
+              "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "~2.0.0",
+                "typedarray": "~0.0.5"
+              },
+              "dependencies": {
+                "readable-stream": {
+                  "version": "2.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~1.0.6",
+                    "string_decoder": "~0.10.x",
+                    "util-deprecate": "~1.0.1"
+                  }
+                }
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            }
+          }
+        },
+        "module-not-found-error": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "mout": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "multiaddr": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "ip": "^1.1.5",
+            "lodash.filter": "^4.6.0",
+            "lodash.map": "^4.6.0",
+            "varint": "^5.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "multibase": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "base-x": "3.0.4"
+          },
+          "dependencies": {
+            "base-x": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
+            }
+          }
+        },
+        "multicodec": {
+          "version": "0.2.7",
+          "bundled": true,
+          "requires": {
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "0.4.14",
+          "bundled": true,
+          "requires": {
+            "bs58": "^4.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.4.8",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.0",
+            "blakejs": "^1.1.0",
+            "js-sha3": "^0.7.0",
+            "multihashes": "~0.4.13",
+            "murmurhash3js": "^3.0.1",
+            "nodeify": "^1.0.1"
+          }
+        },
+        "multimatch": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "array-differ": "^2.0.3",
+            "array-union": "^1.0.2",
+            "arrify": "^1.0.1",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "murmurhash3js": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "mz": {
+          "version": "2.7.0",
+          "bundled": true,
+          "requires": {
+            "any-promise": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "thenify-all": "^1.0.0"
+          }
+        },
+        "nan": {
+          "version": "2.12.1",
+          "bundled": true
+        },
+        "nano-json-stream-parser": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "nanomatch": {
+          "version": "1.2.13",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "ndjson": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "json-stringify-safe": "^5.0.1",
+            "minimist": "^1.2.0",
+            "split2": "^2.1.0",
+            "through2": "^2.0.3"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "nise": {
+          "version": "1.4.8",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/formatio": "^3.1.0",
+            "just-extend": "^4.0.2",
+            "lolex": "^2.3.2",
+            "path-to-regexp": "^1.7.0",
+            "text-encoding": "^0.6.4"
+          },
+          "dependencies": {
+            "path-to-regexp": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            }
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        },
+        "node-forge": {
+          "version": "0.7.6",
+          "bundled": true
+        },
+        "node-modules-regexp": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "node-releases": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.3.0"
+          }
+        },
+        "nodeify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "is-promise": "~1.0.0",
+            "promise": "~1.3.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "normalize-url": {
+          "version": "1.9.1",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        },
+        "now-and-later": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.2"
+          }
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "number-to-bn": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "strip-hex-prefix": "1.0.0"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            }
+          }
+        },
+        "nyc": {
+          "version": "11.9.0",
+          "bundled": true,
+          "requires": {
+            "archy": "^1.0.0",
+            "arrify": "^1.0.1",
+            "caching-transform": "^1.0.0",
+            "convert-source-map": "^1.5.1",
+            "debug-log": "^1.0.1",
+            "default-require-extensions": "^1.0.0",
+            "find-cache-dir": "^0.1.1",
+            "find-up": "^2.1.0",
+            "foreground-child": "^1.5.3",
+            "glob": "^7.0.6",
+            "istanbul-lib-coverage": "^1.1.2",
+            "istanbul-lib-hook": "^1.1.0",
+            "istanbul-lib-instrument": "^1.10.0",
+            "istanbul-lib-report": "^1.1.3",
+            "istanbul-lib-source-maps": "^1.2.3",
+            "istanbul-reports": "^1.4.0",
+            "md5-hex": "^1.2.0",
+            "merge-source-map": "^1.1.0",
+            "micromatch": "^3.1.10",
+            "mkdirp": "^0.5.0",
+            "resolve-from": "^2.0.0",
+            "rimraf": "^2.6.2",
+            "signal-exit": "^3.0.1",
+            "spawn-wrap": "^1.4.2",
+            "test-exclude": "^4.2.0",
+            "yargs": "11.1.0",
+            "yargs-parser": "^8.0.0"
+          },
+          "dependencies": {
+            "align-text": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
+              }
+            },
+            "amdefine": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "2.2.1",
+              "bundled": true
+            },
+            "append-transform": {
+              "version": "0.4.0",
+              "bundled": true,
+              "requires": {
+                "default-require-extensions": "^1.0.0"
+              }
+            },
+            "archy": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "arr-diff": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "arr-flatten": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "arr-union": {
+              "version": "3.1.0",
+              "bundled": true
+            },
+            "array-unique": {
+              "version": "0.3.2",
+              "bundled": true
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "assign-symbols": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "async": {
+              "version": "1.5.2",
+              "bundled": true
+            },
+            "atob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "babel-code-frame": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
+              }
+            },
+            "babel-generator": {
+              "version": "6.26.1",
+              "bundled": true,
+              "requires": {
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
+              }
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.22.0"
+              }
+            },
+            "babel-runtime": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+              }
+            },
+            "babel-template": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-traverse": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
+              }
+            },
+            "babel-types": {
+              "version": "6.26.0",
+              "bundled": true,
+              "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+              }
+            },
+            "babylon": {
+              "version": "6.18.0",
+              "bundled": true
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "base": {
+              "version": "0.11.2",
+              "bundled": true,
+              "requires": {
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "braces": {
+              "version": "2.3.2",
+              "bundled": true,
+              "requires": {
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "builtin-modules": {
+              "version": "1.1.1",
+              "bundled": true
+            },
+            "cache-base": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "caching-transform": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "md5-hex": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "write-file-atomic": "^1.1.4"
+              }
+            },
+            "camelcase": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true
+            },
+            "center-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
+              }
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "class-utils": {
+              "version": "0.3.6",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "cliui": {
+              "version": "2.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
+                "wordwrap": "0.0.2"
+              },
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "collection-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
+              }
+            },
+            "commondir": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "bundled": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "convert-source-map": {
+              "version": "1.5.1",
+              "bundled": true
+            },
+            "copy-descriptor": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "core-js": {
+              "version": "2.5.6",
+              "bundled": true
+            },
+            "cross-spawn": {
+              "version": "4.0.2",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
+              }
+            },
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "debug-log": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "decode-uri-component": {
+              "version": "0.2.0",
+              "bundled": true
+            },
+            "default-require-extensions": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "repeating": "^2.0.0"
+              }
+            },
+            "error-ex": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "is-arrayish": "^0.2.1"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "bundled": true
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              },
+              "dependencies": {
+                "cross-spawn": {
+                  "version": "5.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "lru-cache": "^4.0.1",
+                    "shebang-command": "^1.2.0",
+                    "which": "^1.2.9"
+                  }
+                }
+              }
+            },
+            "expand-brackets": {
+              "version": "2.1.4",
+              "bundled": true,
+              "requires": {
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "extend-shallow": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "extglob": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "fill-range": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "find-cache-dir": {
+              "version": "0.1.1",
+              "bundled": true,
+              "requires": {
+                "commondir": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pkg-dir": "^1.0.0"
+              }
+            },
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^2.0.0"
+              }
+            },
+            "for-in": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "foreground-child": {
+              "version": "1.5.6",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^4",
+                "signal-exit": "^3.0.0"
+              }
+            },
+            "fragment-cache": {
+              "version": "0.2.1",
+              "bundled": true,
+              "requires": {
+                "map-cache": "^0.2.2"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "get-caller-file": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "get-value": {
+              "version": "2.0.6",
+              "bundled": true
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "globals": {
+              "version": "9.18.0",
+              "bundled": true
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "handlebars": {
+              "version": "4.0.11",
+              "bundled": true,
+              "requires": {
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.4.4",
+                  "bundled": true,
+                  "requires": {
+                    "amdefine": ">=0.0.4"
+                  }
+                }
+              }
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "has-flag": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "has-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "has-values": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "kind-of": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "^1.1.5"
+                  }
+                }
+              }
+            },
+            "hosted-git-info": {
+              "version": "2.6.0",
+              "bundled": true
+            },
+            "imurmurhash": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "invariant": {
+              "version": "2.2.4",
+              "bundled": true,
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            },
+            "invert-kv": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "is-accessor-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-arrayish": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-buffer": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "is-builtin-module": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "builtin-modules": "^1.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "0.1.4",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "0.1.6",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "5.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-extendable": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "is-finite": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "is-odd": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-number": "^4.0.0"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "4.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "is-plain-object": {
+              "version": "2.0.4",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "is-stream": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "is-utf8": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "is-windows": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isexe": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "isobject": {
+              "version": "3.0.1",
+              "bundled": true
+            },
+            "istanbul-lib-coverage": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "istanbul-lib-hook": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "append-transform": "^0.4.0"
+              }
+            },
+            "istanbul-lib-instrument": {
+              "version": "1.10.1",
+              "bundled": true,
+              "requires": {
+                "babel-generator": "^6.18.0",
+                "babel-template": "^6.16.0",
+                "babel-traverse": "^6.18.0",
+                "babel-types": "^6.18.0",
+                "babylon": "^6.18.0",
+                "istanbul-lib-coverage": "^1.2.0",
+                "semver": "^5.3.0"
+              }
+            },
+            "istanbul-lib-report": {
+              "version": "1.1.3",
+              "bundled": true,
+              "requires": {
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "path-parse": "^1.0.5",
+                "supports-color": "^3.1.2"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "3.2.3",
+                  "bundled": true,
+                  "requires": {
+                    "has-flag": "^1.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-lib-source-maps": {
+              "version": "1.2.3",
+              "bundled": true,
+              "requires": {
+                "debug": "^3.1.0",
+                "istanbul-lib-coverage": "^1.1.2",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.6.1",
+                "source-map": "^0.5.3"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "3.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
+                }
+              }
+            },
+            "istanbul-reports": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "handlebars": "^4.0.3"
+              }
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "bundled": true
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            },
+            "lazy-cache": {
+              "version": "1.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "lcid": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "^1.0.0"
+              }
+            },
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+              },
+              "dependencies": {
+                "path-exists": {
+                  "version": "3.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.10",
+              "bundled": true
+            },
+            "longest": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "js-tokens": "^3.0.0"
+              }
+            },
+            "lru-cache": {
+              "version": "4.1.3",
+              "bundled": true,
+              "requires": {
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
+              }
+            },
+            "map-cache": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "map-visit": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "object-visit": "^1.0.0"
+              }
+            },
+            "md5-hex": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "md5-o-matic": "^0.1.1"
+              }
+            },
+            "md5-o-matic": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "mem": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "^1.0.0"
+              }
+            },
+            "merge-source-map": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "source-map": "^0.6.1"
+              },
+              "dependencies": {
+                "source-map": {
+                  "version": "0.6.1",
+                  "bundled": true
+                }
+              }
+            },
+            "micromatch": {
+              "version": "3.1.10",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "mimic-fn": {
+              "version": "1.2.0",
+              "bundled": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mixin-deep": {
+              "version": "1.3.1",
+              "bundled": true,
+              "requires": {
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
+              },
+              "dependencies": {
+                "is-extendable": {
+                  "version": "1.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-plain-object": "^2.0.4"
+                  }
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "nanomatch": {
+              "version": "1.2.9",
+              "bundled": true,
+              "requires": {
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "bundled": true,
+              "requires": {
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+              }
+            },
+            "npm-run-path": {
+              "version": "2.0.2",
+              "bundled": true,
+              "requires": {
+                "path-key": "^2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true
+            },
+            "object-copy": {
+              "version": "0.1.0",
+              "bundled": true,
+              "requires": {
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "object-visit": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "object.pick": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isobject": "^3.0.1"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "os-locale": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
+              }
+            },
+            "p-finally": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "p-limit": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^1.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^1.1.0"
+              }
+            },
+            "p-try": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "parse-json": {
+              "version": "2.2.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.2.0"
+              }
+            },
+            "pascalcase": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "path-key": {
+              "version": "2.0.1",
+              "bundled": true
+            },
+            "path-parse": {
+              "version": "1.0.5",
+              "bundled": true
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "pify": {
+              "version": "2.3.0",
+              "bundled": true
+            },
+            "pinkie": {
+              "version": "2.0.4",
+              "bundled": true
+            },
+            "pinkie-promise": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "pinkie": "^2.0.0"
+              }
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "posix-character-classes": {
+              "version": "0.1.1",
+              "bundled": true
+            },
+            "pseudomap": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
+              },
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "path-exists": "^2.0.0",
+                    "pinkie-promise": "^2.0.0"
+                  }
+                }
+              }
+            },
+            "regenerator-runtime": {
+              "version": "0.11.1",
+              "bundled": true
+            },
+            "regex-not": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "repeat-element": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "repeat-string": {
+              "version": "1.6.1",
+              "bundled": true
+            },
+            "repeating": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-finite": "^1.0.0"
+              }
+            },
+            "require-directory": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "require-main-filename": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "resolve-from": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "resolve-url": {
+              "version": "0.2.1",
+              "bundled": true
+            },
+            "ret": {
+              "version": "0.1.15",
+              "bundled": true
+            },
+            "right-align": {
+              "version": "0.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "align-text": "^0.1.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.2",
+              "bundled": true,
+              "requires": {
+                "glob": "^7.0.5"
+              }
+            },
+            "safe-regex": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "ret": "~0.1.10"
+              }
+            },
+            "semver": {
+              "version": "5.5.0",
+              "bundled": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "set-value": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "shebang-command": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "shebang-regex": "^1.0.0"
+              }
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true
+            },
+            "slide": {
+              "version": "1.1.6",
+              "bundled": true
+            },
+            "snapdragon": {
+              "version": "0.8.2",
+              "bundled": true,
+              "requires": {
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                },
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "snapdragon-node": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^1.0.0"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "snapdragon-util": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.2.0"
+              }
+            },
+            "source-map": {
+              "version": "0.5.7",
+              "bundled": true
+            },
+            "source-map-resolve": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "atob": "^2.0.0",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
+              }
+            },
+            "source-map-url": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "spawn-wrap": {
+              "version": "1.4.2",
+              "bundled": true,
+              "requires": {
+                "foreground-child": "^1.5.6",
+                "mkdirp": "^0.5.0",
+                "os-homedir": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "signal-exit": "^3.0.2",
+                "which": "^1.3.0"
+              }
+            },
+            "spdx-correct": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-exceptions": {
+              "version": "2.1.0",
+              "bundled": true
+            },
+            "spdx-expression-parse": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+              }
+            },
+            "spdx-license-ids": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "split-string": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^3.0.0"
+              }
+            },
+            "static-extend": {
+              "version": "0.1.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
+              },
+              "dependencies": {
+                "define-property": {
+                  "version": "0.2.5",
+                  "bundled": true,
+                  "requires": {
+                    "is-descriptor": "^0.1.0"
+                  }
+                }
+              }
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "^0.2.0"
+              }
+            },
+            "strip-eof": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "test-exclude": {
+              "version": "4.2.1",
+              "bundled": true,
+              "requires": {
+                "arrify": "^1.0.1",
+                "micromatch": "^3.1.8",
+                "object-assign": "^4.1.0",
+                "read-pkg-up": "^1.0.1",
+                "require-main-filename": "^1.0.1"
+              },
+              "dependencies": {
+                "arr-diff": {
+                  "version": "4.0.0",
+                  "bundled": true
+                },
+                "array-unique": {
+                  "version": "0.3.2",
+                  "bundled": true
+                },
+                "braces": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "arr-flatten": "^1.1.0",
+                    "array-unique": "^0.3.2",
+                    "extend-shallow": "^2.0.1",
+                    "fill-range": "^4.0.0",
+                    "isobject": "^3.0.1",
+                    "repeat-element": "^1.1.2",
+                    "snapdragon": "^0.8.1",
+                    "snapdragon-node": "^2.0.1",
+                    "split-string": "^3.0.2",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "debug": "^2.3.3",
+                    "define-property": "^0.2.5",
+                    "extend-shallow": "^2.0.1",
+                    "posix-character-classes": "^0.1.0",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "0.2.5",
+                      "bundled": true,
+                      "requires": {
+                        "is-descriptor": "^0.1.0"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    },
+                    "is-accessor-descriptor": {
+                      "version": "0.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "^3.0.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "^1.1.5"
+                          }
+                        }
+                      }
+                    },
+                    "is-data-descriptor": {
+                      "version": "0.1.4",
+                      "bundled": true,
+                      "requires": {
+                        "kind-of": "^3.0.2"
+                      },
+                      "dependencies": {
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "bundled": true,
+                          "requires": {
+                            "is-buffer": "^1.1.5"
+                          }
+                        }
+                      }
+                    },
+                    "is-descriptor": {
+                      "version": "0.1.6",
+                      "bundled": true,
+                      "requires": {
+                        "is-accessor-descriptor": "^0.1.6",
+                        "is-data-descriptor": "^0.1.4",
+                        "kind-of": "^5.0.0"
+                      }
+                    },
+                    "kind-of": {
+                      "version": "5.1.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "2.0.4",
+                  "bundled": true,
+                  "requires": {
+                    "array-unique": "^0.3.2",
+                    "define-property": "^1.0.0",
+                    "expand-brackets": "^2.1.4",
+                    "extend-shallow": "^2.0.1",
+                    "fragment-cache": "^0.2.1",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.1"
+                  },
+                  "dependencies": {
+                    "define-property": {
+                      "version": "1.0.0",
+                      "bundled": true,
+                      "requires": {
+                        "is-descriptor": "^1.0.0"
+                      }
+                    },
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "fill-range": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-number": "^3.0.0",
+                    "repeat-string": "^1.6.1",
+                    "to-regex-range": "^2.1.0"
+                  },
+                  "dependencies": {
+                    "extend-shallow": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "is-extendable": "^0.1.0"
+                      }
+                    }
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^6.0.0"
+                  }
+                },
+                "is-descriptor": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
+                  }
+                },
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "is-buffer": "^1.1.5"
+                      }
+                    }
+                  }
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                },
+                "micromatch": {
+                  "version": "3.1.10",
+                  "bundled": true,
+                  "requires": {
+                    "arr-diff": "^4.0.0",
+                    "array-unique": "^0.3.2",
+                    "braces": "^2.3.1",
+                    "define-property": "^2.0.2",
+                    "extend-shallow": "^3.0.2",
+                    "extglob": "^2.0.4",
+                    "fragment-cache": "^0.2.1",
+                    "kind-of": "^6.0.2",
+                    "nanomatch": "^1.2.9",
+                    "object.pick": "^1.3.0",
+                    "regex-not": "^1.0.0",
+                    "snapdragon": "^0.8.1",
+                    "to-regex": "^3.0.2"
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "bundled": true
+            },
+            "to-object-path": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^3.0.2"
+              }
+            },
+            "to-regex": {
+              "version": "3.0.2",
+              "bundled": true,
+              "requires": {
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
+              }
+            },
+            "to-regex-range": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
+              },
+              "dependencies": {
+                "is-number": {
+                  "version": "3.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "kind-of": "^3.0.2"
+                  }
+                }
+              }
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "uglify-js": {
+              "version": "2.8.29",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
+              },
+              "dependencies": {
+                "yargs": {
+                  "version": "3.10.0",
+                  "bundled": true,
+                  "optional": true,
+                  "requires": {
+                    "camelcase": "^1.0.2",
+                    "cliui": "^2.1.0",
+                    "decamelize": "^1.0.0",
+                    "window-size": "0.1.0"
+                  }
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "union-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
+              },
+              "dependencies": {
+                "extend-shallow": {
+                  "version": "2.0.1",
+                  "bundled": true,
+                  "requires": {
+                    "is-extendable": "^0.1.0"
+                  }
+                },
+                "set-value": {
+                  "version": "0.4.3",
+                  "bundled": true,
+                  "requires": {
+                    "extend-shallow": "^2.0.1",
+                    "is-extendable": "^0.1.1",
+                    "is-plain-object": "^2.0.1",
+                    "to-object-path": "^0.3.0"
+                  }
+                }
+              }
+            },
+            "unset-value": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
+              },
+              "dependencies": {
+                "has-value": {
+                  "version": "0.3.1",
+                  "bundled": true,
+                  "requires": {
+                    "get-value": "^2.0.3",
+                    "has-values": "^0.1.4",
+                    "isobject": "^2.0.0"
+                  },
+                  "dependencies": {
+                    "isobject": {
+                      "version": "2.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "isarray": "1.0.0"
+                      }
+                    }
+                  }
+                },
+                "has-values": {
+                  "version": "0.1.4",
+                  "bundled": true
+                },
+                "isobject": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "urix": {
+              "version": "0.1.0",
+              "bundled": true
+            },
+            "use": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "6.0.2",
+                  "bundled": true
+                }
+              }
+            },
+            "validate-npm-package-license": {
+              "version": "3.0.3",
+              "bundled": true,
+              "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+              }
+            },
+            "which": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "isexe": "^2.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "window-size": {
+              "version": "0.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "wordwrap": {
+              "version": "0.0.3",
+              "bundled": true
+            },
+            "wrap-ansi": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
+              },
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "number-is-nan": "^1.0.0"
+                  }
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "write-file-atomic": {
+              "version": "1.3.4",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
+              }
+            },
+            "y18n": {
+              "version": "3.2.1",
+              "bundled": true
+            },
+            "yallist": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "11.1.0",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              },
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                },
+                "cliui": {
+                  "version": "4.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "string-width": "^2.1.1",
+                    "strip-ansi": "^4.0.0",
+                    "wrap-ansi": "^2.0.0"
+                  }
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "bundled": true,
+                  "requires": {
+                    "ansi-regex": "^3.0.0"
+                  }
+                },
+                "yargs-parser": {
+                  "version": "9.0.2",
+                  "bundled": true,
+                  "requires": {
+                    "camelcase": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "yargs-parser": {
+              "version": "8.1.0",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^4.1.0"
+              },
+              "dependencies": {
+                "camelcase": {
+                  "version": "4.1.0",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-copy": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "object-inspect": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "object-visit": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.0"
+          }
+        },
+        "object.assign": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "function-bind": "^1.1.1",
+            "has-symbols": "^1.0.0",
+            "object-keys": "^1.0.11"
+          },
+          "dependencies": {
+            "object-keys": {
+              "version": "1.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "object.pick": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "oboe": {
+          "version": "2.1.3",
+          "bundled": true,
+          "requires": {
+            "http-https": "^1.0.0"
+          }
+        },
+        "observable-to-promise": {
+          "version": "0.5.0",
+          "bundled": true,
+          "requires": {
+            "is-observable": "^0.2.0",
+            "symbol-observable": "^1.0.4"
+          },
+          "dependencies": {
+            "is-observable": {
+              "version": "0.2.0",
+              "bundled": true,
+              "requires": {
+                "symbol-observable": "^0.2.2"
+              },
+              "dependencies": {
+                "symbol-observable": {
+                  "version": "0.2.4",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "optimist": {
+          "version": "0.3.7",
+          "bundled": true,
+          "requires": {
+            "wordwrap": "~0.0.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.4",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "wordwrap": "~1.0.0"
+          },
+          "dependencies": {
+            "wordwrap": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "ora": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^1.3.1",
+            "log-symbols": "^2.2.0",
+            "strip-ansi": "^5.0.0",
+            "wcwidth": "^1.0.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^4.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ordered-read-streams": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^2.0.1"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lcid": "^1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "is-plain-obj": "^1.1.0",
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "p-cancelable": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "p-is-promise": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "p-timeout": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "p-finally": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "package-hash": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
+            "lodash.flattendeep": "^4.4.0",
+            "release-zalgo": "^1.0.0"
+          }
+        },
+        "package-json": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "got": "^6.7.1",
+            "registry-auth-token": "^3.0.1",
+            "registry-url": "^3.0.3",
+            "semver": "^5.1.0"
+          }
+        },
+        "pako": {
+          "version": "1.0.8",
+          "bundled": true
+        },
+        "parse-asn1": {
+          "version": "5.1.4",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3",
+            "safe-buffer": "^5.1.1"
+          },
+          "dependencies": {
+            "asn1.js": {
+              "version": "4.10.1",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+              }
+            }
+          }
+        },
+        "parse-entities": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "character-entities": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "character-reference-invalid": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "parse-filepath": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "is-absolute": "^1.0.0",
+            "map-cache": "^0.2.0",
+            "path-root": "^0.1.1"
+          }
+        },
+        "parse-git-config": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "ini": "^1.3.3"
+          }
+        },
+        "parse-headers": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-each": "^0.3.2",
+            "trim": "0.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "parse-ms": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "parse-path": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "is-ssh": "^1.3.0",
+            "protocols": "^1.4.0"
+          }
+        },
+        "parse-url": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "is-ssh": "^1.3.0",
+            "normalize-url": "^1.9.1",
+            "parse-path": "^3.0.1",
+            "protocols": "^1.4.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "pascalcase": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "path-parse": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "path-root": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "path-root-regex": "^0.1.0"
+          }
+        },
+        "path-root-regex": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "pbkdf2": {
+          "version": "3.0.17",
+          "bundled": true,
+          "requires": {
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
+          }
+        },
+        "peer-id": {
+          "version": "0.10.7",
+          "bundled": true,
+          "requires": {
+            "async": "^2.6.0",
+            "libp2p-crypto": "~0.12.1",
+            "lodash": "^4.17.5",
+            "multihashes": "~0.4.13"
+          }
+        },
+        "peer-info": {
+          "version": "0.11.6",
+          "bundled": true,
+          "requires": {
+            "lodash.uniqby": "^4.7.0",
+            "multiaddr": "^3.0.2",
+            "peer-id": "~0.10.5"
+          }
+        },
+        "pem-jwk": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "1.0.3"
+          },
+          "dependencies": {
+            "asn1.js": {
+              "version": "1.0.3",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+              }
+            },
+            "bn.js": {
+              "version": "1.3.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "pend": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "^2.0.0"
+          }
+        },
+        "pirates": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "node-modules-regexp": "^1.0.0"
+          }
+        },
+        "pkg-conf": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "load-json-file": "^4.0.0"
+          },
+          "dependencies": {
+            "load-json-file": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
+              }
+            },
+            "parse-json": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
+              }
+            },
+            "pify": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-bom": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "pkg-config": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "debug-log": "^1.0.0",
+            "find-root": "^1.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "pkg-dir": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "^2.1.0"
+          }
+        },
+        "plur": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "irregular-plurals": "^2.0.0"
+          }
+        },
+        "pluralize": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "posix-character-classes": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "prepend-http": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "pretty-ms": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "parse-ms": "^2.0.0"
+          }
+        },
+        "private": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "promise": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "~1"
+          }
+        },
+        "promise-to-callback": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fn": "^1.0.0",
+            "set-immediate-shim": "^1.0.1"
+          }
+        },
+        "promisify-es6": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "property-information": {
+          "version": "4.2.0",
+          "bundled": true,
+          "requires": {
+            "xtend": "^4.0.1"
+          }
+        },
+        "protocol-buffers-schema": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "protocols": {
+          "version": "1.4.7",
+          "bundled": true
+        },
+        "protons": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "protocol-buffers-schema": "^3.3.1",
+            "safe-buffer": "^5.1.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "proxy-addr": {
+          "version": "2.0.4",
+          "bundled": true,
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.8.0"
+          }
+        },
+        "proxyquire": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "fill-keys": "^1.0.2",
+            "module-not-found-error": "^1.0.0",
+            "resolve": "~1.8.1"
+          },
+          "dependencies": {
+            "resolve": {
+              "version": "1.8.1",
+              "bundled": true,
+              "requires": {
+                "path-parse": "^1.0.5"
+              }
+            }
+          }
+        },
+        "prr": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pseudomap": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "psl": {
+          "version": "1.1.31",
+          "bundled": true
+        },
+        "public-encrypt": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
+          }
+        },
+        "pull-defer": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "pull-pushable": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "pull-stream": {
+          "version": "3.6.9",
+          "bundled": true
+        },
+        "pull-traverse": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "pump": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "pumpify": {
+          "version": "1.5.1",
+          "bundled": true,
+          "requires": {
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        },
+        "quick-lru": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "radspec": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "bn.js": "4.11.6",
+            "date-fns": "2.0.0-alpha.22",
+            "web3-eth": "1.0.0-beta.33",
+            "web3-eth-abi": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            }
+          }
+        },
+        "randombytes": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomfill": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "randomhex": {
+          "version": "0.1.5",
+          "bundled": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bytes": "1",
+            "string_decoder": "0.10"
+          }
+        },
+        "rc": {
+          "version": "1.2.8",
+          "bundled": true,
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "react-is": {
+          "version": "16.8.2",
+          "bundled": true
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "pinkie-promise": "^2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "bundled": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            }
+          }
+        },
+        "readdirp": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "indent-string": "^3.0.0",
+            "strip-indent": "^2.0.0"
+          }
+        },
+        "regenerate": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "regenerate-unicode-properties": {
+          "version": "7.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.4.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.10.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
+          }
+        },
+        "regex-not": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "regexp-tree": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "cli-table3": "^0.5.0",
+            "colors": "^1.1.2",
+            "yargs": "^12.0.5"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "camelcase": {
+              "version": "5.0.0",
+              "bundled": true
+            },
+            "cliui": {
+              "version": "4.1.0",
+              "bundled": true,
+              "requires": {
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
+              }
+            },
+            "find-up": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "invert-kv": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "lcid": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "invert-kv": "^2.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "os-locale": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "p-try": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "which-module": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "yargs": {
+              "version": "12.0.5",
+              "bundled": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
+              }
+            },
+            "yargs-parser": {
+              "version": "11.1.1",
+              "bundled": true,
+              "requires": {
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
+              }
+            }
+          }
+        },
+        "regexpp": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
+          }
+        },
+        "registry-auth-token": {
+          "version": "3.3.2",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.1.6",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "registry-url": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "rc": "^1.0.1"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "~0.5.0"
+          }
+        },
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es6-error": "^4.0.1"
+          }
+        },
+        "remark": {
+          "version": "9.0.0",
+          "bundled": true,
+          "requires": {
+            "remark-parse": "^5.0.0",
+            "remark-stringify": "^5.0.0",
+            "unified": "^6.0.0"
+          }
+        },
+        "remark-html": {
+          "version": "8.0.0",
+          "bundled": true,
+          "requires": {
+            "hast-util-sanitize": "^1.0.0",
+            "hast-util-to-html": "^4.0.0",
+            "mdast-util-to-hast": "^3.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-parse": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-reference-links": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "remark-slug": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "^1.0.0",
+            "mdast-util-to-string": "^1.0.0",
+            "unist-util-visit": "^1.0.0"
+          }
+        },
+        "remark-stringify": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "ccount": "^1.0.0",
+            "is-alphanumeric": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "longest-streak": "^2.0.1",
+            "markdown-escapes": "^1.0.0",
+            "markdown-table": "^1.1.0",
+            "mdast-util-compact": "^1.0.0",
+            "parse-entities": "^1.0.2",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "stringify-entities": "^1.0.1",
+            "unherit": "^1.0.4",
+            "xtend": "^4.0.1"
+          }
+        },
+        "remark-toc": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "mdast-util-toc": "^3.0.0",
+            "remark-slug": "^5.0.0"
+          }
+        },
+        "remote-origin-url": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "parse-git-config": "^0.2.0"
+          }
+        },
+        "remove-bom-buffer": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "^1.1.5",
+            "is-utf8": "^0.2.1"
+          }
+        },
+        "remove-bom-stream": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "remove-bom-buffer": "^3.0.0",
+            "safe-buffer": "^5.1.0",
+            "through2": "^2.0.3"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "^1.0.0"
+          }
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.88.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.0",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.4.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-precompiled": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "^0.1.0",
+            "resolve-from": "^1.0.0"
+          },
+          "dependencies": {
+            "resolve-from": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-cwd": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "resolve-from": "^3.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "resolve-options": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "value-or-function": "^3.0.0"
+          }
+        },
+        "resolve-url": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "bundled": true,
+          "requires": {
+            "through": "~2.3.4"
+          }
+        },
+        "ret": {
+          "version": "0.1.15",
+          "bundled": true
+        },
+        "rimraf": {
+          "version": "2.6.3",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "ripemd160": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
+          }
+        },
+        "rlp": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "^4.11.1",
+            "safe-buffer": "^5.1.1"
+          }
+        },
+        "rsa-pem-to-jwk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^2.0.0",
+            "rsa-unpack": "0.0.6"
+          },
+          "dependencies": {
+            "object-assign": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "rsa-unpack": {
+          "version": "0.0.6",
+          "bundled": true,
+          "requires": {
+            "optimist": "~0.3.5"
+          }
+        },
+        "run-async": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "is-promise": "^2.1.0"
+          },
+          "dependencies": {
+            "is-promise": {
+              "version": "2.1.0",
+              "bundled": true
+            }
+          }
+        },
+        "run-parallel": {
+          "version": "1.1.9",
+          "bundled": true
+        },
+        "rustbn.js": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "rxjs": {
+          "version": "5.5.12",
+          "bundled": true,
+          "requires": {
+            "symbol-observable": "1.0.1"
+          },
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true
+        },
+        "safe-event-emitter": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "events": "^3.0.0"
+          }
+        },
+        "safe-json-parse": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "safe-regex": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "ret": "~0.1.10"
+          }
+        },
+        "safer-buffer": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "scrypt": {
+          "version": "6.0.3",
+          "bundled": true,
+          "requires": {
+            "nan": "^2.0.8"
+          }
+        },
+        "scrypt.js": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
+          }
+        },
+        "scryptsy": {
+          "version": "1.2.1",
+          "bundled": true,
+          "requires": {
+            "pbkdf2": "^3.0.3"
+          }
+        },
+        "secp256k1": {
+          "version": "3.6.2",
+          "bundled": true,
+          "requires": {
+            "bindings": "^1.2.1",
+            "bip66": "^1.1.3",
+            "bn.js": "^4.11.3",
+            "create-hash": "^1.1.2",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.2.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
+          }
+        },
+        "seek-bzip": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "commander": "~2.8.1"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "bundled": true,
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            }
+          }
+        },
+        "semaphore": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.6.0",
+          "bundled": true
+        },
+        "semver-diff": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^5.0.3"
+          }
+        },
+        "send": {
+          "version": "0.16.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "mime": {
+              "version": "1.4.1",
+              "bundled": true
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "statuses": {
+              "version": "1.4.0",
+              "bundled": true
+            }
+          }
+        },
+        "serialize-error": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "serve-static": {
+          "version": "1.13.2",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.2"
+          }
+        },
+        "servify": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "body-parser": "^1.16.0",
+            "cors": "^2.8.1",
+            "express": "^4.14.0",
+            "request": "^2.79.0",
+            "xhr": "^2.3.3"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "set-value": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "setimmediate": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.11",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "sha3": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "nan": "2.10.0"
+          },
+          "dependencies": {
+            "nan": {
+              "version": "2.10.0",
+              "bundled": true
+            }
+          }
+        },
+        "shebang-command": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "shebang-regex": "^1.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "signed-varint": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "varint": "~5.0.0"
+          }
+        },
+        "simple-concat": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "simple-get": {
+          "version": "2.8.1",
+          "bundled": true,
+          "requires": {
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
+          }
+        },
+        "sinon": {
+          "version": "6.3.5",
+          "bundled": true,
+          "requires": {
+            "@sinonjs/commons": "^1.0.2",
+            "@sinonjs/formatio": "^3.0.0",
+            "@sinonjs/samsam": "^2.1.2",
+            "diff": "^3.5.0",
+            "lodash.get": "^4.4.2",
+            "lolex": "^2.7.5",
+            "nise": "^1.4.5",
+            "supports-color": "^5.5.0",
+            "type-detect": "^4.0.8"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "3.5.0",
+              "bundled": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "slide": {
+          "version": "1.1.6",
+          "bundled": true
+        },
+        "snapdragon": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            },
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "snapdragon-node": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^1.0.0"
+              }
+            },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "^6.0.0"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
+              }
+            }
+          }
+        },
+        "snapdragon-util": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.2.0"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "solc": {
+          "version": "0.4.25",
+          "bundled": true,
+          "requires": {
+            "fs-extra": "^0.30.0",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^1.1.0",
+            "semver": "^5.3.0",
+            "yargs": "^4.7.1"
+          }
+        },
+        "solidity-parser-antlr": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "sort-keys": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "is-plain-obj": "^1.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "bundled": true
+        },
+        "source-map-resolve": {
+          "version": "0.5.2",
+          "bundled": true,
+          "requires": {
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
+          }
+        },
+        "source-map-support": {
+          "version": "0.4.18",
+          "bundled": true,
+          "requires": {
+            "source-map": "^0.5.6"
+          }
+        },
+        "source-map-url": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "space-separated-tokens": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "spdx-correct": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-exceptions": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
+          }
+        },
+        "spdx-license-ids": {
+          "version": "3.0.3",
+          "bundled": true
+        },
+        "split-string": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "^3.0.0"
+          }
+        },
+        "split2": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.2"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.16.1",
+          "bundled": true,
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
+          }
+        },
+        "stable": {
+          "version": "0.1.8",
+          "bundled": true
+        },
+        "stack-utils": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "standard": {
+          "version": "12.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint": "~5.4.0",
+            "eslint-config-standard": "12.0.0",
+            "eslint-config-standard-jsx": "6.0.2",
+            "eslint-plugin-import": "~2.14.0",
+            "eslint-plugin-node": "~7.0.1",
+            "eslint-plugin-promise": "~4.0.0",
+            "eslint-plugin-react": "~7.11.1",
+            "eslint-plugin-standard": "~4.0.0",
+            "standard-engine": "~9.0.0"
+          }
+        },
+        "standard-engine": {
+          "version": "9.0.0",
+          "bundled": true,
+          "requires": {
+            "deglob": "^2.1.0",
+            "get-stdin": "^6.0.0",
+            "minimist": "^1.1.0",
+            "pkg-conf": "^2.0.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "state-toggle": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "static-extend": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
+          },
+          "dependencies": {
+            "define-property": {
+              "version": "0.2.5",
+              "bundled": true,
+              "requires": {
+                "is-descriptor": "^0.1.0"
+              }
+            }
+          }
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "stream-array": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "~2.1.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "^1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
+              }
+            }
+          }
+        },
+        "stream-combiner2": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "duplexer2": "~0.1.0",
+            "readable-stream": "^2.0.2"
+          }
+        },
+        "stream-http": {
+          "version": "2.8.3",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "stream-to-pull-stream": {
+          "version": "1.7.2",
+          "bundled": true,
+          "requires": {
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
+          }
+        },
+        "streamifier": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "bundled": true
+        },
+        "stringify-entities": {
+          "version": "1.3.2",
+          "bundled": true,
+          "requires": {
+            "character-entities-html4": "^1.0.0",
+            "character-entities-legacy": "^1.0.0",
+            "is-alphanumerical": "^1.0.0",
+            "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "^0.2.0"
+          }
+        },
+        "strip-bom-buf": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-utf8": "^0.2.1"
+          }
+        },
+        "strip-dirs": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "is-natural-number": "^4.0.1"
+          }
+        },
+        "strip-eof": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "strip-hex-prefix": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-hex-prefixed": "1.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "minimist": "^1.1.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "supertap": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "^1.0.1",
+            "indent-string": "^3.2.0",
+            "js-yaml": "^3.10.0",
+            "serialize-error": "^2.1.0",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "swarm-js": {
+          "version": "0.1.37",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^2.1.2",
+            "fs-promise": "^2.0.0",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar.gz": "^1.0.5",
+            "xhr-request-promise": "^0.1.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "2.1.2",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "got": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "table": {
+          "version": "4.0.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "^6.0.1",
+            "ajv-keywords": "^3.0.0",
+            "chalk": "^2.1.0",
+            "lodash": "^4.17.4",
+            "slice-ansi": "1.0.0",
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "tape": {
+          "version": "4.10.1",
+          "bundled": true,
+          "requires": {
+            "deep-equal": "~1.0.1",
+            "defined": "~1.0.0",
+            "for-each": "~0.3.3",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.3",
+            "has": "~1.0.3",
+            "inherits": "~2.0.3",
+            "minimist": "~1.2.0",
+            "object-inspect": "~1.6.0",
+            "resolve": "~1.10.0",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.1.2",
+            "through": "~2.3.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
+          }
+        },
+        "tar-stream": {
+          "version": "1.6.2",
+          "bundled": true,
+          "requires": {
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.2.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.1",
+            "xtend": "^4.0.0"
+          }
+        },
+        "tar.gz": {
+          "version": "1.0.7",
+          "bundled": true,
+          "requires": {
+            "bluebird": "^2.9.34",
+            "commander": "^2.8.1",
+            "fstream": "^1.0.8",
+            "mout": "^0.11.0",
+            "tar": "^2.1.1"
+          },
+          "dependencies": {
+            "bluebird": {
+              "version": "2.11.0",
+              "bundled": true
+            }
+          }
+        },
+        "term-size": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "execa": "^0.7.0"
+          },
+          "dependencies": {
+            "cross-spawn": {
+              "version": "5.1.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
+              }
+            },
+            "execa": {
+              "version": "0.7.0",
+              "bundled": true,
+              "requires": {
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
+              }
+            },
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "text-encoding": {
+          "version": "0.6.4",
+          "bundled": true
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "thenify": {
+          "version": "3.3.0",
+          "bundled": true,
+          "requires": {
+            "any-promise": "^1.0.0"
+          }
+        },
+        "thenify-all": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "thenify": ">= 3.1.0 < 4"
+          }
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        },
+        "through2-filter": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "~2.0.0",
+            "xtend": "~4.0.0"
+          }
+        },
+        "time-zone": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "timed-out": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "tiny-lr": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "body": "^5.1.0",
+            "debug": "^3.1.0",
+            "faye-websocket": "~0.10.0",
+            "livereload-js": "^2.3.0",
+            "object-assign": "^4.1.0",
+            "qs": "^6.4.0"
+          }
+        },
+        "tmp": {
+          "version": "0.0.33",
+          "bundled": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        },
+        "to-absolute-glob": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "is-absolute": "^1.0.0",
+            "is-negated-glob": "^1.0.0"
+          }
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-buffer": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "to-object-path": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "to-regex": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        },
+        "to-through": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "^2.0.3"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "bundled": true,
+          "requires": {
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true
+            }
+          }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "trim-lines": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "trim-off-newlines": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-trailing-lines": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "trough": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "truffle-flattener": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "@resolver-engine/imports-fs": "^0.2.2",
+            "find-up": "^2.1.0",
+            "mkdirp": "^0.5.1",
+            "solidity-parser-antlr": "^0.4.0",
+            "tsort": "0.0.1"
+          }
+        },
+        "truffle-hdwallet-provider": {
+          "version": "0.0.3",
+          "bundled": true,
+          "requires": {
+            "bip39": "^2.2.0",
+            "ethereumjs-wallet": "^0.6.0",
+            "web3": "^0.18.2",
+            "web3-provider-engine": "^8.4.0"
+          },
+          "dependencies": {
+            "utf8": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "web3": {
+              "version": "0.18.4",
+              "bundled": true,
+              "requires": {
+                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+                "crypto-js": "^3.1.4",
+                "utf8": "^2.1.1",
+                "xhr2": "*",
+                "xmlhttprequest": "*"
+              }
+            }
+          }
+        },
+        "truffle-hdwallet-provider-privkey": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "ethereumjs-tx": "^1.3.4",
+            "ethereumjs-wallet": "^0.6.0",
+            "web3": "^0.20.6",
+            "web3-provider-engine": "^13.8.0"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+              "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+              "bundled": true
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "utf8": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "web3": {
+              "version": "0.20.7",
+              "bundled": true,
+              "requires": {
+                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
+                "crypto-js": "^3.1.4",
+                "utf8": "^2.1.1",
+                "xhr2-cookies": "^1.1.0",
+                "xmlhttprequest": "*"
+              }
+            },
+            "web3-provider-engine": {
+              "version": "13.8.0",
+              "bundled": true,
+              "requires": {
+                "async": "^2.5.0",
+                "clone": "^2.0.0",
+                "eth-block-tracker": "^2.2.2",
+                "eth-sig-util": "^1.4.2",
+                "ethereumjs-block": "^1.2.2",
+                "ethereumjs-tx": "^1.2.0",
+                "ethereumjs-util": "^5.1.1",
+                "ethereumjs-vm": "^2.0.2",
+                "fetch-ponyfill": "^4.0.0",
+                "json-rpc-error": "^2.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "promise-to-callback": "^1.0.0",
+                "readable-stream": "^2.2.9",
+                "request": "^2.67.0",
+                "semaphore": "^1.0.3",
+                "solc": "^0.4.2",
+                "tape": "^4.4.0",
+                "xhr": "^2.2.0",
+                "xtend": "^4.0.1"
+              }
+            }
+          }
+        },
+        "tsort": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        },
+        "type-detect": {
+          "version": "4.0.8",
+          "bundled": true
+        },
+        "type-is": {
+          "version": "1.6.16",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.18"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "typedarray-to-buffer": {
+          "version": "3.1.5",
+          "bundled": true,
+          "requires": {
+            "is-typedarray": "^1.0.0"
+          }
+        },
+        "uid2": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "ultron": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unbzip2-stream": {
+          "version": "1.3.3",
+          "bundled": true,
+          "requires": {
+            "buffer": "^5.2.1",
+            "through": "^2.3.8"
+          }
+        },
+        "unc-path-regex": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "bundled": true
+        },
+        "unherit": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.1",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unicode-canonical-property-names-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "unicode-match-property-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "unicode-canonical-property-names-ecmascript": "^1.0.4",
+            "unicode-property-aliases-ecmascript": "^1.0.4"
+          }
+        },
+        "unicode-match-property-value-ecmascript": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "unicode-property-aliases-ecmascript": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "unified": {
+          "version": "6.2.0",
+          "bundled": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^2.0.0",
+            "x-is-string": "^0.1.0"
+          },
+          "dependencies": {
+            "vfile": {
+              "version": "2.3.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "^1.1.4",
+                "replace-ext": "1.0.0",
+                "unist-util-stringify-position": "^1.0.0",
+                "vfile-message": "^1.0.0"
+              }
+            }
+          }
+        },
+        "union-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            },
+            "set-value": {
+              "version": "0.4.3",
+              "bundled": true,
+              "requires": {
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
+              }
+            }
+          }
+        },
+        "uniq": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "unique-stream": {
+          "version": "2.3.1",
+          "bundled": true,
+          "requires": {
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "through2-filter": "^3.0.0"
+          }
+        },
+        "unique-string": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "crypto-random-string": "^1.0.0"
+          }
+        },
+        "unique-temp-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1",
+            "os-tmpdir": "^1.0.1",
+            "uid2": "0.0.3"
+          }
+        },
+        "unist-builder": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "object-assign": "^4.1.0"
+          }
+        },
+        "unist-util-generated": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "unist-util-is": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "unist-util-position": {
+          "version": "3.0.2",
+          "bundled": true
+        },
+        "unist-util-remove-position": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "^1.1.0"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "unist-util-visit": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-is": "^2.1.2"
+          }
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "unset-value": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          },
+          "dependencies": {
+            "has-value": {
+              "version": "0.3.1",
+              "bundled": true,
+              "requires": {
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
+              },
+              "dependencies": {
+                "isobject": {
+                  "version": "2.1.0",
+                  "bundled": true,
+                  "requires": {
+                    "isarray": "1.0.0"
+                  }
+                }
+              }
+            },
+            "has-values": {
+              "version": "0.1.4",
+              "bundled": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "unzip-response": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "upath": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "update-notifier": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "boxen": "^1.2.1",
+            "chalk": "^2.0.1",
+            "configstore": "^3.0.0",
+            "import-lazy": "^2.1.0",
+            "is-ci": "^1.0.10",
+            "is-installed-globally": "^0.1.0",
+            "is-npm": "^1.0.0",
+            "latest-version": "^3.0.0",
+            "semver-diff": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "bundled": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "ci-info": {
+              "version": "1.6.0",
+              "bundled": true
+            },
+            "is-ci": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "ci-info": "^1.5.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "uri-js": {
+          "version": "4.2.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "url-parse-lax": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "prepend-http": "^1.0.1"
+          }
+        },
+        "url-set-query": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "url-to-options": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "use": {
+          "version": "3.1.1",
+          "bundled": true
+        },
+        "utf8": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
+          }
+        },
+        "value-or-function": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "varint": {
+          "version": "5.0.0",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.10.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
+        },
+        "vfile": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-message": "^1.0.0"
+          },
+          "dependencies": {
+            "is-buffer": {
+              "version": "2.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "vfile-location": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "vfile-message": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-stringify-position": "^1.1.1"
+          }
+        },
+        "vfile-reporter": {
+          "version": "5.1.1",
+          "bundled": true,
+          "requires": {
+            "repeat-string": "^1.5.0",
+            "string-width": "^2.0.0",
+            "supports-color": "^5.4.0",
+            "unist-util-stringify-position": "^1.0.0",
+            "vfile-sort": "^2.1.2",
+            "vfile-statistics": "^1.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "vfile-sort": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "vfile-statistics": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "vinyl": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "clone": "^2.1.1",
+            "clone-buffer": "^1.0.0",
+            "clone-stats": "^1.0.0",
+            "cloneable-readable": "^1.0.0",
+            "remove-trailing-separator": "^1.0.1",
+            "replace-ext": "^1.0.0"
+          }
+        },
+        "vinyl-fs": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "fs-mkdirp-stream": "^1.0.0",
+            "glob-stream": "^6.1.0",
+            "graceful-fs": "^4.0.0",
+            "is-valid-glob": "^1.0.0",
+            "lazystream": "^1.0.0",
+            "lead": "^1.0.0",
+            "object.assign": "^4.0.4",
+            "pumpify": "^1.3.5",
+            "readable-stream": "^2.3.3",
+            "remove-bom-buffer": "^3.0.0",
+            "remove-bom-stream": "^1.2.0",
+            "resolve-options": "^1.1.0",
+            "through2": "^2.0.0",
+            "to-through": "^2.0.0",
+            "value-or-function": "^3.0.0",
+            "vinyl": "^2.0.0",
+            "vinyl-sourcemap": "^1.1.0"
+          }
+        },
+        "vinyl-sourcemap": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "append-buffer": "^1.0.2",
+            "convert-source-map": "^1.5.0",
+            "graceful-fs": "^4.1.6",
+            "normalize-path": "^2.1.1",
+            "now-and-later": "^2.0.0",
+            "remove-bom-buffer": "^3.0.0",
+            "vinyl": "^2.0.0"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
+          }
+        },
+        "vue-template-compiler": {
+          "version": "2.6.6",
+          "bundled": true,
+          "requires": {
+            "de-indent": "^1.0.2",
+            "he": "^1.1.0"
+          }
+        },
+        "wcwidth": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "defaults": "^1.0.3"
+          }
+        },
         "web3": {
           "version": "1.0.0-beta.33",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-1.0.0-beta.33.tgz",
-          "integrity": "sha1-xgIbV2mSdyY3HBhLhoRFMRsTkpU=",
+          "bundled": true,
           "requires": {
             "web3-bzz": "1.0.0-beta.33",
             "web3-core": "1.0.0-beta.33",
@@ -613,6 +14088,650 @@
             "web3-net": "1.0.0-beta.33",
             "web3-shh": "1.0.0-beta.33",
             "web3-utils": "1.0.0-beta.33"
+          }
+        },
+        "web3-bzz": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "got": "7.1.0",
+            "swarm-js": "0.1.37",
+            "underscore": "1.8.3"
+          },
+          "dependencies": {
+            "get-stream": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "got": {
+              "version": "7.1.0",
+              "bundled": true,
+              "requires": {
+                "decompress-response": "^3.2.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "p-cancelable": "^0.3.0",
+                "p-timeout": "^1.1.1",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "url-parse-lax": "^1.0.0",
+                "url-to-options": "^1.0.1"
+              }
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-core": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-core-requestmanager": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-eth-iban": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-core-method": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-promievent": "1.0.0-beta.33",
+            "web3-core-subscriptions": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "1.1.1"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-providers-http": "1.0.0-beta.33",
+            "web3-providers-ipc": "1.0.0-beta.33",
+            "web3-providers-ws": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "eventemitter3": "1.1.1",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-core-subscriptions": "1.0.0-beta.33",
+            "web3-eth-abi": "1.0.0-beta.33",
+            "web3-eth-accounts": "1.0.0-beta.33",
+            "web3-eth-contract": "1.0.0-beta.33",
+            "web3-eth-iban": "1.0.0-beta.33",
+            "web3-eth-personal": "1.0.0-beta.33",
+            "web3-net": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scrypt.js": "0.2.0",
+            "underscore": "1.8.3",
+            "uuid": "2.0.1",
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "scrypt.js": {
+              "version": "0.2.0",
+              "bundled": true,
+              "requires": {
+                "scrypt": "^6.0.2",
+                "scryptsy": "^1.2.1"
+              }
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-core-promievent": "1.0.0-beta.33",
+            "web3-core-subscriptions": "1.0.0-beta.33",
+            "web3-eth-abi": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "web3-utils": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-net": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          }
+        },
+        "web3-net": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-utils": "1.0.0-beta.33"
+          }
+        },
+        "web3-provider-engine": {
+          "version": "8.6.1",
+          "bundled": true,
+          "requires": {
+            "async": "^2.1.2",
+            "clone": "^2.0.0",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.0.1",
+            "ethereumjs-vm": "^2.0.2",
+            "isomorphic-fetch": "^2.2.0",
+            "request": "^2.67.0",
+            "semaphore": "^1.0.3",
+            "solc": "^0.4.2",
+            "tape": "^4.4.0",
+            "web3": "^0.16.0",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+              "from": "git+https://github.com/debris/bignumber.js.git#master",
+              "bundled": true
+            },
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "bundled": true,
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            },
+            "utf8": {
+              "version": "2.1.2",
+              "bundled": true
+            },
+            "web3": {
+              "version": "0.16.0",
+              "bundled": true,
+              "requires": {
+                "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
+                "crypto-js": "^3.1.4",
+                "utf8": "^2.1.1",
+                "xmlhttprequest": "*"
+              }
+            }
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "web3-core-helpers": "1.0.0-beta.33",
+            "xhr2": "0.1.4"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "oboe": "2.1.3",
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "underscore": "1.8.3",
+            "web3-core-helpers": "1.0.0-beta.33",
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          },
+          "dependencies": {
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            }
+          }
+        },
+        "web3-shh": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "web3-core": "1.0.0-beta.33",
+            "web3-core-method": "1.0.0-beta.33",
+            "web3-core-subscriptions": "1.0.0-beta.33",
+            "web3-net": "1.0.0-beta.33"
+          }
+        },
+        "web3-utils": {
+          "version": "1.0.0-beta.33",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "eth-lib": "0.1.27",
+            "ethjs-unit": "0.1.6",
+            "number-to-bn": "1.7.0",
+            "randomhex": "0.1.5",
+            "underscore": "1.8.3",
+            "utf8": "2.1.1"
+          },
+          "dependencies": {
+            "bn.js": {
+              "version": "4.11.6",
+              "bundled": true
+            },
+            "underscore": {
+              "version": "1.8.3",
+              "bundled": true
+            },
+            "utf8": {
+              "version": "2.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "webcrypto-shim": {
+          "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
+          "from": "github:dignifiedquire/webcrypto-shim#master",
+          "bundled": true
+        },
+        "websocket": {
+          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+          "bundled": true,
+          "requires": {
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.9",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "websocket-driver": {
+          "version": "0.7.0",
+          "bundled": true,
+          "requires": {
+            "http-parser-js": ">=0.4.0",
+            "websocket-extensions": ">=0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "well-known-symbols": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "whatwg-fetch": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "which": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "widest-line": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "string-width": "^2.1.1"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "bundled": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^0.5.1"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "ws": {
+          "version": "3.3.3",
+          "bundled": true,
+          "requires": {
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
+          }
+        },
+        "x-is-string": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "xdg-basedir": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "xhr": {
+          "version": "2.5.0",
+          "bundled": true,
+          "requires": {
+            "global": "~4.3.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
+          }
+        },
+        "xhr-request": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "buffer-to-arraybuffer": "^0.0.5",
+            "object-assign": "^4.1.1",
+            "query-string": "^5.0.1",
+            "simple-get": "^2.7.0",
+            "timed-out": "^4.0.1",
+            "url-set-query": "^1.0.0",
+            "xhr": "^2.0.4"
+          },
+          "dependencies": {
+            "query-string": {
+              "version": "5.1.1",
+              "bundled": true,
+              "requires": {
+                "decode-uri-component": "^0.2.0",
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
+              }
+            }
+          }
+        },
+        "xhr-request-promise": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "xhr-request": "^1.0.1"
+          }
+        },
+        "xhr2": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "xhr2-cookies": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "cookiejar": "^2.1.1"
+          }
+        },
+        "xmlhttprequest": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yaeti": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "4.8.1",
+          "bundled": true,
+          "requires": {
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "lodash.assign": "^4.0.3",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.1",
+            "which-module": "^1.0.0",
+            "window-size": "^0.2.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^2.4.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "bundled": true,
+          "requires": {
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
+          }
+        },
+        "yauzl": {
+          "version": "2.10.0",
+          "bundled": true,
+          "requires": {
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.1.0"
           }
         }
       }
@@ -2001,21 +16120,6 @@
             "buffer-from": "^1.0.0",
             "source-map": "^0.6.0"
           }
-        }
-      }
-    },
-    "@babel/runtime": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.3.1.tgz",
-      "integrity": "sha512-7jGW8ppV0ant637pIqAcFfQDDH1orEPGJb8aXfUozuCU3QqX7rX4DA8iwrbPrR1hcH0FTTHz47yQnk+bl5xHQA==",
-      "requires": {
-        "regenerator-runtime": "^0.12.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },
@@ -5199,11 +19303,6 @@
         "assert-plus": "^1.0.0"
       }
     },
-    "date-fns": {
-      "version": "2.0.0-alpha.22",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.22.tgz",
-      "integrity": "sha512-ovlz0I0OFhyn9bgTfqFAUvJvo8VS9mUuOxZ6cwKwBjSx42lMpXPGolcINYZoTNAG2M4YJ3QoApiQQljQEuy/Uw=="
-    },
     "date-time": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/date-time/-/date-time-2.1.0.tgz",
@@ -6015,6 +20114,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+      "dev": true,
       "requires": {
         "is-obj": "^1.0.0"
       }
@@ -6835,7 +20935,7 @@
       "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
       "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
       "requires": {
-        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#d84a96796079c8595a0c78accd1e7709f2277215",
+        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
         "ethereumjs-util": "^5.1.1"
       },
       "dependencies": {
@@ -6859,49 +20959,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
       "integrity": "sha512-XOnAR/3rntJgbCdGhqdaLIxDLWKLmsZOGhHdBKadEr6gEnJLH52k93Ou+TUdFaPN3hJc3isBZBal3U/XZ15abA=="
-    },
-    "ethereum-ens": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/ethereum-ens/-/ethereum-ens-0.7.4.tgz",
-      "integrity": "sha512-oY3vFgr/ZUGJwB2xCjDhe/97Ir3GNVBdELIlz0fHz2tPYprATgoXck7kcW1cZfAE3XQfoojmxUQG6yOT/trjfg==",
-      "requires": {
-        "bluebird": "^3.4.7",
-        "eth-ens-namehash": "^2.0.0",
-        "js-sha3": "^0.5.7",
-        "pako": "^1.0.4",
-        "text-encoding": "^0.6.4",
-        "underscore": "^1.8.3",
-        "web3": "^0.19.1"
-      },
-      "dependencies": {
-        "bignumber.js": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
-          "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
-        },
-        "js-sha3": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
-        },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
-        },
-        "web3": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
-          "integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
-          "requires": {
-            "bignumber.js": "^4.0.2",
-            "crypto-js": "^3.1.4",
-            "utf8": "^2.1.1",
-            "xhr2": "*",
-            "xmlhttprequest": "*"
-          }
-        }
-      }
     },
     "ethereum-ens-network-map": {
       "version": "1.0.0",
@@ -7895,7 +21952,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7916,12 +21974,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7936,17 +21996,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8063,7 +22126,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8075,6 +22139,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8089,6 +22154,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8096,12 +22162,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8120,6 +22188,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8200,7 +22269,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8212,6 +22282,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8297,7 +22368,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8333,6 +22405,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8352,6 +22425,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8395,12 +22469,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8489,7 +22565,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
           "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
           "requires": {
-            "xtend": "4.0.1"
+            "xtend": "~4.0.0"
           }
         },
         "accepts": {
@@ -8497,7 +22573,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
           "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
           "requires": {
-            "mime-types": "2.1.18",
+            "mime-types": "~2.1.18",
             "negotiator": "0.6.1"
           }
         },
@@ -8511,10 +22587,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
           "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
           }
         },
         "ansi-regex": {
@@ -8552,9 +22628,9 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "requires": {
-            "bn.js": "4.11.6",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "assert": {
@@ -8570,10 +22646,10 @@
           "resolved": "https://registry.npmjs.org/assert-match/-/assert-match-1.1.1.tgz",
           "integrity": "sha512-c0QY2kpYVrH/jis6cCq9Mnt4/bIdGALDh1N8HY9ZARZedsMs5LSbgywxkjd5A1uNVLN0L8evANxBPxKiabVoZw==",
           "requires": {
-            "assert": "1.4.1",
-            "babel-runtime": "6.26.0",
-            "es-to-primitive": "1.1.1",
-            "lodash.merge": "4.6.1"
+            "assert": "^1.4.1",
+            "babel-runtime": "^6.23.0",
+            "es-to-primitive": "^1.1.1",
+            "lodash.merge": "^4.6.0"
           }
         },
         "assert-plus": {
@@ -8591,7 +22667,7 @@
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         },
         "async-eventemitter": {
@@ -8599,7 +22675,7 @@
           "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
           "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
           "requires": {
-            "async": "2.6.1"
+            "async": "^2.4.0"
           }
         },
         "async-limiter": {
@@ -8627,9 +22703,9 @@
           "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           }
         },
         "babel-core": {
@@ -8637,25 +22713,25 @@
           "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-generator": "6.26.1",
-            "babel-helpers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-register": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "convert-source-map": "1.5.1",
-            "debug": "2.6.9",
-            "json5": "0.5.1",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4",
-            "path-is-absolute": "1.0.1",
-            "private": "0.1.8",
-            "slash": "1.0.0",
-            "source-map": "0.5.7"
+            "babel-code-frame": "^6.26.0",
+            "babel-generator": "^6.26.0",
+            "babel-helpers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-register": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "convert-source-map": "^1.5.1",
+            "debug": "^2.6.9",
+            "json5": "^0.5.1",
+            "lodash": "^4.17.4",
+            "minimatch": "^3.0.4",
+            "path-is-absolute": "^1.0.1",
+            "private": "^0.1.8",
+            "slash": "^1.0.0",
+            "source-map": "^0.5.7"
           }
         },
         "babel-generator": {
@@ -8663,14 +22739,14 @@
           "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "detect-indent": "4.0.0",
-            "jsesc": "1.3.0",
-            "lodash": "4.17.10",
-            "source-map": "0.5.7",
-            "trim-right": "1.0.1"
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "detect-indent": "^4.0.0",
+            "jsesc": "^1.3.0",
+            "lodash": "^4.17.4",
+            "source-map": "^0.5.7",
+            "trim-right": "^1.0.1"
           },
           "dependencies": {
             "jsesc": {
@@ -8685,9 +22761,9 @@
           "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "requires": {
-            "babel-helper-explode-assignable-expression": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-explode-assignable-expression": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-call-delegate": {
@@ -8695,10 +22771,10 @@
           "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-define-map": {
@@ -8706,10 +22782,10 @@
           "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.10"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -8717,9 +22793,9 @@
           "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-function-name": {
@@ -8727,11 +22803,11 @@
           "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "requires": {
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-get-function-arity": {
@@ -8739,8 +22815,8 @@
           "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-hoist-variables": {
@@ -8748,8 +22824,8 @@
           "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -8757,8 +22833,8 @@
           "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-regex": {
@@ -8766,9 +22842,9 @@
           "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.10"
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -8776,11 +22852,11 @@
           "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helper-replace-supers": {
@@ -8788,12 +22864,12 @@
           "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "requires": {
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-helpers": {
@@ -8801,8 +22877,8 @@
           "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-messages": {
@@ -8810,7 +22886,7 @@
           "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -8818,7 +22894,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -8841,9 +22917,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "requires": {
-            "babel-helper-remap-async-to-generator": "6.24.1",
-            "babel-plugin-syntax-async-functions": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-remap-async-to-generator": "^6.24.1",
+            "babel-plugin-syntax-async-functions": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -8851,7 +22927,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -8859,7 +22935,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -8867,11 +22943,11 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "lodash": "4.17.10"
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -8879,15 +22955,15 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "requires": {
-            "babel-helper-define-map": "6.26.0",
-            "babel-helper-function-name": "6.24.1",
-            "babel-helper-optimise-call-expression": "6.24.1",
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-define-map": "^6.24.1",
+            "babel-helper-function-name": "^6.24.1",
+            "babel-helper-optimise-call-expression": "^6.24.1",
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -8895,8 +22971,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -8904,7 +22980,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -8912,8 +22988,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
           "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -8921,7 +22997,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -8929,9 +23005,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "requires": {
-            "babel-helper-function-name": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-function-name": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -8939,7 +23015,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -8947,9 +23023,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
           "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -8957,10 +23033,10 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
           "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
           "requires": {
-            "babel-plugin-transform-strict-mode": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-plugin-transform-strict-mode": "^6.24.1",
+            "babel-runtime": "^6.26.0",
+            "babel-template": "^6.26.0",
+            "babel-types": "^6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -8968,9 +23044,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
           "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "requires": {
-            "babel-helper-hoist-variables": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-helper-hoist-variables": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -8978,9 +23054,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
           "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0"
+            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -8988,8 +23064,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "requires": {
-            "babel-helper-replace-supers": "6.24.1",
-            "babel-runtime": "6.26.0"
+            "babel-helper-replace-supers": "^6.24.1",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -8997,12 +23073,12 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "requires": {
-            "babel-helper-call-delegate": "6.24.1",
-            "babel-helper-get-function-arity": "6.24.1",
-            "babel-runtime": "6.26.0",
-            "babel-template": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-call-delegate": "^6.24.1",
+            "babel-helper-get-function-arity": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-template": "^6.24.1",
+            "babel-traverse": "^6.24.1",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -9010,8 +23086,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -9019,7 +23095,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -9027,9 +23103,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -9037,7 +23113,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -9045,7 +23121,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "requires": {
-            "babel-runtime": "6.26.0"
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -9053,9 +23129,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "requires": {
-            "babel-helper-regex": "6.26.0",
-            "babel-runtime": "6.26.0",
-            "regexpu-core": "2.0.0"
+            "babel-helper-regex": "^6.24.1",
+            "babel-runtime": "^6.22.0",
+            "regexpu-core": "^2.0.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -9063,9 +23139,9 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-            "babel-runtime": "6.26.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+            "babel-runtime": "^6.22.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -9073,7 +23149,7 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "requires": {
-            "regenerator-transform": "0.10.1"
+            "regenerator-transform": "^0.10.0"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -9081,8 +23157,8 @@
           "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0"
+            "babel-runtime": "^6.22.0",
+            "babel-types": "^6.24.1"
           }
         },
         "babel-preset-env": {
@@ -9090,36 +23166,36 @@
           "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
           "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
           "requires": {
-            "babel-plugin-check-es2015-constants": "6.22.0",
-            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-            "babel-plugin-transform-async-to-generator": "6.24.1",
-            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-            "babel-plugin-transform-es2015-classes": "6.24.1",
-            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-            "babel-plugin-transform-es2015-destructuring": "6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-            "babel-plugin-transform-es2015-for-of": "6.23.0",
-            "babel-plugin-transform-es2015-function-name": "6.24.1",
-            "babel-plugin-transform-es2015-literals": "6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-            "babel-plugin-transform-es2015-object-super": "6.24.1",
-            "babel-plugin-transform-es2015-parameters": "6.24.1",
-            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-            "babel-plugin-transform-es2015-spread": "6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-            "babel-plugin-transform-es2015-template-literals": "6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-            "babel-plugin-transform-exponentiation-operator": "6.24.1",
-            "babel-plugin-transform-regenerator": "6.26.0",
-            "browserslist": "3.2.8",
-            "invariant": "2.2.4",
-            "semver": "5.4.1"
+            "babel-plugin-check-es2015-constants": "^6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+            "babel-plugin-transform-async-to-generator": "^6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+            "babel-plugin-transform-es2015-classes": "^6.23.0",
+            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+            "babel-plugin-transform-es2015-for-of": "^6.23.0",
+            "babel-plugin-transform-es2015-function-name": "^6.22.0",
+            "babel-plugin-transform-es2015-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+            "babel-plugin-transform-es2015-object-super": "^6.22.0",
+            "babel-plugin-transform-es2015-parameters": "^6.23.0",
+            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+            "babel-plugin-transform-es2015-spread": "^6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+            "babel-plugin-transform-regenerator": "^6.22.0",
+            "browserslist": "^3.2.6",
+            "invariant": "^2.2.2",
+            "semver": "^5.3.0"
           }
         },
         "babel-register": {
@@ -9127,13 +23203,13 @@
           "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "requires": {
-            "babel-core": "6.26.3",
-            "babel-runtime": "6.26.0",
-            "core-js": "2.5.6",
-            "home-or-tmp": "2.0.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "source-map-support": "0.4.18"
+            "babel-core": "^6.26.0",
+            "babel-runtime": "^6.26.0",
+            "core-js": "^2.5.0",
+            "home-or-tmp": "^2.0.0",
+            "lodash": "^4.17.4",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.4.15"
           }
         },
         "babel-runtime": {
@@ -9141,8 +23217,8 @@
           "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "requires": {
-            "core-js": "2.5.6",
-            "regenerator-runtime": "0.11.1"
+            "core-js": "^2.4.0",
+            "regenerator-runtime": "^0.11.0"
           }
         },
         "babel-template": {
@@ -9150,11 +23226,11 @@
           "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-traverse": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "lodash": "4.17.10"
+            "babel-runtime": "^6.26.0",
+            "babel-traverse": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "lodash": "^4.17.4"
           }
         },
         "babel-traverse": {
@@ -9162,15 +23238,15 @@
           "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "babel-messages": "6.23.0",
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "babylon": "6.18.0",
-            "debug": "2.6.9",
-            "globals": "9.18.0",
-            "invariant": "2.2.4",
-            "lodash": "4.17.10"
+            "babel-code-frame": "^6.26.0",
+            "babel-messages": "^6.23.0",
+            "babel-runtime": "^6.26.0",
+            "babel-types": "^6.26.0",
+            "babylon": "^6.18.0",
+            "debug": "^2.6.8",
+            "globals": "^9.18.0",
+            "invariant": "^2.2.2",
+            "lodash": "^4.17.4"
           }
         },
         "babel-types": {
@@ -9178,10 +23254,10 @@
           "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "esutils": "2.0.2",
-            "lodash": "4.17.10",
-            "to-fast-properties": "1.0.3"
+            "babel-runtime": "^6.26.0",
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.4",
+            "to-fast-properties": "^1.0.3"
           }
         },
         "babelify": {
@@ -9189,8 +23265,8 @@
           "resolved": "https://registry.npmjs.org/babelify/-/babelify-7.3.0.tgz",
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "requires": {
-            "babel-core": "6.26.3",
-            "object-assign": "4.1.1"
+            "babel-core": "^6.0.14",
+            "object-assign": "^4.0.0"
           }
         },
         "babylon": {
@@ -9203,7 +23279,7 @@
           "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
           "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
           "requires": {
-            "precond": "0.2.3"
+            "precond": "0.2"
           }
         },
         "balanced-match": {
@@ -9227,7 +23303,7 @@
           "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "bindings": {
@@ -9240,11 +23316,11 @@
           "resolved": "https://registry.npmjs.org/bip39/-/bip39-2.4.0.tgz",
           "integrity": "sha512-1++HywqIyPtWDo7gm4v0ylYbwkLvHkuwVSKbBlZBbTCP/mnkyrlARBny906VLAwxJbC5xw9EvuJasHFIZaIFMQ==",
           "requires": {
-            "create-hash": "1.2.0",
-            "pbkdf2": "3.0.16",
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2",
-            "unorm": "1.4.1"
+            "create-hash": "^1.1.0",
+            "pbkdf2": "^3.0.9",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "unorm": "^1.3.3"
           }
         },
         "bip66": {
@@ -9252,7 +23328,7 @@
           "resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "bl": {
@@ -9260,7 +23336,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
-            "readable-stream": "1.0.34"
+            "readable-stream": "~1.0.26"
           },
           "dependencies": {
             "readable-stream": {
@@ -9268,10 +23344,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             }
           }
@@ -9281,7 +23357,7 @@
           "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
           "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "bluebird": {
@@ -9300,15 +23376,15 @@
           "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
           "requires": {
             "bytes": "3.0.0",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "http-errors": "1.6.3",
+            "depd": "~1.1.2",
+            "http-errors": "~1.6.3",
             "iconv-lite": "0.4.23",
-            "on-finished": "2.3.0",
+            "on-finished": "~2.3.0",
             "qs": "6.5.2",
             "raw-body": "2.3.3",
-            "type-is": "1.6.16"
+            "type-is": "~1.6.16"
           }
         },
         "brace-expansion": {
@@ -9316,7 +23392,7 @@
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -9335,12 +23411,12 @@
           "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "browserify-cipher": {
@@ -9348,9 +23424,9 @@
           "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
           "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
           "requires": {
-            "browserify-aes": "1.2.0",
-            "browserify-des": "1.0.1",
-            "evp_bytestokey": "1.0.3"
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
           }
         },
         "browserify-des": {
@@ -9358,9 +23434,9 @@
           "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.1.tgz",
           "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
           "requires": {
-            "cipher-base": "1.0.4",
-            "des.js": "1.0.0",
-            "inherits": "2.0.3"
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "browserify-rsa": {
@@ -9368,8 +23444,8 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "requires": {
-            "bn.js": "4.11.6",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
           }
         },
         "browserify-sha3": {
@@ -9377,7 +23453,7 @@
           "resolved": "https://registry.npmjs.org/browserify-sha3/-/browserify-sha3-0.0.1.tgz",
           "integrity": "sha1-P/NKMAbvFcD7NWflQbkaI0ASPRE=",
           "requires": {
-            "js-sha3": "0.3.1"
+            "js-sha3": "^0.3.1"
           }
         },
         "browserify-sign": {
@@ -9385,13 +23461,13 @@
           "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
           "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
           "requires": {
-            "bn.js": "4.11.6",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "elliptic": "6.4.0",
-            "inherits": "2.0.3",
-            "parse-asn1": "5.1.1"
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
           }
         },
         "browserslist": {
@@ -9399,8 +23475,8 @@
           "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "requires": {
-            "caniuse-lite": "1.0.30000850",
-            "electron-to-chromium": "1.3.47"
+            "caniuse-lite": "^1.0.30000844",
+            "electron-to-chromium": "^1.3.47"
           }
         },
         "bs58": {
@@ -9408,7 +23484,7 @@
           "resolved": "https://registry.npmjs.org/bs58/-/bs58-3.1.0.tgz",
           "integrity": "sha1-1MJjiL9IBMrHFBQbGUWqR+XrJI4=",
           "requires": {
-            "base-x": "1.1.0"
+            "base-x": "^1.1.0"
           }
         },
         "bs58check": {
@@ -9416,8 +23492,8 @@
           "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-1.3.4.tgz",
           "integrity": "sha1-xSVABzdJEXcU+gQsMEfrj5FRy/g=",
           "requires": {
-            "bs58": "3.1.0",
-            "create-hash": "1.2.0"
+            "bs58": "^3.1.0",
+            "create-hash": "^1.1.0"
           }
         },
         "buffer": {
@@ -9425,8 +23501,8 @@
           "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
           "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.11"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
           }
         },
         "buffer-alloc": {
@@ -9434,8 +23510,8 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
           "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
           "requires": {
-            "buffer-alloc-unsafe": "0.1.1",
-            "buffer-fill": "0.1.1"
+            "buffer-alloc-unsafe": "^0.1.0",
+            "buffer-fill": "^0.1.0"
           }
         },
         "buffer-alloc-unsafe": {
@@ -9483,8 +23559,8 @@
           "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
           "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
           "requires": {
-            "bytewise-core": "1.2.3",
-            "typewise": "1.0.3"
+            "bytewise-core": "^1.2.2",
+            "typewise": "^1.0.3"
           }
         },
         "bytewise-core": {
@@ -9492,7 +23568,7 @@
           "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
           "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
           "requires": {
-            "typewise-core": "1.2.0"
+            "typewise-core": "^1.2"
           }
         },
         "cachedown": {
@@ -9500,8 +23576,8 @@
           "resolved": "https://registry.npmjs.org/cachedown/-/cachedown-1.0.0.tgz",
           "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
           "requires": {
-            "abstract-leveldown": "2.7.2",
-            "lru-cache": "3.2.0"
+            "abstract-leveldown": "^2.4.1",
+            "lru-cache": "^3.2.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -9509,7 +23585,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "requires": {
-                "xtend": "4.0.1"
+                "xtend": "~4.0.0"
               }
             }
           }
@@ -9534,9 +23610,9 @@
           "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
           "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
           "requires": {
-            "assertion-error": "1.1.0",
-            "deep-eql": "0.1.3",
-            "type-detect": "1.0.0"
+            "assertion-error": "^1.0.1",
+            "deep-eql": "^0.1.3",
+            "type-detect": "^1.0.0"
           }
         },
         "chalk": {
@@ -9544,11 +23620,11 @@
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
           }
         },
         "checkpoint-store": {
@@ -9556,7 +23632,7 @@
           "resolved": "https://registry.npmjs.org/checkpoint-store/-/checkpoint-store-1.1.0.tgz",
           "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
           "requires": {
-            "functional-red-black-tree": "1.0.1"
+            "functional-red-black-tree": "^1.0.1"
           }
         },
         "cipher-base": {
@@ -9564,8 +23640,8 @@
           "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "cliui": {
@@ -9573,9 +23649,9 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "clone": {
@@ -9598,8 +23674,8 @@
           "resolved": "https://registry.npmjs.org/coinstring/-/coinstring-2.3.0.tgz",
           "integrity": "sha1-zbYzY6lhUCQEolr7gsLibV/2J6Q=",
           "requires": {
-            "bs58": "2.0.1",
-            "create-hash": "1.2.0"
+            "bs58": "^2.0.1",
+            "create-hash": "^1.1.1"
           },
           "dependencies": {
             "bs58": {
@@ -9614,7 +23690,7 @@
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "commander": {
@@ -9622,7 +23698,7 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
-            "graceful-readlink": "1.0.1"
+            "graceful-readlink": ">= 1.0.0"
           }
         },
         "concat-map": {
@@ -9635,10 +23711,10 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
-            "buffer-from": "1.1.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           },
           "dependencies": {
             "buffer-from": {
@@ -9688,8 +23764,8 @@
           "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
           "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
           "requires": {
-            "object-assign": "4.1.1",
-            "vary": "1.1.2"
+            "object-assign": "^4",
+            "vary": "^1"
           }
         },
         "create-ecdh": {
@@ -9697,8 +23773,8 @@
           "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
           "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
           "requires": {
-            "bn.js": "4.11.6",
-            "elliptic": "6.4.0"
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
           }
         },
         "create-hash": {
@@ -9706,11 +23782,11 @@
           "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "requires": {
-            "cipher-base": "1.0.4",
-            "inherits": "2.0.3",
-            "md5.js": "1.3.4",
-            "ripemd160": "2.0.2",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
           }
         },
         "create-hmac": {
@@ -9718,12 +23794,12 @@
           "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "requires": {
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "inherits": "2.0.3",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.1.2",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "cross-fetch": {
@@ -9740,17 +23816,17 @@
           "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
           "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
           "requires": {
-            "browserify-cipher": "1.0.1",
-            "browserify-sign": "4.0.4",
-            "create-ecdh": "4.0.3",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "diffie-hellman": "5.0.3",
-            "inherits": "2.0.3",
-            "pbkdf2": "3.0.16",
-            "public-encrypt": "4.0.2",
-            "randombytes": "2.0.6",
-            "randomfill": "1.0.4"
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
           }
         },
         "d64": {
@@ -9763,7 +23839,7 @@
           "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "debug": {
@@ -9789,14 +23865,14 @@
           "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
           "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
           "requires": {
-            "decompress-tar": "4.1.1",
-            "decompress-tarbz2": "4.1.1",
-            "decompress-targz": "4.1.1",
-            "decompress-unzip": "4.0.1",
-            "graceful-fs": "4.1.11",
-            "make-dir": "1.3.0",
-            "pify": "2.3.0",
-            "strip-dirs": "2.1.0"
+            "decompress-tar": "^4.0.0",
+            "decompress-tarbz2": "^4.0.0",
+            "decompress-targz": "^4.0.0",
+            "decompress-unzip": "^4.0.1",
+            "graceful-fs": "^4.1.10",
+            "make-dir": "^1.0.0",
+            "pify": "^2.3.0",
+            "strip-dirs": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -9811,7 +23887,7 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "requires": {
-            "mimic-response": "1.0.0"
+            "mimic-response": "^1.0.0"
           }
         },
         "decompress-tar": {
@@ -9819,9 +23895,9 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "requires": {
-            "file-type": "5.2.0",
-            "is-stream": "1.1.0",
-            "tar-stream": "1.6.1"
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0",
+            "tar-stream": "^1.5.2"
           }
         },
         "decompress-tarbz2": {
@@ -9829,11 +23905,11 @@
           "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
           "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
           "requires": {
-            "decompress-tar": "4.1.1",
-            "file-type": "6.2.0",
-            "is-stream": "1.1.0",
-            "seek-bzip": "1.0.5",
-            "unbzip2-stream": "1.2.5"
+            "decompress-tar": "^4.1.0",
+            "file-type": "^6.1.0",
+            "is-stream": "^1.1.0",
+            "seek-bzip": "^1.0.5",
+            "unbzip2-stream": "^1.0.9"
           },
           "dependencies": {
             "file-type": {
@@ -9848,9 +23924,9 @@
           "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
           "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
           "requires": {
-            "decompress-tar": "4.1.1",
-            "file-type": "5.2.0",
-            "is-stream": "1.1.0"
+            "decompress-tar": "^4.1.1",
+            "file-type": "^5.2.0",
+            "is-stream": "^1.1.0"
           }
         },
         "decompress-unzip": {
@@ -9858,10 +23934,10 @@
           "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
           "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
           "requires": {
-            "file-type": "3.9.0",
-            "get-stream": "2.3.1",
-            "pify": "2.3.0",
-            "yauzl": "2.9.1"
+            "file-type": "^3.8.0",
+            "get-stream": "^2.2.0",
+            "pify": "^2.3.0",
+            "yauzl": "^2.4.2"
           },
           "dependencies": {
             "file-type": {
@@ -9874,8 +23950,8 @@
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
               "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
               "requires": {
-                "object-assign": "4.1.1",
-                "pinkie-promise": "2.0.1"
+                "object-assign": "^4.0.1",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pify": {
@@ -9910,7 +23986,7 @@
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
           "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
           "requires": {
-            "abstract-leveldown": "2.6.3"
+            "abstract-leveldown": "~2.6.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -9918,7 +23994,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "requires": {
-                "xtend": "4.0.1"
+                "xtend": "~4.0.0"
               }
             }
           }
@@ -9928,8 +24004,8 @@
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
           "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
           "requires": {
-            "foreach": "2.0.5",
-            "object-keys": "1.0.11"
+            "foreach": "^2.0.5",
+            "object-keys": "^1.0.8"
           },
           "dependencies": {
             "object-keys": {
@@ -9959,8 +24035,8 @@
           "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
           "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "destroy": {
@@ -9973,7 +24049,7 @@
           "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "requires": {
-            "repeating": "2.0.1"
+            "repeating": "^2.0.0"
           }
         },
         "diff": {
@@ -9986,9 +24062,9 @@
           "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
           "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
           "requires": {
-            "bn.js": "4.11.6",
-            "miller-rabin": "4.0.1",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "dom-walk": {
@@ -10001,9 +24077,9 @@
           "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
           "requires": {
-            "browserify-aes": "1.2.0",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7"
+            "browserify-aes": "^1.0.6",
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4"
           }
         },
         "duplexer3": {
@@ -10017,7 +24093,7 @@
           "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "ee-first": {
@@ -10035,13 +24111,13 @@
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
           "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
           "requires": {
-            "bn.js": "4.11.6",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.3",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
         "encodeurl": {
@@ -10054,7 +24130,7 @@
           "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
           "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "requires": {
-            "iconv-lite": "0.4.23"
+            "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
@@ -10062,7 +24138,7 @@
           "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
           "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "errno": {
@@ -10070,7 +24146,7 @@
           "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
           "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "error-ex": {
@@ -10078,7 +24154,7 @@
           "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "es-abstract": {
@@ -10086,11 +24162,11 @@
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
           "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "requires": {
-            "es-to-primitive": "1.1.1",
-            "function-bind": "1.1.1",
-            "has": "1.0.3",
-            "is-callable": "1.1.3",
-            "is-regex": "1.0.4"
+            "es-to-primitive": "^1.1.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.1",
+            "is-callable": "^1.1.3",
+            "is-regex": "^1.0.4"
           }
         },
         "es-to-primitive": {
@@ -10098,9 +24174,9 @@
           "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
           "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
           "requires": {
-            "is-callable": "1.1.3",
-            "is-date-object": "1.0.1",
-            "is-symbol": "1.0.1"
+            "is-callable": "^1.1.1",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.1"
           }
         },
         "escape-html": {
@@ -10128,13 +24204,13 @@
           "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
           "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
           "requires": {
-            "eth-query": "2.1.2",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "5.2.0",
-            "ethjs-util": "0.1.4",
-            "json-rpc-engine": "3.7.3",
-            "pify": "2.3.0",
-            "tape": "4.9.0"
+            "eth-query": "^2.1.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.3",
+            "ethjs-util": "^0.1.3",
+            "json-rpc-engine": "^3.6.0",
+            "pify": "^2.3.0",
+            "tape": "^4.6.3"
           },
           "dependencies": {
             "pify": {
@@ -10149,11 +24225,11 @@
           "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.1.2.tgz",
           "integrity": "sha512-IuK5Iowfs6taluA/3Okmu6EfZcFMq6MQuyrUL1PrCoJstuuBr3TvVeSy3keDyxfbrjFB34nCo538I8G+qMtsbw==",
           "requires": {
-            "cross-fetch": "2.2.1",
-            "eth-json-rpc-middleware": "1.6.0",
-            "json-rpc-engine": "3.7.3",
-            "json-rpc-error": "2.0.0",
-            "tape": "4.9.0"
+            "cross-fetch": "^2.1.1",
+            "eth-json-rpc-middleware": "^1.5.0",
+            "json-rpc-engine": "^3.4.0",
+            "json-rpc-error": "^2.0.0",
+            "tape": "^4.8.0"
           }
         },
         "eth-json-rpc-middleware": {
@@ -10161,19 +24237,19 @@
           "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
           "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
           "requires": {
-            "async": "2.6.1",
-            "eth-query": "2.1.2",
-            "eth-tx-summary": "3.2.3",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "5.2.0",
-            "ethereumjs-vm": "2.3.5",
-            "fetch-ponyfill": "4.1.0",
-            "json-rpc-engine": "3.7.3",
-            "json-rpc-error": "2.0.0",
-            "json-stable-stringify": "1.0.1",
-            "promise-to-callback": "1.0.0",
-            "tape": "4.9.0"
+            "async": "^2.5.0",
+            "eth-query": "^2.1.2",
+            "eth-tx-summary": "^3.1.2",
+            "ethereumjs-block": "^1.6.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.2",
+            "ethereumjs-vm": "^2.1.0",
+            "fetch-ponyfill": "^4.0.0",
+            "json-rpc-engine": "^3.6.0",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "tape": "^4.6.3"
           },
           "dependencies": {
             "ethereum-common": {
@@ -10186,11 +24262,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
-                "async": "2.6.1",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.4",
-                "ethereumjs-util": "5.2.0",
-                "merkle-patricia-tree": "2.3.1"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               }
             }
           }
@@ -10200,13 +24276,13 @@
           "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
           "integrity": "sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==",
           "requires": {
-            "bn.js": "4.11.6",
-            "elliptic": "6.4.0",
-            "keccakjs": "0.2.1",
-            "nano-json-stream-parser": "0.1.2",
-            "servify": "0.1.12",
-            "ws": "3.3.3",
-            "xhr-request-promise": "0.1.2"
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "keccakjs": "^0.2.1",
+            "nano-json-stream-parser": "^0.1.2",
+            "servify": "^0.1.12",
+            "ws": "^3.0.0",
+            "xhr-request-promise": "^0.1.2"
           }
         },
         "eth-query": {
@@ -10214,8 +24290,8 @@
           "resolved": "https://registry.npmjs.org/eth-query/-/eth-query-2.1.2.tgz",
           "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
           "requires": {
-            "json-rpc-random-id": "1.0.1",
-            "xtend": "4.0.1"
+            "json-rpc-random-id": "^1.0.0",
+            "xtend": "^4.0.1"
           }
         },
         "eth-sig-util": {
@@ -10224,7 +24300,7 @@
           "integrity": "sha512-tB6E8jf/aZQ943bo3+iojl8xRe3Jzcl+9OT6v8K7kWis6PdIX19SB2vYvN849cB9G9m/XLjYFK381SgdbsnpTA==",
           "requires": {
             "ethereumjs-abi": "0.6.5",
-            "ethereumjs-util": "5.2.0"
+            "ethereumjs-util": "^5.1.1"
           }
         },
         "eth-tx-summary": {
@@ -10232,26 +24308,26 @@
           "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.3.tgz",
           "integrity": "sha512-1gZpA5fKarJOVSb5OUlPnhDQuIazqAkI61zlVvf5LdG47nEgw+/qhyZnuj3CUdE/TLTKuRzPLeyXLjaB4qWTRQ==",
           "requires": {
-            "async": "2.6.1",
-            "bn.js": "4.11.8",
-            "clone": "2.1.1",
-            "concat-stream": "1.6.2",
-            "end-of-stream": "1.4.1",
-            "eth-query": "2.1.2",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "5.2.0",
+            "async": "^2.1.2",
+            "bn.js": "^4.11.8",
+            "clone": "^2.0.0",
+            "concat-stream": "^1.5.1",
+            "end-of-stream": "^1.1.0",
+            "eth-query": "^2.0.2",
+            "ethereumjs-block": "^1.4.1",
+            "ethereumjs-tx": "^1.1.1",
+            "ethereumjs-util": "^5.0.1",
             "ethereumjs-vm": "2.3.4",
-            "through2": "2.0.3",
-            "treeify": "1.1.0",
-            "web3-provider-engine": "13.8.0"
+            "through2": "^2.0.3",
+            "treeify": "^1.0.1",
+            "web3-provider-engine": "^13.3.2"
           },
           "dependencies": {
             "async-eventemitter": {
               "version": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
               "from": "async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
               "requires": {
-                "async": "2.6.1"
+                "async": "^2.4.0"
               }
             },
             "bn.js": {
@@ -10264,14 +24340,14 @@
               "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-2.3.1.tgz",
               "integrity": "sha512-NamWuMBIl8kmkJFVj8WzGatySTzQPQag4Xr677yFxdVtIxACFbL/dQowk0MzEqIKk93U1TwY3MjVU6mOcwZnKA==",
               "requires": {
-                "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
-                "eth-query": "2.1.2",
-                "ethereumjs-tx": "1.3.4",
-                "ethereumjs-util": "5.2.0",
-                "ethjs-util": "0.1.4",
-                "json-rpc-engine": "3.7.3",
-                "pify": "2.3.0",
-                "tape": "4.9.0"
+                "async-eventemitter": "async-eventemitter@github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                "eth-query": "^2.1.0",
+                "ethereumjs-tx": "^1.3.3",
+                "ethereumjs-util": "^5.1.3",
+                "ethjs-util": "^0.1.3",
+                "json-rpc-engine": "^3.6.0",
+                "pify": "^2.3.0",
+                "tape": "^4.6.3"
               }
             },
             "eth-sig-util": {
@@ -10279,8 +24355,8 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                "ethereumjs-util": "5.2.0"
+                "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereum-common": {
@@ -10292,8 +24368,8 @@
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
               "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
               "requires": {
-                "bn.js": "4.11.8",
-                "ethereumjs-util": "5.2.0"
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ethereumjs-block": {
@@ -10301,11 +24377,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
-                "async": "2.6.1",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.4",
-                "ethereumjs-util": "5.2.0",
-                "merkle-patricia-tree": "2.3.1"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               }
             },
             "ethereumjs-vm": {
@@ -10313,17 +24389,17 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.4.tgz",
               "integrity": "sha512-Y4SlzNDqxrCO58jhp98HdnZVdjOqB+HC0hoU+N/DEp1aU+hFkRX/nru5F7/HkQRPIlA6aJlQp/xIA6xZs1kspw==",
               "requires": {
-                "async": "2.6.1",
-                "async-eventemitter": "github:ahultgren/async-eventemitter#fa06e39e56786ba541c180061dbf2c0a5bbf951c",
+                "async": "^2.1.2",
+                "async-eventemitter": "^0.2.2",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-account": "2.0.5",
-                "ethereumjs-block": "1.7.1",
-                "ethereumjs-util": "5.2.0",
-                "fake-merkle-patricia-tree": "1.0.1",
-                "functional-red-black-tree": "1.0.1",
-                "merkle-patricia-tree": "2.3.1",
-                "rustbn.js": "0.1.2",
-                "safe-buffer": "5.1.2"
+                "ethereumjs-account": "^2.0.3",
+                "ethereumjs-block": "~1.7.0",
+                "ethereumjs-util": "^5.1.3",
+                "fake-merkle-patricia-tree": "^1.0.1",
+                "functional-red-black-tree": "^1.0.1",
+                "merkle-patricia-tree": "^2.1.2",
+                "rustbn.js": "~0.1.1",
+                "safe-buffer": "^5.1.1"
               }
             },
             "pify": {
@@ -10336,25 +24412,25 @@
               "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-13.8.0.tgz",
               "integrity": "sha512-fZXhX5VWwWpoFfrfocslyg6P7cN3YWPG/ASaevNfeO80R+nzgoPUBXcWQekSGSsNDkeRTis4aMmpmofYf1TNtQ==",
               "requires": {
-                "async": "2.6.1",
-                "clone": "2.1.1",
-                "eth-block-tracker": "2.3.1",
-                "eth-sig-util": "1.4.2",
-                "ethereumjs-block": "1.7.1",
-                "ethereumjs-tx": "1.3.4",
-                "ethereumjs-util": "5.2.0",
-                "ethereumjs-vm": "2.3.4",
-                "fetch-ponyfill": "4.1.0",
-                "json-rpc-error": "2.0.0",
-                "json-stable-stringify": "1.0.1",
-                "promise-to-callback": "1.0.0",
-                "readable-stream": "2.3.6",
-                "request": "2.87.0",
-                "semaphore": "1.1.0",
-                "solc": "0.4.24",
-                "tape": "4.9.0",
-                "xhr": "2.5.0",
-                "xtend": "4.0.1"
+                "async": "^2.5.0",
+                "clone": "^2.0.0",
+                "eth-block-tracker": "^2.2.2",
+                "eth-sig-util": "^1.4.2",
+                "ethereumjs-block": "^1.2.2",
+                "ethereumjs-tx": "^1.2.0",
+                "ethereumjs-util": "^5.1.1",
+                "ethereumjs-vm": "^2.0.2",
+                "fetch-ponyfill": "^4.0.0",
+                "json-rpc-error": "^2.0.0",
+                "json-stable-stringify": "^1.0.1",
+                "promise-to-callback": "^1.0.0",
+                "readable-stream": "^2.2.9",
+                "request": "^2.67.0",
+                "semaphore": "^1.0.3",
+                "solc": "^0.4.2",
+                "tape": "^4.4.0",
+                "xhr": "^2.2.0",
+                "xtend": "^4.0.1"
               }
             }
           }
@@ -10369,8 +24445,8 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
           "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
           "requires": {
-            "bn.js": "4.11.6",
-            "ethereumjs-util": "4.5.0"
+            "bn.js": "^4.10.0",
+            "ethereumjs-util": "^4.3.0"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -10378,11 +24454,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
               "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
               "requires": {
-                "bn.js": "4.11.6",
-                "create-hash": "1.2.0",
-                "keccakjs": "0.2.1",
-                "rlp": "2.0.0",
-                "secp256k1": "3.5.0"
+                "bn.js": "^4.8.0",
+                "create-hash": "^1.1.2",
+                "keccakjs": "^0.2.0",
+                "rlp": "^2.0.0",
+                "secp256k1": "^3.0.1"
               }
             }
           }
@@ -10392,9 +24468,9 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-2.0.5.tgz",
           "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
           "requires": {
-            "ethereumjs-util": "5.2.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2"
+            "ethereumjs-util": "^5.0.0",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1"
           }
         },
         "ethereumjs-block": {
@@ -10402,11 +24478,11 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.2.2.tgz",
           "integrity": "sha1-LsdTSlkCG47JuDww5JaQxuuu3aE=",
           "requires": {
-            "async": "1.5.2",
+            "async": "^1.5.2",
             "ethereum-common": "0.0.16",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "4.5.0",
-            "merkle-patricia-tree": "2.3.1"
+            "ethereumjs-tx": "^1.0.0",
+            "ethereumjs-util": "^4.0.1",
+            "merkle-patricia-tree": "^2.1.2"
           },
           "dependencies": {
             "async": {
@@ -10419,11 +24495,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
               "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
               "requires": {
-                "bn.js": "4.11.6",
-                "create-hash": "1.2.0",
-                "keccakjs": "0.2.1",
-                "rlp": "2.0.0",
-                "secp256k1": "3.5.0"
+                "bn.js": "^4.8.0",
+                "create-hash": "^1.1.2",
+                "keccakjs": "^0.2.0",
+                "rlp": "^2.0.0",
+                "secp256k1": "^3.0.1"
               }
             }
           }
@@ -10433,8 +24509,8 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-1.3.4.tgz",
           "integrity": "sha512-kOgUd5jC+0tgV7t52UDECMMz9Uf+Lro+6fSpCvzWemtXfMEcwI3EOxf5mVPMRbTFkMMhuERokNNVF3jItAjidg==",
           "requires": {
-            "ethereum-common": "0.0.18",
-            "ethereumjs-util": "5.2.0"
+            "ethereum-common": "^0.0.18",
+            "ethereumjs-util": "^5.0.0"
           },
           "dependencies": {
             "ethereum-common": {
@@ -10449,13 +24525,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
           "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
           "requires": {
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "ethjs-util": "0.1.4",
-            "keccak": "1.4.0",
-            "rlp": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "secp256k1": "3.5.0"
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
           }
         },
         "ethereumjs-vm": {
@@ -10463,17 +24539,17 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-vm/-/ethereumjs-vm-2.3.5.tgz",
           "integrity": "sha512-AJ7x44+xqyE5+UO3Nns19WkTdZfyqFZ+sEjIEpvme7Ipbe3iBU1uwCcHEdiu/yY9bdhr3IfSa/NfIKNeXPaRVQ==",
           "requires": {
-            "async": "2.6.1",
-            "async-eventemitter": "0.2.4",
+            "async": "^2.1.2",
+            "async-eventemitter": "^0.2.2",
             "ethereum-common": "0.2.0",
-            "ethereumjs-account": "2.0.5",
-            "ethereumjs-block": "1.7.1",
-            "ethereumjs-util": "5.2.0",
-            "fake-merkle-patricia-tree": "1.0.1",
-            "functional-red-black-tree": "1.0.1",
-            "merkle-patricia-tree": "2.3.1",
-            "rustbn.js": "0.1.2",
-            "safe-buffer": "5.1.2"
+            "ethereumjs-account": "^2.0.3",
+            "ethereumjs-block": "~1.7.0",
+            "ethereumjs-util": "^5.1.3",
+            "fake-merkle-patricia-tree": "^1.0.1",
+            "functional-red-black-tree": "^1.0.1",
+            "merkle-patricia-tree": "^2.1.2",
+            "rustbn.js": "~0.1.1",
+            "safe-buffer": "^5.1.1"
           },
           "dependencies": {
             "ethereum-common": {
@@ -10486,11 +24562,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-block/-/ethereumjs-block-1.7.1.tgz",
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "requires": {
-                "async": "2.6.1",
+                "async": "^2.0.1",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "1.3.4",
-                "ethereumjs-util": "5.2.0",
-                "merkle-patricia-tree": "2.3.1"
+                "ethereumjs-tx": "^1.2.2",
+                "ethereumjs-util": "^5.0.0",
+                "merkle-patricia-tree": "^2.1.2"
               }
             }
           }
@@ -10500,13 +24576,13 @@
           "resolved": "https://registry.npmjs.org/ethereumjs-wallet/-/ethereumjs-wallet-0.6.0.tgz",
           "integrity": "sha1-gnY7Fpfuenlr5xVdqd+0my+Yz9s=",
           "requires": {
-            "aes-js": "0.2.4",
-            "bs58check": "1.3.4",
-            "ethereumjs-util": "4.5.0",
-            "hdkey": "0.7.1",
-            "scrypt.js": "0.2.0",
-            "utf8": "2.1.2",
-            "uuid": "2.0.3"
+            "aes-js": "^0.2.3",
+            "bs58check": "^1.0.8",
+            "ethereumjs-util": "^4.4.0",
+            "hdkey": "^0.7.0",
+            "scrypt.js": "^0.2.0",
+            "utf8": "^2.1.1",
+            "uuid": "^2.0.1"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -10514,11 +24590,11 @@
               "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-4.5.0.tgz",
               "integrity": "sha1-PpQosxfuvaPXJg2FT93alUsfG8Y=",
               "requires": {
-                "bn.js": "4.11.6",
-                "create-hash": "1.2.0",
-                "keccakjs": "0.2.1",
-                "rlp": "2.0.0",
-                "secp256k1": "3.5.0"
+                "bn.js": "^4.8.0",
+                "create-hash": "^1.1.2",
+                "keccakjs": "^0.2.0",
+                "rlp": "^2.0.0",
+                "secp256k1": "^3.0.1"
               }
             }
           }
@@ -10551,8 +24627,8 @@
           "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "requires": {
-            "md5.js": "1.3.4",
-            "safe-buffer": "5.1.2"
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
           }
         },
         "express": {
@@ -10560,36 +24636,36 @@
           "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
           "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
           "requires": {
-            "accepts": "1.3.5",
+            "accepts": "~1.3.5",
             "array-flatten": "1.1.1",
             "body-parser": "1.18.2",
             "content-disposition": "0.5.2",
-            "content-type": "1.0.4",
+            "content-type": "~1.0.4",
             "cookie": "0.3.1",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "finalhandler": "1.1.1",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "1.1.2",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "2.0.3",
+            "proxy-addr": "~2.0.3",
             "qs": "6.5.1",
-            "range-parser": "1.2.0",
+            "range-parser": "~1.2.0",
             "safe-buffer": "5.1.1",
             "send": "0.16.2",
             "serve-static": "1.13.2",
             "setprototypeof": "1.1.0",
-            "statuses": "1.4.0",
-            "type-is": "1.6.16",
+            "statuses": "~1.4.0",
+            "type-is": "~1.6.16",
             "utils-merge": "1.0.1",
-            "vary": "1.1.2"
+            "vary": "~1.1.2"
           },
           "dependencies": {
             "body-parser": {
@@ -10598,15 +24674,15 @@
               "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
               "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.15"
               }
             },
             "iconv-lite": {
@@ -10643,7 +24719,7 @@
                     "depd": "1.1.1",
                     "inherits": "2.0.3",
                     "setprototypeof": "1.0.3",
-                    "statuses": "1.4.0"
+                    "statuses": ">= 1.3.1 < 2"
                   }
                 },
                 "setprototypeof": {
@@ -10680,7 +24756,7 @@
           "resolved": "https://registry.npmjs.org/fake-merkle-patricia-tree/-/fake-merkle-patricia-tree-1.0.1.tgz",
           "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
           "requires": {
-            "checkpoint-store": "1.1.0"
+            "checkpoint-store": "^1.1.0"
           }
         },
         "fast-deep-equal": {
@@ -10698,7 +24774,7 @@
           "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
           "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
           "requires": {
-            "pend": "1.2.0"
+            "pend": "~1.2.0"
           }
         },
         "fetch-ponyfill": {
@@ -10706,7 +24782,7 @@
           "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-4.1.0.tgz",
           "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
           "requires": {
-            "node-fetch": "1.7.3"
+            "node-fetch": "~1.7.1"
           },
           "dependencies": {
             "node-fetch": {
@@ -10714,8 +24790,8 @@
               "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
               "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
               "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
               }
             }
           }
@@ -10731,12 +24807,12 @@
           "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "on-finished": "2.3.0",
-            "parseurl": "1.3.2",
-            "statuses": "1.4.0",
-            "unpipe": "1.0.0"
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.4.0",
+            "unpipe": "~1.0.0"
           },
           "dependencies": {
             "statuses": {
@@ -10751,8 +24827,8 @@
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "for-each": {
@@ -10760,7 +24836,7 @@
           "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
           "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
           "requires": {
-            "is-function": "1.0.1"
+            "is-function": "~1.0.0"
           }
         },
         "foreach": {
@@ -10778,9 +24854,9 @@
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
           "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
-            "asynckit": "0.4.0",
+            "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
+            "mime-types": "^2.1.12"
           }
         },
         "forwarded": {
@@ -10803,11 +24879,11 @@
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "fs-promise": {
@@ -10815,10 +24891,10 @@
           "resolved": "https://registry.npmjs.org/fs-promise/-/fs-promise-2.0.3.tgz",
           "integrity": "sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=",
           "requires": {
-            "any-promise": "1.3.0",
-            "fs-extra": "2.1.2",
-            "mz": "2.7.0",
-            "thenify-all": "1.6.0"
+            "any-promise": "^1.3.0",
+            "fs-extra": "^2.0.0",
+            "mz": "^2.6.0",
+            "thenify-all": "^1.6.0"
           },
           "dependencies": {
             "fs-extra": {
@@ -10826,8 +24902,8 @@
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
               "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
               }
             }
           }
@@ -10842,10 +24918,10 @@
           "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
           "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "function-bind": {
@@ -10878,7 +24954,7 @@
           "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           }
         },
         "glob": {
@@ -10886,12 +24962,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "global": {
@@ -10899,8 +24975,8 @@
           "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
           "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
           "requires": {
-            "min-document": "2.19.0",
-            "process": "0.5.2"
+            "min-document": "^2.19.0",
+            "process": "~0.5.1"
           }
         },
         "globals": {
@@ -10913,20 +24989,20 @@
           "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
           "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
           "requires": {
-            "decompress-response": "3.3.0",
-            "duplexer3": "0.1.4",
-            "get-stream": "3.0.0",
-            "is-plain-obj": "1.1.0",
-            "is-retry-allowed": "1.1.0",
-            "is-stream": "1.1.0",
-            "isurl": "1.0.0",
-            "lowercase-keys": "1.0.1",
-            "p-cancelable": "0.3.0",
-            "p-timeout": "1.2.1",
-            "safe-buffer": "5.1.2",
-            "timed-out": "4.0.1",
-            "url-parse-lax": "1.0.0",
-            "url-to-options": "1.0.1"
+            "decompress-response": "^3.2.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "isurl": "^1.0.0-alpha5",
+            "lowercase-keys": "^1.0.0",
+            "p-cancelable": "^0.3.0",
+            "p-timeout": "^1.1.1",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "url-parse-lax": "^1.0.0",
+            "url-to-options": "^1.0.1"
           }
         },
         "graceful-fs": {
@@ -10954,8 +25030,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
           "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
           "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
           }
         },
         "has": {
@@ -10963,7 +25039,7 @@
           "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "requires": {
-            "function-bind": "1.1.1"
+            "function-bind": "^1.1.1"
           }
         },
         "has-ansi": {
@@ -10971,7 +25047,7 @@
           "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -10994,7 +25070,7 @@
           "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
           "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
           "requires": {
-            "has-symbol-support-x": "1.4.2"
+            "has-symbol-support-x": "^1.4.1"
           }
         },
         "hash-base": {
@@ -11002,8 +25078,8 @@
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "hash.js": {
@@ -11011,8 +25087,8 @@
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "hdkey": {
@@ -11020,8 +25096,8 @@
           "resolved": "https://registry.npmjs.org/hdkey/-/hdkey-0.7.1.tgz",
           "integrity": "sha1-yu5L6BqneSHpCbjSKN0PKayu5jI=",
           "requires": {
-            "coinstring": "2.3.0",
-            "secp256k1": "3.5.0"
+            "coinstring": "^2.0.0",
+            "secp256k1": "^3.0.1"
           }
         },
         "he": {
@@ -11039,9 +25115,9 @@
           "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "requires": {
-            "hash.js": "1.1.3",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
           }
         },
         "home-or-tmp": {
@@ -11049,8 +25125,8 @@
           "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.1"
           }
         },
         "hosted-git-info": {
@@ -11063,10 +25139,10 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
           "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
           "requires": {
-            "depd": "1.1.2",
+            "depd": "~1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.0",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.4.0 < 2"
           }
         },
         "http-https": {
@@ -11079,9 +25155,9 @@
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.2"
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "humble-localstorage": {
@@ -11089,8 +25165,8 @@
           "resolved": "https://registry.npmjs.org/humble-localstorage/-/humble-localstorage-1.4.2.tgz",
           "integrity": "sha1-0Fqw1SbE7b3b98amDfb/WAUoNGk=",
           "requires": {
-            "has-localstorage": "1.0.1",
-            "localstorage-memory": "1.0.2"
+            "has-localstorage": "^1.0.1",
+            "localstorage-memory": "^1.0.1"
           }
         },
         "iconv-lite": {
@@ -11098,7 +25174,7 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ieee754": {
@@ -11116,8 +25192,8 @@
           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -11130,7 +25206,7 @@
           "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "requires": {
-            "loose-envify": "1.3.1"
+            "loose-envify": "^1.0.0"
           }
         },
         "invert-kv": {
@@ -11153,7 +25229,7 @@
           "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "requires": {
-            "builtin-modules": "1.1.1"
+            "builtin-modules": "^1.0.0"
           }
         },
         "is-callable": {
@@ -11171,7 +25247,7 @@
           "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-fn": {
@@ -11184,7 +25260,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-function": {
@@ -11217,7 +25293,7 @@
           "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
           "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "requires": {
-            "has": "1.0.3"
+            "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
@@ -11260,8 +25336,8 @@
           "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
           "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
           "requires": {
-            "has-to-string-tag-x": "1.4.1",
-            "is-object": "1.0.1"
+            "has-to-string-tag-x": "^1.2.0",
+            "is-object": "^1.0.1"
           }
         },
         "js-scrypt": {
@@ -11269,7 +25345,7 @@
           "resolved": "https://registry.npmjs.org/js-scrypt/-/js-scrypt-0.2.0.tgz",
           "integrity": "sha1-emK3AbRhbnCtDN5URiequ5nX/jk=",
           "requires": {
-            "generic-pool": "2.0.4"
+            "generic-pool": "~2.0.4"
           }
         },
         "js-sha3": {
@@ -11298,12 +25374,12 @@
           "resolved": "https://registry.npmjs.org/json-rpc-engine/-/json-rpc-engine-3.7.3.tgz",
           "integrity": "sha512-+FO3UWu/wafh/+MZ6BXy0HZU+f5plwUn82FgxpC0scJkEh5snOjFrAAtqCITPDfvfLHRUFOG5pQDUx2pspfERQ==",
           "requires": {
-            "async": "2.6.1",
-            "babel-preset-env": "1.7.0",
-            "babelify": "7.3.0",
-            "clone": "2.1.1",
-            "json-rpc-error": "2.0.0",
-            "promise-to-callback": "1.0.0"
+            "async": "^2.0.1",
+            "babel-preset-env": "^1.3.2",
+            "babelify": "^7.3.0",
+            "clone": "^2.1.1",
+            "json-rpc-error": "^2.0.0",
+            "promise-to-callback": "^1.0.0"
           }
         },
         "json-rpc-error": {
@@ -11311,7 +25387,7 @@
           "resolved": "https://registry.npmjs.org/json-rpc-error/-/json-rpc-error-2.0.0.tgz",
           "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "^2.0.1"
           }
         },
         "json-rpc-random-id": {
@@ -11334,7 +25410,7 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -11352,7 +25428,7 @@
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "jsonify": {
@@ -11376,10 +25452,10 @@
           "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
           "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
           "requires": {
-            "bindings": "1.3.0",
-            "inherits": "2.0.3",
-            "nan": "2.10.0",
-            "safe-buffer": "5.1.2"
+            "bindings": "^1.2.1",
+            "inherits": "^2.0.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
           }
         },
         "keccakjs": {
@@ -11387,8 +25463,8 @@
           "resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.1.tgz",
           "integrity": "sha1-HWM6+QfvMFu/ny+mFtVsRFYd+k0=",
           "requires": {
-            "browserify-sha3": "0.0.1",
-            "sha3": "1.2.2"
+            "browserify-sha3": "^0.0.1",
+            "sha3": "^1.1.0"
           }
         },
         "klaw": {
@@ -11396,7 +25472,7 @@
           "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
           "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.9"
           }
         },
         "lcid": {
@@ -11404,7 +25480,7 @@
           "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
         },
         "level-codec": {
@@ -11417,7 +25493,7 @@
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
           "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.1"
           }
         },
         "level-iterator-stream": {
@@ -11425,10 +25501,10 @@
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
           "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
           "requires": {
-            "inherits": "2.0.3",
-            "level-errors": "1.0.5",
-            "readable-stream": "1.1.14",
-            "xtend": "4.0.1"
+            "inherits": "^2.0.1",
+            "level-errors": "^1.0.3",
+            "readable-stream": "^1.0.33",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "readable-stream": {
@@ -11436,10 +25512,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             }
           }
@@ -11449,7 +25525,7 @@
           "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
           "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
           "requires": {
-            "ltgt": "2.2.1"
+            "ltgt": "^2.1.2"
           }
         },
         "level-sublevel": {
@@ -11457,14 +25533,14 @@
           "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
           "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
           "requires": {
-            "bytewise": "1.1.0",
-            "levelup": "0.19.1",
-            "ltgt": "2.1.3",
-            "pull-defer": "0.2.2",
-            "pull-level": "2.0.4",
-            "pull-stream": "3.6.8",
-            "typewiselite": "1.0.0",
-            "xtend": "4.0.1"
+            "bytewise": "~1.1.0",
+            "levelup": "~0.19.0",
+            "ltgt": "~2.1.1",
+            "pull-defer": "^0.2.2",
+            "pull-level": "^2.0.3",
+            "pull-stream": "^3.6.8",
+            "typewiselite": "~1.0.0",
+            "xtend": "~4.0.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -11472,7 +25548,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
               "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
               "requires": {
-                "xtend": "3.0.0"
+                "xtend": "~3.0.0"
               },
               "dependencies": {
                 "xtend": {
@@ -11487,7 +25563,7 @@
               "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
               "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
               "requires": {
-                "abstract-leveldown": "0.12.4"
+                "abstract-leveldown": "~0.12.1"
               }
             },
             "levelup": {
@@ -11495,13 +25571,13 @@
               "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
               "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
               "requires": {
-                "bl": "0.8.2",
-                "deferred-leveldown": "0.2.0",
-                "errno": "0.1.7",
-                "prr": "0.0.0",
-                "readable-stream": "1.0.34",
-                "semver": "5.1.1",
-                "xtend": "3.0.0"
+                "bl": "~0.8.1",
+                "deferred-leveldown": "~0.2.0",
+                "errno": "~0.1.1",
+                "prr": "~0.0.0",
+                "readable-stream": "~1.0.26",
+                "semver": "~5.1.0",
+                "xtend": "~3.0.0"
               },
               "dependencies": {
                 "xtend": {
@@ -11526,10 +25602,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "semver": {
@@ -11544,8 +25620,8 @@
           "resolved": "https://registry.npmjs.org/level-ws/-/level-ws-0.0.0.tgz",
           "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
           "requires": {
-            "readable-stream": "1.0.34",
-            "xtend": "2.1.2"
+            "readable-stream": "~1.0.15",
+            "xtend": "~2.1.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -11553,10 +25629,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
                 "isarray": "0.0.1",
-                "string_decoder": "0.10.31"
+                "string_decoder": "~0.10.x"
               }
             },
             "xtend": {
@@ -11564,7 +25640,7 @@
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
               "requires": {
-                "object-keys": "0.4.0"
+                "object-keys": "~0.4.0"
               }
             }
           }
@@ -11574,13 +25650,13 @@
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
           "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
           "requires": {
-            "deferred-leveldown": "1.2.2",
-            "level-codec": "7.0.1",
-            "level-errors": "1.0.5",
-            "level-iterator-stream": "1.3.1",
-            "prr": "1.0.1",
-            "semver": "5.4.1",
-            "xtend": "4.0.1"
+            "deferred-leveldown": "~1.2.1",
+            "level-codec": "~7.0.0",
+            "level-errors": "~1.0.3",
+            "level-iterator-stream": "~1.3.0",
+            "prr": "~1.0.1",
+            "semver": "~5.4.1",
+            "xtend": "~4.0.0"
           }
         },
         "load-json-file": {
@@ -11588,11 +25664,11 @@
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -11609,10 +25685,10 @@
           "requires": {
             "abstract-leveldown": "0.12.3",
             "argsarray": "0.0.1",
-            "buffer-from": "0.1.2",
-            "d64": "1.0.0",
-            "humble-localstorage": "1.4.2",
-            "inherits": "2.0.3",
+            "buffer-from": "^0.1.1",
+            "d64": "^1.0.0",
+            "humble-localstorage": "^1.4.2",
+            "inherits": "^2.0.1",
             "tiny-queue": "0.2.0"
           },
           "dependencies": {
@@ -11621,7 +25697,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.3.tgz",
               "integrity": "sha1-EWsexcdxDvei1XBnaLvbREC+EHA=",
               "requires": {
-                "xtend": "3.0.0"
+                "xtend": "~3.0.0"
               }
             },
             "xtend": {
@@ -11661,7 +25737,7 @@
           "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
-            "js-tokens": "3.0.2"
+            "js-tokens": "^3.0.0"
           }
         },
         "lowercase-keys": {
@@ -11674,7 +25750,7 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
           "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
           "requires": {
-            "pseudomap": "1.0.2"
+            "pseudomap": "^1.0.1"
           }
         },
         "ltgt": {
@@ -11687,7 +25763,7 @@
           "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
           "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           }
         },
         "md5.js": {
@@ -11695,8 +25771,8 @@
           "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
           "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
           "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.3"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "media-typer": {
@@ -11709,12 +25785,12 @@
           "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
           "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
           "requires": {
-            "abstract-leveldown": "2.7.2",
-            "functional-red-black-tree": "1.0.1",
-            "immediate": "3.2.3",
-            "inherits": "2.0.3",
-            "ltgt": "2.2.1",
-            "safe-buffer": "5.1.2"
+            "abstract-leveldown": "~2.7.1",
+            "functional-red-black-tree": "^1.0.1",
+            "immediate": "^3.2.3",
+            "inherits": "~2.0.1",
+            "ltgt": "~2.2.0",
+            "safe-buffer": "~5.1.1"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -11722,7 +25798,7 @@
               "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "requires": {
-                "xtend": "4.0.1"
+                "xtend": "~4.0.0"
               }
             }
           }
@@ -11742,14 +25818,14 @@
           "resolved": "https://registry.npmjs.org/merkle-patricia-tree/-/merkle-patricia-tree-2.3.1.tgz",
           "integrity": "sha512-Qp9Mpb3xazznXzzGQBqHbqCpT2AR9joUOHYYPiQjYCarrdCPCnLWXo4BFv77y4xN26KR224xoU1n/qYY7RYYgw==",
           "requires": {
-            "async": "1.5.2",
-            "ethereumjs-util": "5.2.0",
+            "async": "^1.4.2",
+            "ethereumjs-util": "^5.0.0",
             "level-ws": "0.0.0",
-            "levelup": "1.3.9",
-            "memdown": "1.4.1",
-            "readable-stream": "2.3.6",
-            "rlp": "2.0.0",
-            "semaphore": "1.1.0"
+            "levelup": "^1.2.1",
+            "memdown": "^1.0.0",
+            "readable-stream": "^2.0.0",
+            "rlp": "^2.0.0",
+            "semaphore": ">=1.0.1"
           },
           "dependencies": {
             "async": {
@@ -11769,8 +25845,8 @@
           "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "requires": {
-            "bn.js": "4.11.6",
-            "brorand": "1.1.0"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "mime": {
@@ -11788,7 +25864,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         },
         "mimic-response": {
@@ -11801,7 +25877,7 @@
           "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
           "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
           "requires": {
-            "dom-walk": "0.1.1"
+            "dom-walk": "^0.1.0"
           }
         },
         "minimalistic-assert": {
@@ -11819,7 +25895,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -11840,7 +25916,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
           "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
           "requires": {
-            "mkdirp": "0.5.1"
+            "mkdirp": "*"
           }
         },
         "mocha": {
@@ -11879,7 +25955,7 @@
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
               "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
               "requires": {
-                "has-flag": "2.0.0"
+                "has-flag": "^2.0.0"
               }
             }
           }
@@ -11904,9 +25980,9 @@
           "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
           "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
           "requires": {
-            "any-promise": "1.3.0",
-            "object-assign": "4.1.1",
-            "thenify-all": "1.6.0"
+            "any-promise": "^1.0.0",
+            "object-assign": "^4.0.1",
+            "thenify-all": "^1.0.0"
           }
         },
         "nan": {
@@ -11934,10 +26010,10 @@
           "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "requires": {
-            "hosted-git-info": "2.6.0",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
-            "validate-npm-package-license": "3.0.3"
+            "hosted-git-info": "^2.1.4",
+            "is-builtin-module": "^1.0.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "number-is-nan": {
@@ -11979,7 +26055,7 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.3.tgz",
           "integrity": "sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=",
           "requires": {
-            "http-https": "1.0.0"
+            "http-https": "^1.0.0"
           }
         },
         "on-finished": {
@@ -11995,7 +26071,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -12008,7 +26084,7 @@
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "os-tmpdir": {
@@ -12031,7 +26107,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-1.2.1.tgz",
           "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
           "requires": {
-            "p-finally": "1.0.0"
+            "p-finally": "^1.0.0"
           }
         },
         "parse-asn1": {
@@ -12039,11 +26115,11 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.1.tgz",
           "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
           "requires": {
-            "asn1.js": "4.10.1",
-            "browserify-aes": "1.2.0",
-            "create-hash": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "pbkdf2": "3.0.16"
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3"
           }
         },
         "parse-headers": {
@@ -12051,7 +26127,7 @@
           "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
           "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
           "requires": {
-            "for-each": "0.3.2",
+            "for-each": "^0.3.2",
             "trim": "0.0.1"
           }
         },
@@ -12060,7 +26136,7 @@
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
-            "error-ex": "1.3.1"
+            "error-ex": "^1.2.0"
           }
         },
         "parseurl": {
@@ -12073,7 +26149,7 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -12096,9 +26172,9 @@
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -12113,11 +26189,11 @@
           "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
           "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
           "requires": {
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.1.2",
-            "sha.js": "2.4.11"
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "pend": {
@@ -12145,7 +26221,7 @@
           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "precond": {
@@ -12186,8 +26262,8 @@
           "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
           "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
           "requires": {
-            "is-fn": "1.0.0",
-            "set-immediate-shim": "1.0.1"
+            "is-fn": "^1.0.0",
+            "set-immediate-shim": "^1.0.1"
           }
         },
         "proxy-addr": {
@@ -12195,7 +26271,7 @@
           "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
           "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
           "requires": {
-            "forwarded": "0.1.2",
+            "forwarded": "~0.1.2",
             "ipaddr.js": "1.6.0"
           }
         },
@@ -12214,11 +26290,11 @@
           "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
           "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
           "requires": {
-            "bn.js": "4.11.6",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.2.0",
-            "parse-asn1": "5.1.1",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1"
           }
         },
         "pull-cat": {
@@ -12236,13 +26312,13 @@
           "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
           "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
           "requires": {
-            "level-post": "1.0.7",
-            "pull-cat": "1.1.11",
-            "pull-live": "1.0.1",
-            "pull-pushable": "2.2.0",
-            "pull-stream": "3.6.8",
-            "pull-window": "2.1.4",
-            "stream-to-pull-stream": "1.7.2"
+            "level-post": "^1.0.7",
+            "pull-cat": "^1.1.9",
+            "pull-live": "^1.0.1",
+            "pull-pushable": "^2.0.0",
+            "pull-stream": "^3.4.0",
+            "pull-window": "^2.1.4",
+            "stream-to-pull-stream": "^1.7.1"
           }
         },
         "pull-live": {
@@ -12250,8 +26326,8 @@
           "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
           "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
           "requires": {
-            "pull-cat": "1.1.11",
-            "pull-stream": "3.6.8"
+            "pull-cat": "^1.1.9",
+            "pull-stream": "^3.4.0"
           }
         },
         "pull-pushable": {
@@ -12269,7 +26345,7 @@
           "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
           "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
           "requires": {
-            "looper": "2.0.0"
+            "looper": "^2.0.0"
           }
         },
         "punycode": {
@@ -12287,9 +26363,9 @@
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "requires": {
-            "decode-uri-component": "0.2.0",
-            "object-assign": "4.1.1",
-            "strict-uri-encode": "1.1.0"
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
           }
         },
         "randombytes": {
@@ -12297,7 +26373,7 @@
           "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
           "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
@@ -12305,8 +26381,8 @@
           "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
           "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
           "requires": {
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2"
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
           }
         },
         "randomhex": {
@@ -12335,9 +26411,9 @@
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
@@ -12345,8 +26421,8 @@
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
@@ -12354,13 +26430,13 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           },
           "dependencies": {
             "isarray": {
@@ -12373,7 +26449,7 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             }
           }
@@ -12393,9 +26469,9 @@
           "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "requires": {
-            "babel-runtime": "6.26.0",
-            "babel-types": "6.26.0",
-            "private": "0.1.8"
+            "babel-runtime": "^6.18.0",
+            "babel-types": "^6.19.0",
+            "private": "^0.1.6"
           }
         },
         "regexpu-core": {
@@ -12403,9 +26479,9 @@
           "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "requires": {
-            "regenerate": "1.4.0",
-            "regjsgen": "0.2.0",
-            "regjsparser": "0.1.5"
+            "regenerate": "^1.2.1",
+            "regjsgen": "^0.2.0",
+            "regjsparser": "^0.1.4"
           }
         },
         "regjsgen": {
@@ -12418,7 +26494,7 @@
           "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "requires": {
-            "jsesc": "0.5.0"
+            "jsesc": "~0.5.0"
           }
         },
         "repeating": {
@@ -12426,7 +26502,7 @@
           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "requires": {
-            "is-finite": "1.0.2"
+            "is-finite": "^1.0.0"
           }
         },
         "request": {
@@ -12434,26 +26510,26 @@
           "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
           "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
           "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.7.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
           },
           "dependencies": {
             "uuid": {
@@ -12483,7 +26559,7 @@
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
           "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
           "requires": {
-            "path-parse": "1.0.5"
+            "path-parse": "^1.0.5"
           }
         },
         "resumer": {
@@ -12491,7 +26567,7 @@
           "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
           "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
           "requires": {
-            "through": "2.3.8"
+            "through": "~2.3.4"
           }
         },
         "rimraf": {
@@ -12499,7 +26575,7 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "ripemd160": {
@@ -12507,8 +26583,8 @@
           "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.3"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "rlp": {
@@ -12536,7 +26612,7 @@
           "resolved": "https://registry.npmjs.org/scrypt/-/scrypt-6.0.3.tgz",
           "integrity": "sha1-BOAUpWgrU/pQwtXM4WfXGcBthw0=",
           "requires": {
-            "nan": "2.10.0"
+            "nan": "^2.0.8"
           }
         },
         "scrypt.js": {
@@ -12544,8 +26620,8 @@
           "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
           "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
           "requires": {
-            "scrypt": "6.0.3",
-            "scryptsy": "1.2.1"
+            "scrypt": "^6.0.2",
+            "scryptsy": "^1.2.1"
           }
         },
         "scryptsy": {
@@ -12553,7 +26629,7 @@
           "resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-1.2.1.tgz",
           "integrity": "sha1-oyJfpLJST4AnAHYeKFW987LZIWM=",
           "requires": {
-            "pbkdf2": "3.0.16"
+            "pbkdf2": "^3.0.3"
           }
         },
         "secp256k1": {
@@ -12561,14 +26637,14 @@
           "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.5.0.tgz",
           "integrity": "sha512-e5QIJl8W7Y4tT6LHffVcZAxJjvpgE5Owawv6/XCYPQljE9aP2NFFddQ8OYMKhdLshNu88FfL3qCN3/xYkXGRsA==",
           "requires": {
-            "bindings": "1.3.0",
-            "bip66": "1.1.5",
-            "bn.js": "4.11.6",
-            "create-hash": "1.2.0",
-            "drbg.js": "1.0.1",
-            "elliptic": "6.4.0",
-            "nan": "2.10.0",
-            "safe-buffer": "5.1.2"
+            "bindings": "^1.2.1",
+            "bip66": "^1.1.3",
+            "bn.js": "^4.11.3",
+            "create-hash": "^1.1.2",
+            "drbg.js": "^1.0.1",
+            "elliptic": "^6.2.3",
+            "nan": "^2.2.1",
+            "safe-buffer": "^5.1.0"
           }
         },
         "seedrandom": {
@@ -12581,7 +26657,7 @@
           "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
           "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
           "requires": {
-            "commander": "2.8.1"
+            "commander": "~2.8.1"
           }
         },
         "semaphore": {
@@ -12600,18 +26676,18 @@
           "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
           "requires": {
             "debug": "2.6.9",
-            "depd": "1.1.2",
-            "destroy": "1.0.4",
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "etag": "1.8.1",
+            "depd": "~1.1.2",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "1.6.3",
+            "http-errors": "~1.6.2",
             "mime": "1.4.1",
             "ms": "2.0.0",
-            "on-finished": "2.3.0",
-            "range-parser": "1.2.0",
-            "statuses": "1.4.0"
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.4.0"
           },
           "dependencies": {
             "statuses": {
@@ -12626,9 +26702,9 @@
           "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
           "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
           "requires": {
-            "encodeurl": "1.0.2",
-            "escape-html": "1.0.3",
-            "parseurl": "1.3.2",
+            "encodeurl": "~1.0.2",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
             "send": "0.16.2"
           }
         },
@@ -12637,11 +26713,11 @@
           "resolved": "https://registry.npmjs.org/servify/-/servify-0.1.12.tgz",
           "integrity": "sha512-/xE6GvsKKqyo1BAY+KxOWXcLpPsUUyji7Qg3bVD7hh1eRze5bR1uYiuDA/k3Gof1s9BTzQZEJK8sNcNGFIzeWw==",
           "requires": {
-            "body-parser": "1.18.3",
-            "cors": "2.8.4",
-            "express": "4.16.3",
-            "request": "2.87.0",
-            "xhr": "2.5.0"
+            "body-parser": "^1.16.0",
+            "cors": "^2.8.1",
+            "express": "^4.14.0",
+            "request": "^2.79.0",
+            "xhr": "^2.3.3"
           }
         },
         "set-blocking": {
@@ -12669,8 +26745,8 @@
           "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "sha3": {
@@ -12696,9 +26772,9 @@
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "requires": {
-            "decompress-response": "3.3.0",
-            "once": "1.4.0",
-            "simple-concat": "1.0.0"
+            "decompress-response": "^3.3.0",
+            "once": "^1.3.1",
+            "simple-concat": "^1.0.0"
           }
         },
         "slash": {
@@ -12711,11 +26787,11 @@
           "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.24.tgz",
           "integrity": "sha512-2xd7Cf1HeVwrIb6Bu1cwY2/TaLRodrppCq3l7rhLimFQgmxptXhTC3+/wesVLpB09F1A2kZgvbMOgH7wvhFnBQ==",
           "requires": {
-            "fs-extra": "0.30.0",
-            "memorystream": "0.3.1",
-            "require-from-string": "1.2.1",
-            "semver": "5.4.1",
-            "yargs": "4.8.1"
+            "fs-extra": "^0.30.0",
+            "memorystream": "^0.3.1",
+            "require-from-string": "^1.1.0",
+            "semver": "^5.3.0",
+            "yargs": "^4.7.1"
           },
           "dependencies": {
             "yargs": {
@@ -12723,20 +26799,20 @@
               "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
               "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
               "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.1",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.1"
               }
             }
           }
@@ -12751,7 +26827,7 @@
           "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
           "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
           "requires": {
-            "source-map": "0.5.7"
+            "source-map": "^0.5.6"
           }
         },
         "spdx-correct": {
@@ -12759,8 +26835,8 @@
           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -12773,8 +26849,8 @@
           "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
-            "spdx-exceptions": "2.1.0",
-            "spdx-license-ids": "3.0.0"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -12787,15 +26863,15 @@
           "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
           "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "safer-buffer": "2.1.2",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "safer-buffer": "^2.0.2",
+            "tweetnacl": "~0.14.0"
           }
         },
         "statuses": {
@@ -12808,8 +26884,8 @@
           "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
           "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
           "requires": {
-            "looper": "3.0.0",
-            "pull-stream": "3.6.8"
+            "looper": "^3.0.0",
+            "pull-stream": "^3.2.3"
           },
           "dependencies": {
             "looper": {
@@ -12829,9 +26905,9 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string.prototype.trim": {
@@ -12839,9 +26915,9 @@
           "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz",
           "integrity": "sha1-0E3iyJ4Tf019IG8Ia17S+ua+jOo=",
           "requires": {
-            "define-properties": "1.1.2",
-            "es-abstract": "1.12.0",
-            "function-bind": "1.1.1"
+            "define-properties": "^1.1.2",
+            "es-abstract": "^1.5.0",
+            "function-bind": "^1.0.2"
           }
         },
         "string_decoder": {
@@ -12854,7 +26930,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
@@ -12862,7 +26938,7 @@
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-dirs": {
@@ -12870,7 +26946,7 @@
           "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
           "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
           "requires": {
-            "is-natural-number": "4.0.1"
+            "is-natural-number": "^4.0.1"
           }
         },
         "strip-hex-prefix": {
@@ -12891,19 +26967,19 @@
           "resolved": "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.37.tgz",
           "integrity": "sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==",
           "requires": {
-            "bluebird": "3.5.1",
-            "buffer": "5.1.0",
-            "decompress": "4.2.0",
-            "eth-lib": "0.1.27",
-            "fs-extra": "2.1.2",
-            "fs-promise": "2.0.3",
-            "got": "7.1.0",
-            "mime-types": "2.1.18",
-            "mkdirp-promise": "5.0.1",
-            "mock-fs": "4.5.0",
-            "setimmediate": "1.0.5",
-            "tar.gz": "1.0.7",
-            "xhr-request-promise": "0.1.2"
+            "bluebird": "^3.5.0",
+            "buffer": "^5.0.5",
+            "decompress": "^4.0.0",
+            "eth-lib": "^0.1.26",
+            "fs-extra": "^2.1.2",
+            "fs-promise": "^2.0.0",
+            "got": "^7.1.0",
+            "mime-types": "^2.1.16",
+            "mkdirp-promise": "^5.0.1",
+            "mock-fs": "^4.1.0",
+            "setimmediate": "^1.0.5",
+            "tar.gz": "^1.0.5",
+            "xhr-request-promise": "^0.1.2"
           },
           "dependencies": {
             "fs-extra": {
@@ -12911,8 +26987,8 @@
               "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
               "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
               "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "2.4.0"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^2.1.0"
               }
             }
           }
@@ -12922,19 +26998,19 @@
           "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
           "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
           "requires": {
-            "deep-equal": "1.0.1",
-            "defined": "1.0.0",
-            "for-each": "0.3.2",
-            "function-bind": "1.1.1",
-            "glob": "7.1.2",
-            "has": "1.0.3",
-            "inherits": "2.0.3",
-            "minimist": "1.2.0",
-            "object-inspect": "1.5.0",
-            "resolve": "1.5.0",
-            "resumer": "0.0.0",
-            "string.prototype.trim": "1.1.2",
-            "through": "2.3.8"
+            "deep-equal": "~1.0.1",
+            "defined": "~1.0.0",
+            "for-each": "~0.3.2",
+            "function-bind": "~1.1.1",
+            "glob": "~7.1.2",
+            "has": "~1.0.1",
+            "inherits": "~2.0.3",
+            "minimist": "~1.2.0",
+            "object-inspect": "~1.5.0",
+            "resolve": "~1.5.0",
+            "resumer": "~0.0.0",
+            "string.prototype.trim": "~1.1.2",
+            "through": "~2.3.8"
           },
           "dependencies": {
             "minimist": {
@@ -12949,9 +27025,9 @@
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-stream": {
@@ -12959,13 +27035,13 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
           "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
           "requires": {
-            "bl": "1.2.2",
-            "buffer-alloc": "1.1.0",
-            "end-of-stream": "1.4.1",
-            "fs-constants": "1.0.0",
-            "readable-stream": "2.3.6",
-            "to-buffer": "1.1.1",
-            "xtend": "4.0.1"
+            "bl": "^1.0.0",
+            "buffer-alloc": "^1.1.0",
+            "end-of-stream": "^1.0.0",
+            "fs-constants": "^1.0.0",
+            "readable-stream": "^2.3.0",
+            "to-buffer": "^1.1.0",
+            "xtend": "^4.0.0"
           },
           "dependencies": {
             "bl": {
@@ -12973,8 +27049,8 @@
               "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
               "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
               "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
               }
             }
           }
@@ -12984,11 +27060,11 @@
           "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.7.tgz",
           "integrity": "sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==",
           "requires": {
-            "bluebird": "2.11.0",
-            "commander": "2.8.1",
-            "fstream": "1.0.11",
-            "mout": "0.11.1",
-            "tar": "2.2.1"
+            "bluebird": "^2.9.34",
+            "commander": "^2.8.1",
+            "fstream": "^1.0.8",
+            "mout": "^0.11.0",
+            "tar": "^2.1.1"
           },
           "dependencies": {
             "bluebird": {
@@ -13003,8 +27079,8 @@
           "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
           "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
           "requires": {
-            "os-tmpdir": "1.0.2",
-            "rimraf": "2.2.8"
+            "os-tmpdir": "^1.0.0",
+            "rimraf": "~2.2.6"
           },
           "dependencies": {
             "rimraf": {
@@ -13019,7 +27095,7 @@
           "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
           "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
           "requires": {
-            "any-promise": "1.3.0"
+            "any-promise": "^1.0.0"
           }
         },
         "thenify-all": {
@@ -13027,7 +27103,7 @@
           "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
           "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
           "requires": {
-            "thenify": "3.3.0"
+            "thenify": ">= 3.1.0 < 4"
           }
         },
         "through": {
@@ -13040,8 +27116,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
           "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "^2.1.5",
+            "xtend": "~4.0.1"
           }
         },
         "timed-out": {
@@ -13059,7 +27135,7 @@
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
           "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
           "requires": {
-            "os-tmpdir": "1.0.2"
+            "os-tmpdir": "~1.0.1"
           }
         },
         "to-buffer": {
@@ -13077,7 +27153,7 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "treeify": {
@@ -13100,7 +27176,7 @@
           "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -13120,7 +27196,7 @@
           "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "2.1.18"
+            "mime-types": "~2.1.18"
           }
         },
         "typedarray": {
@@ -13133,7 +27209,7 @@
           "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
           "requires": {
-            "is-typedarray": "1.0.0"
+            "is-typedarray": "^1.0.0"
           }
         },
         "typewise": {
@@ -13141,7 +27217,7 @@
           "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
           "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
           "requires": {
-            "typewise-core": "1.2.0"
+            "typewise-core": "^1.2.0"
           }
         },
         "typewise-core": {
@@ -13164,8 +27240,8 @@
           "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
           "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
           "requires": {
-            "buffer": "3.6.0",
-            "through": "2.3.8"
+            "buffer": "^3.0.1",
+            "through": "^2.3.6"
           },
           "dependencies": {
             "base64-js": {
@@ -13179,8 +27255,8 @@
               "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
               "requires": {
                 "base64-js": "0.0.8",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
               }
             },
             "isarray": {
@@ -13210,7 +27286,7 @@
           "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "requires": {
-            "prepend-http": "1.0.4"
+            "prepend-http": "^1.0.1"
           }
         },
         "url-set-query": {
@@ -13263,8 +27339,8 @@
           "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "requires": {
-            "spdx-correct": "3.0.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "vary": {
@@ -13277,9 +27353,9 @@
           "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "requires": {
-            "assert-plus": "1.0.0",
+            "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
+            "extsprintf": "^1.2.0"
           }
         },
         "web3": {
@@ -13422,9 +27498,9 @@
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "requires": {
-                "bn.js": "4.11.6",
-                "elliptic": "6.4.0",
-                "xhr-request-promise": "0.1.2"
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
               }
             },
             "uuid": {
@@ -13485,27 +27561,27 @@
           "resolved": "https://registry.npmjs.org/web3-provider-engine/-/web3-provider-engine-14.0.6.tgz",
           "integrity": "sha512-tr5cGSyxfSC/JqiUpBlJtfZpwQf1yAA8L/zy1C6fDFm0ntR974pobJ4v4676atpZne4Ze5VFy3kPPahHe9gQiQ==",
           "requires": {
-            "async": "2.6.1",
-            "backoff": "2.5.0",
-            "clone": "2.1.1",
-            "cross-fetch": "2.2.1",
-            "eth-block-tracker": "3.0.1",
-            "eth-json-rpc-infura": "3.1.2",
-            "eth-sig-util": "1.4.2",
-            "ethereumjs-block": "1.2.2",
-            "ethereumjs-tx": "1.3.4",
-            "ethereumjs-util": "5.2.0",
-            "ethereumjs-vm": "2.3.5",
-            "json-rpc-error": "2.0.0",
-            "json-stable-stringify": "1.0.1",
-            "promise-to-callback": "1.0.0",
-            "readable-stream": "2.3.6",
-            "request": "2.87.0",
-            "semaphore": "1.1.0",
-            "tape": "4.9.0",
-            "ws": "5.2.0",
-            "xhr": "2.5.0",
-            "xtend": "4.0.1"
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.67.0",
+            "semaphore": "^1.0.3",
+            "tape": "^4.4.0",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
           },
           "dependencies": {
             "eth-sig-util": {
@@ -13513,16 +27589,16 @@
               "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                "ethereumjs-util": "5.2.0"
+                "ethereumjs-abi": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                "ethereumjs-util": "^5.1.1"
               }
             },
             "ethereumjs-abi": {
               "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
               "from": "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
               "requires": {
-                "bn.js": "4.11.6",
-                "ethereumjs-util": "5.2.0"
+                "bn.js": "^4.10.0",
+                "ethereumjs-util": "^5.0.0"
               }
             },
             "ws": {
@@ -13530,7 +27606,7 @@
               "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.0.tgz",
               "integrity": "sha512-c18dMeW+PEQdDFzkhDsnBAlS4Z8KGStBQQUcQ5mf7Nf689jyGk0594L+i9RaQuf4gog6SvWLJorz2NfSaqxZ7w==",
               "requires": {
-                "async-limiter": "1.0.0"
+                "async-limiter": "~1.0.0"
               }
             }
           }
@@ -13561,17 +27637,17 @@
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.34",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "websocket": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
           },
           "dependencies": {
             "websocket": {
               "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "from": "websocket@git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
               "requires": {
-                "debug": "2.6.9",
-                "nan": "2.10.0",
-                "typedarray-to-buffer": "3.1.5",
-                "yaeti": "0.0.6"
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
               }
             }
           }
@@ -13613,10 +27689,10 @@
           "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.26.tgz",
           "integrity": "sha512-fjcrYDPIQxpTnqFQ9JjxUQcdvR89MFAOjPBlF+vjOt49w/XW4fJknUoMz/mDIn2eK1AdslVojcaOxOqyZZV8rw==",
           "requires": {
-            "debug": "2.6.9",
-            "nan": "2.10.0",
-            "typedarray-to-buffer": "3.1.5",
-            "yaeti": "0.0.6"
+            "debug": "^2.2.0",
+            "nan": "^2.3.3",
+            "typedarray-to-buffer": "^3.1.2",
+            "yaeti": "^0.0.6"
           }
         },
         "whatwg-fetch": {
@@ -13639,8 +27715,8 @@
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           }
         },
         "wrappy": {
@@ -13653,9 +27729,9 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
           "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.2",
-            "ultron": "1.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0",
+            "ultron": "~1.1.0"
           }
         },
         "xhr": {
@@ -13663,10 +27739,10 @@
           "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
           "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
           "requires": {
-            "global": "4.3.2",
-            "is-function": "1.0.1",
-            "parse-headers": "2.0.1",
-            "xtend": "4.0.1"
+            "global": "~4.3.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "xhr-request": {
@@ -13674,13 +27750,13 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "requires": {
-            "buffer-to-arraybuffer": "0.0.5",
-            "object-assign": "4.1.1",
-            "query-string": "5.1.1",
-            "simple-get": "2.8.1",
-            "timed-out": "4.0.1",
-            "url-set-query": "1.0.0",
-            "xhr": "2.5.0"
+            "buffer-to-arraybuffer": "^0.0.5",
+            "object-assign": "^4.1.1",
+            "query-string": "^5.0.1",
+            "simple-get": "^2.7.0",
+            "timed-out": "^4.0.1",
+            "url-set-query": "^1.0.0",
+            "xhr": "^2.0.4"
           }
         },
         "xhr-request-promise": {
@@ -13688,7 +27764,7 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.2.tgz",
           "integrity": "sha1-NDxE0e53JrhkgGloLQ+EDIO0Jh0=",
           "requires": {
-            "xhr-request": "1.1.0"
+            "xhr-request": "^1.0.1"
           }
         },
         "xhr2": {
@@ -13716,19 +27792,19 @@
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           },
           "dependencies": {
             "yargs-parser": {
@@ -13736,7 +27812,7 @@
               "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
               "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
               "requires": {
-                "camelcase": "3.0.0"
+                "camelcase": "^3.0.0"
               }
             }
           }
@@ -13746,8 +27822,8 @@
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "requires": {
-            "camelcase": "3.0.0",
-            "lodash.assign": "4.2.0"
+            "camelcase": "^3.0.0",
+            "lodash.assign": "^4.0.6"
           }
         },
         "yauzl": {
@@ -13755,8 +27831,8 @@
           "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
           "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
           "requires": {
-            "buffer-crc32": "0.2.13",
-            "fd-slicer": "1.0.1"
+            "buffer-crc32": "~0.2.3",
+            "fd-slicer": "~1.0.1"
           }
         }
       }
@@ -14899,7 +28975,7 @@
             "protons": "^1.0.1",
             "rsa-pem-to-jwk": "^1.1.3",
             "tweetnacl": "^1.0.0",
-            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+            "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
           },
           "dependencies": {
             "js-sha3": {
@@ -15390,7 +29466,8 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-object": {
       "version": "1.0.1",
@@ -15975,7 +30052,7 @@
         "protons": "^1.0.1",
         "rsa-pem-to-jwk": "^1.1.3",
         "tweetnacl": "^1.0.0",
-        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8"
+        "webcrypto-shim": "github:dignifiedquire/webcrypto-shim#master"
       },
       "dependencies": {
         "tweetnacl": {
@@ -16699,30 +30776,6 @@
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
-      }
-    },
-    "lowdb": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lowdb/-/lowdb-1.0.0.tgz",
-      "integrity": "sha512-2+x8esE/Wb9SQ1F9IHaYWfsC9FIecLOPrK4g17FGEayjUWH172H6nwicRovGvSE2CPZouc2MCIqCI7h9d+GftQ==",
-      "requires": {
-        "graceful-fs": "^4.1.3",
-        "is-promise": "^2.1.0",
-        "lodash": "4",
-        "pify": "^3.0.0",
-        "steno": "^0.4.1"
-      },
-      "dependencies": {
-        "is-promise": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-          "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
-        },
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-        }
       }
     },
     "lowercase-keys": {
@@ -18005,11 +32058,6 @@
         }
       }
     },
-    "pako": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-      "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
-    },
     "parent-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
@@ -18681,26 +32729,6 @@
         "decode-uri-component": "^0.2.0",
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
-      }
-    },
-    "radspec": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/radspec/-/radspec-1.1.5.tgz",
-      "integrity": "sha512-oKyKRyh5LTvE90j+WqUu7+IBYW4w7oQtG+fbeCCFMs0XA0jAblaHjmHl1wy5+XN6x+JLOjoXhWdKq2BuWXGGeg==",
-      "requires": {
-        "@babel/runtime": "^7.1.2",
-        "bn.js": "4.11.6",
-        "date-fns": "2.0.0-alpha.22",
-        "web3-eth": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
       }
     },
     "randomatic": {
@@ -20210,14 +34238,6 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
-    "steno": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/steno/-/steno-0.4.4.tgz",
-      "integrity": "sha1-BxEFvfwobmYVwEA8J+nXtdy4Vcs=",
-      "requires": {
-        "graceful-fs": "^4.1.3"
-      }
-    },
     "stream-array": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/stream-array/-/stream-array-1.1.2.tgz",
@@ -20684,11 +34704,6 @@
         }
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -21127,7 +35142,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.7.tgz",
           "integrity": "sha512-VU6/DSUX93d1fCzBz7WP/SGCQizO1rKZi4Px9j/3yRyfssHyFcZamMw2/sj4E8TlfMXONvZLoforR8B4bRoyTQ==",
           "requires": {
-            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
+            "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xhr2-cookies": "^1.1.0",
@@ -21242,11 +35257,6 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unherit": {
       "version": "1.1.1",
@@ -22112,7 +36122,7 @@
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.34",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
           }
         },
         "web3-shh": {
@@ -22140,272 +36150,6 @@
             "utf8": "2.1.1"
           }
         }
-      }
-    },
-    "web3-bzz": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.33.tgz",
-      "integrity": "sha1-MVAPaZt+cO31FJDFXv+0J7+7OwE=",
-      "requires": {
-        "got": "7.1.0",
-        "swarm-js": "0.1.37",
-        "underscore": "1.8.3"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-core": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+C7VJfW2auzale7O08rSvWlfeDk=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-requestmanager": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      }
-    },
-    "web3-core-helpers": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Kvcz5QTbBefDZIwdrPV3sOwV3EM=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-core-method": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.33.tgz",
-      "integrity": "sha1-7Y7ExK+rIdwJid41g2hEZlIrboY=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-core-promievent": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.33.tgz",
-      "integrity": "sha1-0fXrtgFSfdSWViw2IXblWNly01g=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "eventemitter3": "1.1.1"
-      }
-    },
-    "web3-core-requestmanager": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.33.tgz",
-      "integrity": "sha1-ejbEA1QALfsXnKLb22pgEsn3Ges=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-providers-http": "1.0.0-beta.33",
-        "web3-providers-ipc": "1.0.0-beta.33",
-        "web3-providers-ws": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-core-subscriptions": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.33.tgz",
-      "integrity": "sha1-YCh1yfTV9NDhYhRitfwewZs1veM=",
-      "requires": {
-        "eventemitter3": "1.1.1",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-eth": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.0.0-beta.33.tgz",
-      "integrity": "sha1-hKn5TallUnyS2DitTlcN8CWJhJ8=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-eth-accounts": "1.0.0-beta.33",
-        "web3-eth-contract": "1.0.0-beta.33",
-        "web3-eth-iban": "1.0.0-beta.33",
-        "web3-eth-personal": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-eth-abi": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.33.tgz",
-      "integrity": "sha1-IiH3FRZDZgAypN80D2EjSRaMgko=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-eth-accounts": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.33.tgz",
-      "integrity": "sha1-JajX9OWOHpk7kvBpVILMzckhL5E=",
-      "requires": {
-        "any-promise": "1.3.0",
-        "crypto-browserify": "3.12.0",
-        "eth-lib": "0.2.7",
-        "scrypt.js": "0.2.0",
-        "underscore": "1.8.3",
-        "uuid": "2.0.1",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "scrypt.js": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/scrypt.js/-/scrypt.js-0.2.0.tgz",
-          "integrity": "sha1-r40UZbcemZARC+38WTuUeeA6ito=",
-          "requires": {
-            "scrypt": "^6.0.2",
-            "scryptsy": "^1.2.1"
-          }
-        },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "uuid": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
-        }
-      }
-    },
-    "web3-eth-contract": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.33.tgz",
-      "integrity": "sha1-nlkZ8pF6PGe0+2Vp1JxeMDiSW84=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-promievent": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-eth-abi": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-eth-iban": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.33.tgz",
-      "integrity": "sha1-HXPQxSiKRWWxdUp1tfs+oLd6Uy8=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        }
-      }
-    },
-    "web3-eth-personal": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tOSFh8xOfrAY2ib947Tzul+bmO8=",
-      "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
-      }
-    },
-    "web3-net": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.33.tgz",
-      "integrity": "sha1-tskNGg4WJuquiz2SKsFTZy/VZEU=",
-      "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-utils": "1.0.0-beta.33"
       }
     },
     "web3-provider-engine": {
@@ -22457,96 +36201,11 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
           }
-        }
-      }
-    },
-    "web3-providers-http": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.0.0-beta.33.tgz",
-      "integrity": "sha1-OzWuAO599blrSTSWKtSobypVmcE=",
-      "requires": {
-        "web3-core-helpers": "1.0.0-beta.33",
-        "xhr2": "0.1.4"
-      }
-    },
-    "web3-providers-ipc": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.33.tgz",
-      "integrity": "sha1-Twrcmv6dEsBm5L5cPFNvUHPLB8Y=",
-      "requires": {
-        "oboe": "2.1.3",
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-providers-ws": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.33.tgz",
-      "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
-      "requires": {
-        "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        }
-      }
-    },
-    "web3-shh": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.33.tgz",
-      "integrity": "sha1-+Z4mVz9uCZMhrw2fK/z+Pe01UKE=",
-      "requires": {
-        "web3-core": "1.0.0-beta.33",
-        "web3-core-method": "1.0.0-beta.33",
-        "web3-core-subscriptions": "1.0.0-beta.33",
-        "web3-net": "1.0.0-beta.33"
-      }
-    },
-    "web3-utils": {
-      "version": "1.0.0-beta.33",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.33.tgz",
-      "integrity": "sha1-4JG3mU8JtxSwGYpAV9OtLrjL4jg=",
-      "requires": {
-        "bn.js": "4.11.6",
-        "eth-lib": "0.1.27",
-        "ethjs-unit": "0.1.6",
-        "number-to-bn": "1.7.0",
-        "randomhex": "0.1.5",
-        "underscore": "1.8.3",
-        "utf8": "2.1.1"
-      },
-      "dependencies": {
-        "bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU="
-        },
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
-        },
-        "utf8": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-          "integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g="
         }
       }
     },

--- a/src/commands/dao.js
+++ b/src/commands/dao.js
@@ -16,7 +16,7 @@ exports.command = 'dao <command>'
 exports.describe = 'Manage your Aragon DAO'
 
 exports.builder = function(yargs) {
-  if (process.argv[3] !== 'new') {
+  if (process.argv[3] !== 'new' && process.argv[3] !== 'act') {
     yargs = daoArg(yargs)
   }
 

--- a/src/commands/dao_cmds/act.js
+++ b/src/commands/dao_cmds/act.js
@@ -17,7 +17,7 @@ exports.builder = function(yargs) {
       type: 'string',
     })
     .positional('target', {
-      description: 'Function to be executed',
+      description: 'Address where the action is being executed',
       type: 'string',
     })
     .positional('signature', {

--- a/src/commands/dao_cmds/act.js
+++ b/src/commands/dao_cmds/act.js
@@ -4,10 +4,11 @@ const { ensureWeb3 } = require('../../helpers/web3-fallback')
 const ABI = require('web3-eth-abi')
 
 const EXECUTE_FUNCTION_NAME = 'execute'
+const ZERO_ADDR = '0x0000000000000000000000000000000000000000'
 
 exports.command = 'act <agent-address> <target> <signature> [call-args..]'
 
-exports.describe = 'Executes a call from the Agent app'
+exports.describe = 'Executes an action from the Agent app'
 
 exports.builder = function(yargs) {
   return yargs
@@ -59,7 +60,12 @@ exports.handler = async function({
   const web3 = await ensureWeb3(network)
   const dao = await getAppKernel(web3, agentAddress)
 
-  // TODO: assert dao != 0x00...00
+  if (dao === ZERO_ADDR) {
+    throw new Error(
+      'Invalid Agent app address, cannot find Kernel reference in contract'
+    )
+  }
+
   const fnArgs = [target, 0, encodeCalldata(signature, callArgs)]
 
   const getTransactionPath = wrapper =>

--- a/src/commands/dao_cmds/act.js
+++ b/src/commands/dao_cmds/act.js
@@ -1,0 +1,73 @@
+const execHandler = require('./utils/execHandler').handler
+const getAppKernel = require('./utils/app-kernel')
+const { ensureWeb3 } = require('../../helpers/web3-fallback')
+const ABI = require('web3-eth-abi')
+
+exports.command = 'act <agent-address> <target> <signature> [call-args..]'
+
+exports.describe = 'Executes a call from the Agent app'
+
+exports.builder = function(yargs) {
+  return yargs
+    .positional('agent-address', {
+      description: 'Address of the Agent app proxy',
+      type: 'string',
+    })
+    .positional('target', {
+      description: 'Function to be executed',
+      type: 'string',
+    })
+    .positional('signature', {
+      description: 'Function to be executed',
+      type: 'string',
+    })
+    .option('call-args', {
+      description: 'Arguments to be passed to the function',
+      array: true,
+      default: [],
+    })
+  // TODO: Add an optional argument to provide the eth value for the execution
+}
+
+const encodeCalldata = (signature, params) => {
+  const sigBytes = ABI.encodeFunctionSignature(signature)
+
+  const types = signature
+    .replace(')', '')
+    .split('(')[1]
+    .split(',')
+  const paramBytes = ABI.encodeParameters(types, params)
+
+  return `${sigBytes}${paramBytes.slice(2)}`
+}
+
+exports.handler = async function({
+  reporter,
+  apm,
+  network,
+  agentAddress,
+  target,
+  signature,
+  callArgs,
+  wsProvider,
+}) {
+  const web3 = await ensureWeb3(network)
+  const dao = await getAppKernel(web3, agentAddress)
+
+  // TODO: assert dao != 0x00...00
+
+  const fn = 'execute'
+  const fnArgs = [target, 0, encodeCalldata(signature, callArgs)]
+
+  // console.log(fn, fnArgs)
+
+  const getTransactionPath = wrapper =>
+    wrapper.getTransactionPath(agentAddress, fn, fnArgs)
+
+  return execHandler(dao, getTransactionPath, {
+    reporter,
+    apm,
+    network,
+    wsProvider,
+  })
+}

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -9,7 +9,7 @@ const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
 const encodeInitPayload = require('./utils/encodeInitPayload')
 const { getContract, ANY_ENTITY, NO_MANAGER } = require('../../util')
-const kernelABI = require('@aragon/wrapper/abi/aragon/Kernel')
+const kernelABI = require('@aragon/wrapper/artifacts/aragon/Kernel')
 const listrOpts = require('../../helpers/listr-options')
 
 const addressesEqual = (a, b) => a.toLowerCase() === b.toLowerCase()

--- a/src/commands/dao_cmds/utils/app-kernel.js
+++ b/src/commands/dao_cmds/utils/app-kernel.js
@@ -1,0 +1,6 @@
+const { abi } = require('@aragon/os/build/contracts/AragonApp')
+
+module.exports = (web3, appAddress) => {
+  const app = new web3.eth.Contract(abi, appAddress)
+  return app.methods.kernel().call()
+}


### PR DESCRIPTION
Requires https://github.com/aragon/aragon.js/pull/238 & https://github.com/aragon/radspec/pull/55 (link radspec -> aragon.js -> cli and make sure to `npm run build` everywhere)

Implements a new command `dao act` (which we should probably rename after the Actor -> Agent rename, but can't think of anything better) that provides some syntax sugar over `dao exec` for executing actions using Agent app instances in a DAO.

<img width="830" alt="2019-02-12 at 10 49 28 am" src="https://user-images.githubusercontent.com/447328/52626966-a2b0d680-2eb4-11e9-979d-02b1582d8f42.png">

## Testing

- Get the Agent app from https://github.com/aragon/aragon-apps/pull/580
- Get Aragon from https://github.com/aragon/aragon/pull/610 or https://github.com/aragon/aragon/pull/608
- `npm i && cd future-apps/agent && npm link @aragon/cli`
- `npx aragon run --client-path path/to/aragon`
- `npx dao apps [dao]`
- `npx dao act [agent proxy] [agent proxy or another contract]  "isForwarder()"`