### PR TITLE
Implement transaction pathing in 'aragon apm publish'

### DIFF
--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -40,11 +40,11 @@
   },
   "homepage": "https://github.com/aragon/aragon-cli#readme",
   "dependencies": {
-    "@aragon/apm": "^2.0.2",
+    "@aragon/apm": "^3.1.0",
     "@aragon/apps-shared-minime": "^1.0.1",
     "@aragon/aragen": "^4.0.0",
     "@aragon/os": "^4.0.0",
-    "@aragon/wrapper": "^3.0.0-beta.4",
+    "@aragon/wrapper": "^5.0.0-rc.3",
     "@babel/polyfill": "^7.0.0",
     "ajv": "^6.6.2",
     "bignumber.js": "^7.1.0",

--- a/packages/aragon-cli/src/commands/apm_cmds/publish.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/publish.js
@@ -575,10 +575,14 @@ exports.task = function({
               ctx.contract
             )
 
-            const { dao, proxyAddress, name, params } = intent
+            const { dao, proxyAddress, methodName, params } = intent
 
             const getTransactionPath = wrapper => {
-              return wrapper.getTransactionPath(proxyAddress, name, params)
+              return wrapper.getTransactionPath(
+                proxyAddress,
+                methodName,
+                params
+              )
             }
 
             return execTask(dao, getTransactionPath, {


### PR DESCRIPTION
Requires https://github.com/aragon/aragon.js/pull/273 and https://github.com/aragon/apm.js/pull/35

Makes `aragon apm publish` use the new `publishVersionIntent` from apm.js which returns an intent object that is then used to do transaction pathing using an `execTask`.

By having transaction pathing for publishing we will be able to have governance in aragonPM registries, which will be needed for decentralizing `aragonpm.eth` (see [AGP draft](https://github.com/aragon/AGPs/pull/28)).