### PR TITLE
Don't slice content hash in dao apps

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/apps.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/apps.js
@@ -24,7 +24,7 @@ exports.builder = function(yargs) {
 }
 
 const printAppName = appId => {
-  return knownApps[appId] ? knownApps[appId] : appId.slice(0, 10) + '...'
+  return knownApps[appId] ? knownApps[appId] : appId
 }
 
 const printContent = content => {
@@ -32,7 +32,7 @@ const printContent = content => {
     return '(No UI available)'
   }
 
-  return `${content.provider}:${content.location}`.slice(0, 25) + '...'
+  return `${content.provider}:${content.location}`
 }
 
 exports.handler = async function({

--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -166,7 +166,7 @@ exports.task = async ({
         task: async (ctx, task) => {
           if (!ctx.repo.roles || ctx.repo.roles.length === 0) {
             throw new Error(
-              'You have no roles defined in your arapp.json.\nThis is required for your app to be properly installed.\nSee https://hack.aragon.org/docs/cli-usage.html#global-configuration for more information.'
+              'You have no roles defined in your arapp.json.\nThis is required for your app to be properly installed.\nSee https://hack.aragon.org/docs/cli-global-confg#the-arappjson-file for more information.'
             )
           }
 


### PR DESCRIPTION
I'm not sure I understand why we slice the content or the app name, is it just to make the table fit in small terminals? 
When debugging it's useful to get the full ipfs hash.

```
 √ Inspecting DAO
 √ Successfully fetched DAO apps for 0x6c9ea46b5147fb185a8fd556bb47e37fd2b509e8
┌──────────────────────┬────────────────────────────────────────────┬─────────────────────────────────────────────────────┐
│ App                  │ Proxy address                              │ Content                                             │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ kernel               │ 0x6c9ea46b5147fb185a8fd556bb47e37fd2b509e8 │ (No UI available)                                   │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ acl                  │ 0xd6c22d289a6ee0fc305b0c422f26dd9ef77fc60a │ (No UI available)                                   │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ evmreg               │ 0xc4a7e20ec8e13d63c46c880b696f680af63ddc96 │ (No UI available)                                   │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ voting@v1.1.7        │ 0x71c864931167d815255d06ced82a6540fe9f39ec │ ipfs:QmTCYzgvrjtV4ETkhM3ZNgrVYNi2roXhNxCRmwsePNqL1B │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ vault@v2.0.1         │ 0xfb46046537b3a6509db1f172646be70c8463df9b │ ipfs:Qmf4n8SU86dkqep4cjcUG1jGsR9RNmXQToUSMAuUpTtWoS │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ finance@v1.1.5       │ 0x9a0f7bb765237b7682d101ea82ec85976a9d2ca4 │ ipfs:QmVFmiY9Ch82WCLToew3Xo6X2ngJxYoXhkHVy8Y18nYPvW │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ token-manager@v1.1.6 │ 0x8587933f9a2e7e3217d2e67a142397c1d856b46a │ ipfs:QmNeEr4VTDFrMDVUR69xBA2Puy74CGwWtRzpvyAg2fuPpL │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ foo.open@v2.0.0      │ 0x286e70ce728fe2aed3cddca969b192e3b2620aa3 │ ipfs:Qmadb3hzwLDKtb93fF367Vg1epkdsLZF4dhpapNYynjgZF │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ token-manager@v1.1.6 │ 0xeda89b3db376db89bfe333b71aa1988a183dc81e │ ipfs:QmNeEr4VTDFrMDVUR69xBA2Puy74CGwWtRzpvyAg2fuPpL │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ token-manager@v1.1.6 │ 0x9e6ee7102e046bee28a2ec62133ed2511c65fb94 │ ipfs:QmNeEr4VTDFrMDVUR69xBA2Puy74CGwWtRzpvyAg2fuPpL │
├──────────────────────┼────────────────────────────────────────────┼─────────────────────────────────────────────────────┤
│ voting@v1.1.7        │ 0x72db64b3f6a7c571e69cfeb549111266885571a5 │ ipfs:QmTCYzgvrjtV4ETkhM3ZNgrVYNi2roXhNxCRmwsePNqL1B │
```