### PR TITLE
Fix solidity-extractor function declaration detection

### DIFF
--- a/packages/aragon-cli/src/helpers/solidity-extractor.js
+++ b/packages/aragon-cli/src/helpers/solidity-extractor.js
@@ -15,7 +15,9 @@ const typeOrAddress = type => {
 
 // extracts function signature from function declaration
 const getSignature = declaration => {
-  let [name, params] = declaration.match(/function ([^]*?)\)/)[1].split('(')
+  let [name, params] = declaration
+    .match(/^\s*function ([^]*?)\)/m)[1]
+    .split('(')
 
   if (!name) {
     return 'fallback'


### PR DESCRIPTION
# 🦅 Pull Request

The `solidity-extractor` helper was failing to detect the correct function signature when the comment of a function contained the word `function`.

Modifies the regex used to extract the function signature to just look for the word `function` if it is at the beginning of a line.

## 🚨 Test instructions

See the `sig` of the 4th function in this [recently deployed Finance artifact](https://ipfs.eth.aragon.network/ipfs/QmYjawCLnLokVeREo42GWxzJLisChPpL3YiFLhXct7ZDZs/artifact.json)

The easiest way to test is by doing `aragon apm publish` on an any app in aragon-apps and inspecting the generated `artifacts.json` or using the extractor directly with #423 

## ✔️ PR Todo

- [x] Included links to related issues/PRs
- [ ] Added/updated unit tests for this change
- [ ] Added/updated the necessary documentation
- [ ] Cleared dependencies on other modules that have to be released before merging this
