### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,22 @@
-## Proposed changes
+# 🦅 Pull Request
 
-Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
+<!-- Please let us know why do you wish to include this change. 👇 -->
 
-## Types of changes
+## 🚨 Test instructions
 
-What types of changes does your code introduce?
-_Put an `x` in the boxes that apply_
+<!-- In case it is difficult or not straightforward to test this feature/fix,
+please provide test instructions! -->
 
-- [ ] Bugfix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+## ✔️ PR Todo
 
-## Checklist
+- [ ] Included links to related issues/PRs
+- [ ] Added/updated unit tests for this change
+- [ ] Added/updated the necessary documentation
+- [ ] Cleared dependencies on other modules that have to be released before merging this
 
-_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+<!--
+Thank you for contributing! 
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) doc
-- [ ] I have signed the [CLA](https://cla-assistant.io/aragon/aragon-cli)
-- [ ] Lint and unit tests pass locally with my changes
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added necessary documentation (if appropriate)
-- [ ] Any dependent changes have been merged and published in downstream modules
-
-## Further comments
-
-If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
+To help us review this change in a timely manner, please make sure to read and follow the 
+[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
+-->


### PR DESCRIPTION
I think we should aim to welcome any contributions regardless if they follow a specific PR template, read the guidelines of our contributing document or not.

With this change I've tried to lower the amount of text someone has to read and delete (by adding these instructions as comments).

I removed the "types of changes" section which I think might be better suited for us the maintainers to asses (since only us can add labels anyway) and some checkboxes that felt redundant.

We could keep this template short & sweet and the detailed instructions in the contributing doc.