### PR TITLE
aragonCLI: upgrade installed Aragon client version

### DIFF
--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -123,7 +123,7 @@
     ]
   },
   "aragon": {
-    "clientVersion": "b64f184910de7c5bcc19f87b32de4b6768c448fd",
+    "clientVersion": "694a70b6d3c4e0b53bb7d50afa8688cc9c56409f",
     "clientPort": "3000",
     "defaultGasPrice": "10000000000"
   },


### PR DESCRIPTION
https://github.com/aragon/aragon/commit/694a70b6d3c4e0b53bb7d50afa8688cc9c56409f Introduces some messaging APIs that are now exposed as part of [`@aragon/api-react`](https://github.com/aragon/aragon.js/tree/master/packages/aragon-api-react).

It would be great if we could do a release with this new client version bundled so app developers can start using these APIs.