### PR TITLE
Add issues and PR templates, edit contributing.md && add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @0x6431346e @0xGabi

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,3 @@
+## 👉 [Please follow one of these issue templates](https://github.com/aragon/aragon-cli/issues/new/choose) 👈
+
+Note: to keep the backlog clean and actionable, issues may be immediately closed if they do not follow one of the above issue templates.

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,69 @@
+---
+name: 🐛 Bug Report
+about: Submit a bug report to help us improve
+labels: bug
+---
+
+## 🐛 Bug Report
+
+(A clear and concise description of what the bug is)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)
+
+## Context
+
+#### Mainnet or testnet?
+
+(Which network you are using the app with.)
+
+#### Organization
+
+(Enter the URL or ENS name of your organization.)
+
+#### Environment
+
+- OS and OS version: [e.g. Linux Mint 18.0]
+- Browser and browser version: [e.g. Firefox 64.0]
+- Add any other context about the problem here.
+
+## To Reproduce
+
+(Write your steps here:)
+
+1. 1. 1.
+
+## Expected behavior
+
+<!--
+  How did you expect your project to behave?
+  It’s fine if you’re not sure your understanding is correct.
+  Just write down what you thought would happen.
+-->
+
+(Write what you thought would happen.)
+
+## Actual Behavior
+
+<!--
+  Did something go wrong?
+  Is something broken, or not behaving as you expected?
+  Describe this section in detail, and attach screenshots if possible.
+  Don't just say "it doesn't work"!
+-->
+
+(Write what happened. Add screenshots, if applicable.)
+
+## Reproducible Demo
+
+(Paste the link to an example repo, and exact instructions to reproduce the issue.)
+
+<!--
+  Please remember that:
+
+    * The person fixing the bug would have to do that anyway. Please be respectful of their time.
+    * You might figure out the issues yourself as you work on extracting it.
+
+  Thanks for helping us help you!
+-->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,13 @@
+---
+name: 📚 Documentation
+about: Report an issue related to documentation
+labels: docs
+---
+
+## 📚 Documentation
+
+(A clear and concise description of what the issue is.)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,21 @@
+---
+name: 🚀 Feature
+about: Submit a proposal/request for a new feature
+labels: enhancement
+---
+
+## 🚀 Feature
+
+(A clear and concise description of what the feature is. Include any alternative solutions or features you've considered.)
+
+## Have you read the [Contributing Guidelines on issues](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)
+
+## Motivation
+
+(Please outline the motivation for the proposal.)
+
+## Pitch
+
+(Please explain why this feature should be implemented and how it would be used. Add any other context or screenshots about the feature request here.)

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,12 @@
+---
+name: 💥 Proposal
+about: Propose a non-trivial change to Docusaurus
+---
+
+## 💥 Proposal
+
+(A clear and concise description of what the proposal is.)
+
+### Have you read the [Contributing Guidelines on issues](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md#ways-to-contribute)?
+
+(Write your answer here.)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,14 @@
+---
+name: ❓ Questions/Help
+about: If you have questions, please check Aragon Hack, Aragon Forum or Aragon Chat
+---
+
+## ❓ Questions and Help
+
+### Please note that this issue tracker is not a help form and this issue will be closed.
+
+Please contact us instead. We have a few channels:
+
+- [Aragon Hack](https://hack.aragon.org/docs/cli-intro.html)
+- [Aragon Forum](https://forum.aragon.org)
+- [Aragon Chat](https://aragon.chat)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Proposed changes
+
+Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+
+## Types of changes
+
+What types of changes does your code introduce?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) doc
+- [ ] I have signed the [CLA](https://cla-assistant.io/aragon/aragon-cli)
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Further comments
+
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,29 +1,50 @@
-# Contributing to aragon-cli
+# Contributing to aragonCLI
 
-:tada: Thank you for being interested in contributing to an Aragon Project! :tada: 
+:tada: Thank you for being interested in contributing to an Aragon Project! :tada:
 
 Feel welcome and read the following sections in order to know how to ask questions and how to work on something.
 
 All members of our community are expected to follow our [Code of Conduct](https://wiki.aragon.org/documentation/Code_of_Conduct/). Please make sure you are welcoming and friendly in all of our spaces.
 
-## Ways to contribute
+## Get Involved
 
-### File an issue
-If you see a problem that should be improved, you can simply report it in our [issue tracker](https://github.com/aragon/aragon-cli/issues).  Please take a quick look to see if the issue doesn't already exist before filing yours.
+There are many ways to contribute to Aragon, and many of them do not involve writing any code. Here's a few ideas to get started:
+
+- Does everything work as expected? If not, we're always looking for improvements. Let us know by [opening an issue](#reporting-new-issues).
+- Look through the [open issues](https://github.com/aragon/aragon-cli/issues). Provide workarounds, ask for clarification, or suggest labels.
+- If you find an issue you would like to fix, [open a pull request](#your-first-code-contribution). Issues tagged as [_Good first issue_](https://github.com/aragon/aragon-cli/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) are a good place to get started.
+- Read through [Aragon documentation](https://hack.aragon.org/docs/cli-intro.html). If you find anything that is confusing or can be improved, you can make edits by clicking "Edit" at the top of most docs.
+- Take a look at the [features requested](https://github.com/aragon/aragon-cli/labels/enhancement) by others in the community and consider opening a pull request if you see something you want to work on.
+
+Contributions are very welcome.
+
+## Ways to Contribute
+
+We use [GitHub Issues](https://github.com/aragon/aragon-cli/issues) for our public bugs. If you would like to report a problem, take a look around and see if someone already opened an issue about it. If you a are certain this is a new, unreported bug, you can submit a [bug report](#reporting-new-issues).
+
+You can also file issues as [feature requests or enhancements](https://github.com/aragon/aragon-cli/labels/enhancement). If you see anything you'd like to be implemented, create an issue with [feature template](https://raw.githubusercontent.com/aragon/aragon-cli/master/.github/ISSUE_TEMPLATE/feature.md).
 
 Do your best to include as many details as needed in order for someone else to fix the problem and resolve the issue.
 
+### Reporting new issues
+
+When [opening a new issue](https://github.com/aragon/aragon-cli/issues/new/choose), always make sure to fill out the issue template. **This step is very important!**
+
+- **One issue, one bug:** Please report a single bug per issue.
+- **Provide reproduction steps:** List all the steps necessary to reproduce the issue. The person reading your bug report should be able to follow these steps to reproduce your issue with minimal effort.
+
 ### Fix an issue
+
 You can browse our [issue tracker](https://github.com/aragon/aragon-cli/issues) and choose an issue to fix. The development process follows one typical of open source contributions. Here's a quick rundown:
 
 1. [Find an issue](https://github.com/aragon/aragon-cli/issues) that you are interested in addressing or a feature that you would like to add.
-2. Fork the repository to your local GitHub organization. This means that you will have a copy of the repository under ```your-GitHub-username/hack```.
-3. Clone the repository to your local machine using ```git clone https://github.com/github-username/aragon.js.git```.
-4. Create a new branch for your fix using ```git checkout -b branch-name-here```.
+2. Fork the repository to your local GitHub organization. This means that you will have a copy of the repository under `your-GitHub-username/hack`.
+3. Clone the repository to your local machine using `git clone https://github.com/github-username/aragon.js.git`.
+4. Create a new branch for your fix using `git checkout -b branch-name-here`.
 5. Make the appropriate changes for the issue you are trying to address or the feature that you want to add.
-6. Use ```git add insert-paths-of-changed-files-here``` to add the file contents of the changed files to the "snapshot" git uses to manage the state of the project, also known as the index.
-7. Use ```git commit -m "Insert a short message of the changes made here"``` to store the contents of the index with a descriptive message.
-8. Push the changes to the remote repository using ```git push origin branch-name-here```.
+6. Use `git add insert-paths-of-changed-files-here` to add the file contents of the changed files to the "snapshot" git uses to manage the state of the project, also known as the index.
+7. Use `git commit -m "Insert a short message of the changes made here"` to store the contents of the index with a descriptive message.
+8. Push the changes to the remote repository using `git push origin branch-name-here`.
 9. Submit a pull request in github to the upstream repository.
 10. Title the pull request with a short description of the changes made and the issue or bug number associated with your change. For example, you can use a title like "Added more log outputting to resolve #4352".
 11. In the description of the pull request, explain the changes that you made, any issues you think exist with the pull request you made, and any questions you have for the maintainer. It's OK if your pull request is not perfect (no pull request is). The reviewer will be able to help you fix any problems and improve it!
@@ -33,32 +54,70 @@ You can browse our [issue tracker](https://github.com/aragon/aragon-cli/issues) 
 
 ## Your First Code Contribution
 
+So you have decided to contribute code back to upstream by opening a pull request. You've invested a good chunk of time, and we appreciate it. We will do our best to work with you and get the PR looked at.
+
+Working on your first Pull Request? You can learn how from this free video series:
+
+[**How to Contribute to an Open Source Project on GitHub**](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github)
+
 Unsure where to begin contributing? You can start by looking through these `good first issue` issues:
 
-* [Good first issue](https://github.com/aragon/aragon-cli/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
+- [Good first issue](https://github.com/aragon/aragon-cli/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
 
 ## Getting help
-If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://aragon.chat/channel/dev-help) on the Aragon Chat.  We'd love to hear from you and know what you're working on!
 
-## Styleguides
+If you need help, please reach out to Aragon core contributors and community members in the [#dev-help channel](https://aragon.chat/channel/dev-help) on the Aragon Chat. We'd love to hear from you and know what you're working on!
 
-### Commits
+## Style Guide
 
-* Use the present tense ("Add feature" not "Added feature")
-* Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
-* Limit the first line to 72 characters or less
-* Reference issues and pull requests liberally after the first line
+[Prettier](https://prettier.io) will catch most styling issues that may exist in your code.
 
->A good rule of thumb is that your commit message follows these rules if you can prefix it with "This commit will ..." and it makes sense.
+However, there are still some styles that Prettier cannot pick up.
 
->For example, "This commit will **add a feature**" vs "This commit will **added a feature**".
+## Semantic Commit Messages
 
-### JavaScript
+See how a minor change to your commit message style can make you a better programmer.
+
+Format: `<type>(<scope>): <subject>`
+
+`<scope>` is optional
+
+### Example
+
+```
+feat: allow overriding of webpack config
+^--^  ^------------^
+|     |
+|     +-> Summary in present tense.
+|
++-------> Type: chore, docs, feat, fix, refactor, style, or test.
+```
+
+The various types of commits:
+
+- `feat`: (new feature for the user, not a new feature for build script)
+- `fix`: (bug fix for the user, not a fix to a build script)
+- `docs`: (changes to the documentation)
+- `style`: (formatting, missing semi colons, etc; no production code change)
+- `refactor`: (refactoring production code, eg. renaming a variable)
+- `test`: (adding missing tests, refactoring tests; no production code change)
+- `chore`: (updating grunt tasks etc; no production code change)
+
+### Rules
+
+- Use lower case not title case!
+- Use the present tense ("Add feature" not "Added feature")
+- Use the imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Limit the first line to 72 characters or less
+- Reference issues and pull requests liberally after the first line
+
+## JavaScript
 
 All JavaScript must adhere to [JavaScript Standard Style](https://standardjs.com/).
 
-* Prefer the object spread operator (`{...anotherObj}`) to `Object.assign()`
-* Inline `export`s with expressions whenever possible
+- Prefer the object spread operator (`{...anotherObj}`) to `Object.assign()`
+- Inline `export`s with expressions whenever possible
+
 ```
   js
   // Use this:


### PR DESCRIPTION
closes #400 

I included a basic version of CODEOWNER.md to start experiment with while we create a more general approach across repos (as discussed in #412).