### PR TITLE
Fix staging and production references from arapp.json.

### DIFF
--- a/packages/create-aragon-app/src/lib/prepare-template.js
+++ b/packages/create-aragon-app/src/lib/prepare-template.js
@@ -7,16 +7,16 @@ export async function prepareTemplate(dir, appName) {
   const arapp = await fs.readJson(arappPath)
 
   const defaultEnv = arapp.environments.default
-  const stagingEnv = arapp.environments.staging
-  const productionEnv = arapp.environments.production
+  const stagingEnv = arapp.environments["aragon:staging"]
+  const productionEnv = arapp.environments["aragon:mainnet"]
 
   defaultEnv.appName = appName
   stagingEnv.appName = stagingEnv.appName.replace(/^app/, basename)
   productionEnv.appName = productionEnv.appName.replace(/^app/, basename)
 
   Object.assign(arapp.environments.default, defaultEnv)
-  Object.assign(arapp.environments.staging, stagingEnv)
-  Object.assign(arapp.environments.production, productionEnv)
+  Object.assign(arapp.environments["aragon:staging"], stagingEnv)
+  Object.assign(arapp.environments["aragon:mainnet"], productionEnv)
 
   const gitFolderPath = path.resolve(dir, '.git')
   const licensePath = path.resolve(dir, 'LICENSE')


### PR DESCRIPTION
While trying to use the template in [aragon-react-boilerplate](https://github.com/aragon/aragon-react-boilerplate), when executing the command `npx create-aragon-app app.aragonpm.eth react --debug`, I was getting the following error:

```
Preparing template [failed]
→ Cannot read property 'appName' of undefined
 ✖ Cannot read property 'appName' of undefined
 ❯ TypeError: Cannot read property 'appName' of undefined
    at _callee$ (/home/user_name/.npm/_npx/2243/lib/node_modules/create-aragon-app/dist/lib/prepare-template.js:42:45)
    at tryCatch (/home/user_name/.npm/_npx/2243/lib/node_modules/create-aragon-app/node_modules/regenerator-runtime/runtime.js:45:40)
...
```

This seems to be because [prepare-template.js is looking for "environments.staging" and "environments.production" entries in arapp.json](https://github.com/aragon/aragon-cli/blob/master/packages/create-aragon-app/src/lib/prepare-template.js#L10). However, `arapp.json` contains `environments["aragon:staging"]` and `environments["aragon:mainnet"]` instead, so `stagingEnv` and `productionEnv` both result undefined in `prepare-template.js`, and the command fails when trying to get `appName` of undefined.

My fix in this PR is just for illustrative purposes. I'm sure that there is a more correct way to fix this, probably by making a change in the template instead of the cli. However, I do confirm that the Counter app works perfectly with this small change.