### PR TITLE
Fix getDependentBinary

### DIFF
--- a/docs-internal/Specification.md
+++ b/docs-internal/Specification.md
@@ -64,8 +64,10 @@ node_modules
 In this case the binaries will be available at `node_modules/aragon-cli/node_modules/.bin`.
 
 Having this said, we need an utility to calculate the correct path. This utility should check
-whether the binary exists in `project_root` + `node_modules/.bin`, and if it does not,
+whether the binary exists in `project_root` + `./node_modules/.bin`, and if it does not,
 it should go up once or twice (if scoped) and look into the `.bin` directory. This can be achieved
-using [`__dirname`](https://nodejs.org/docs/latest/api/globals.html#globals_dirname).
+using [`__dirname`][dirname-docs].
 
 See `src/util.js#getDependentBinary`.
+
+[dirname-docs]: https://nodejs.org/docs/latest/api/globals.html#globals_dirname

--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -127,7 +127,6 @@
       "@babel/register"
     ],
     "files": [
-      "src/**/*.test.js",
       "test/**/*.test.js"
     ]
   },

--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -115,6 +115,7 @@
     "lint-staged": "^8.1.0",
     "nyc": "^13.3.0",
     "prettier": "^1.15.3",
+    "proxyquire": "^2.1.0",
     "sinon": "^7.3.1"
   },
   "engines": {
@@ -126,7 +127,8 @@
       "@babel/register"
     ],
     "files": [
-      "test/commands/**/*.test.js"
+      "src/**/*.test.js",
+      "test/**/*.test.js"
     ]
   },
   "aragon": {

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -63,29 +63,29 @@ const installDeps = (cwd, task) => {
   })
 }
 
-const getDependentBinary = binaryName => {
+const getDependentBinary = (binaryName, projectRoot) => {
+  if (!projectRoot) {
+    // __dirname evaluates to the directory of this file (util.js)
+    // e.g.: `../dist/` or `../src/`
+    projectRoot = path.join(__dirname, '..')
+  }
+
   // check local node_modules
-  let binaryPath = path.join(
-    __dirname,
-    '..', // because __dirname will evaluate to project_root/dist/
-    'node_modules',
-    '.bin',
-    binaryName
-  )
+  let binaryPath = path.join(projectRoot, 'node_modules', '.bin', binaryName)
 
   if (fs.existsSync(binaryPath)) {
     return binaryPath
   }
 
   // check parent node_modules
-  binaryPath = path.join(__dirname, '..', '..', '.bin', binaryName)
+  binaryPath = path.join(projectRoot, '..', '.bin', binaryName)
 
   if (fs.existsSync(binaryPath)) {
     return binaryPath
   }
 
   // check parent node_modules if this module is scoped (e.g.: @scope/package)
-  binaryPath = path.join(__dirname, '..', '..', '..', '.bin', binaryName)
+  binaryPath = path.join(projectRoot, '..', '..', '.bin', binaryName)
 
   if (fs.existsSync(binaryPath)) {
     return binaryPath

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -78,14 +78,14 @@ const getDependentBinary = binaryName => {
   }
 
   // check parent node_modules
-  binaryPath = path.join(__dirname, '..', '.bin', binaryName)
+  binaryPath = path.join(__dirname, '..', '..', '.bin', binaryName)
 
   if (fs.existsSync(binaryPath)) {
     return binaryPath
   }
 
   // check parent node_modules if this module is scoped (e.g.: @scope/package)
-  binaryPath = path.join(__dirname, '..', '..', '.bin', binaryName)
+  binaryPath = path.join(__dirname, '..', '..', '..', '.bin', binaryName)
 
   if (fs.existsSync(binaryPath)) {
     return binaryPath

--- a/packages/aragon-cli/src/util.test.js
+++ b/packages/aragon-cli/src/util.test.js
@@ -1,0 +1,67 @@
+import test from 'ava'
+import sinon from 'sinon'
+import proxyquire from 'proxyquire'
+
+test.beforeEach(t => {
+  const fsStub = {
+    existsSync: sinon.stub(),
+  }
+
+  const util = proxyquire.noCallThru().load('./util', {
+    fs: fsStub,
+  })
+
+  t.context = {
+    util,
+    fsStub,
+  }
+})
+
+test.afterEach.always(() => {
+  sinon.restore()
+})
+
+test('getDependentBinary should find the binary path from the local node_modules', t => {
+  t.plan(1)
+  const { util, fsStub } = t.context
+
+  // arrange
+  fsStub.existsSync.returns(true)
+  // act
+  const path = util.getDependentBinary('truff', 'project_root')
+  // assert
+  t.is(path, 'project_root/node_modules/.bin/truff')
+})
+
+test('getDependentBinary should find the binary path from the parent node_modules', t => {
+  t.plan(1)
+  const { util, fsStub } = t.context
+
+  // arrange
+  fsStub.existsSync.onCall(0).returns(false)
+  fsStub.existsSync.onCall(1).returns(true)
+  // act
+  const path = util.getDependentBinary(
+    'truff',
+    'parent/node_modules/project_root'
+  )
+  // assert
+  t.is(path, 'parent/node_modules/.bin/truff')
+})
+
+test("getDependentBinary should find the binary path from the parent node_modules even when it's scoped", t => {
+  t.plan(1)
+  const { util, fsStub } = t.context
+
+  // arrange
+  fsStub.existsSync.onCall(0).returns(false)
+  fsStub.existsSync.onCall(1).returns(false)
+  fsStub.existsSync.onCall(2).returns(true)
+  // act
+  const path = util.getDependentBinary(
+    'truff',
+    'parent/node_modules/@scope/project_root'
+  )
+  // assert
+  t.is(path, 'parent/node_modules/.bin/truff')
+})

--- a/packages/aragon-cli/test/util.test.js
+++ b/packages/aragon-cli/test/util.test.js
@@ -7,7 +7,7 @@ test.beforeEach(t => {
     existsSync: sinon.stub(),
   }
 
-  const util = proxyquire.noCallThru().load('./util', {
+  const util = proxyquire.noCallThru().load('../src/util', {
     fs: fsStub,
   })
 


### PR DESCRIPTION
# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->
Should've tested this more thoroughly... :man_facepalming: 
or better yet, write some tests for it. :bulb: 

Fixes: 
```
Error: Cannot find the truffle dependency. Has this module installed correctly?
    at getDependentBinary (/Users/jonathanschwartz/Documents/owl/grants/aragon/identity/node_modules/@aragon/cli/src/util.js:94:9)
```

## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this feature/fix,
please provide test instructions! -->

## ✔️ PR Todo

- [x] Included links to related issues/PRs: #442 
- [ ] Added/updated unit tests for this change
- [ ] Added/updated the necessary documentation
- [x] Cleared dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
