### PR TITLE
[WIP] Upgrade @aragon/wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@aragon/aragen": "^2.0.3",
     "@aragon/os": "^4.0.0",
     "@aragon/templates-beta": "^1.1.3",
-    "@aragon/wrapper": "^3.0.0-beta.3",
+    "@aragon/wrapper": "^3.0.0-beta.4",
     "@babel/polyfill": "^7.0.0",
     "ajv": "^6.6.2",
     "bignumber.js": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run extract-roles && babel -d dist src --copy-files",
     "prepare": "npm run build",
     "test": "ava",
-    "lint": "eslint src test/commands && documentation lint src test/commands",
+    "lint": "eslint src test/commands",
     "extract-roles": "node scripts/extract-roles"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "npm run extract-roles && babel -d dist src --copy-files",
     "prepare": "npm run build",
     "test": "ava",
-    "lint": "eslint src test/commands",
+    "lint": "eslint src test/commands && documentation lint src",
     "extract-roles": "node scripts/extract-roles"
   },
   "repository": {

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -9,7 +9,7 @@ const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
 const encodeInitPayload = require('./utils/encodeInitPayload')
 const { getContract, ANY_ENTITY, NO_MANAGER } = require('../../util')
-const kernelABI = require('@aragon/wrapper/artifacts/aragon/Kernel')
+const kernelABI = require('@aragon/os/abi/Kernel')
 const listrOpts = require('../../helpers/listr-options')
 
 const addressesEqual = (a, b) => a.toLowerCase() === b.toLowerCase()

--- a/src/commands/dao_cmds/install.js
+++ b/src/commands/dao_cmds/install.js
@@ -9,7 +9,7 @@ const chalk = require('chalk')
 const getRepoTask = require('./utils/getRepoTask')
 const encodeInitPayload = require('./utils/encodeInitPayload')
 const { getContract, ANY_ENTITY, NO_MANAGER } = require('../../util')
-const kernelABI = require('@aragon/os/abi/Kernel')
+const kernelABI = require('@aragon/os/abi/Kernel').abi
 const listrOpts = require('../../helpers/listr-options')
 
 const addressesEqual = (a, b) => a.toLowerCase() === b.toLowerCase()


### PR DESCRIPTION
`@aragon/wrapper` no longer exports ABIs

We need to upgrade after https://github.com/aragon/aragon.js/pull/236 is merged and released, in order to resolve https://github.com/aragon/aragon-cli/issues/344.

TODO:
- [x] fix unhandled promise rejections - by https://github.com/aragon/aragon.js/pull/238
```
 % dao apps showcase --all --environment aragon:rinkeby                                                                         
 ⠏ Inspecting DAO
   → Fetching apps for showcase.aragonid.eth...
   Fetching permissionless apps
(node:12872) UnhandledPromiseRejectionWarning: Error: No available storage method found.
    at /home/daniel/repos/aragon/aragon.js/packages/aragon-wrapper/node_modules/localforage/dist/localforage.js:2743:25
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
(node:12872) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 7)
(node:12872) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:12872) UnhandledPromiseRejectionWarning: Error: No available storage method found.
    at /home/daniel/repos/aragon/aragon.js/packages/aragon-wrapper/node_modules/localforage/dist/localforage.js:2743:25
 ✔ Inspecting DAO
 ✔ Fetching permissionless apps
 ✔ Successfully fetched DAO apps for 0x6c9ea46b5147fb185a8fd556bb47e37fd2b509e8

```