### PR TITLE
aragonCLI: upgrade installed Aragon client version to 0.7.2

### DIFF
--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -130,7 +130,7 @@
     ]
   },
   "aragon": {
-    "clientVersion": "b8955ef92856b90600fe5bb5c7f96724043bde86",
+    "clientVersion": "e08deb62080e17fe652fa83f60dc81a02c455c41",
     "clientPort": "3000",
     "defaultGasPrice": "10000000000"
   },


### PR DESCRIPTION
@0xGabi perhaps we should also update aragen with the new versions of the app frontends (bumping them from 0.7.0 to 0.7.2)?

Fixes https://github.com/aragon/aragon-apps/issues/859