### PR TITLE
enable proxy address to show on dao install

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -133,7 +133,6 @@ exports.task = async ({
       },
       {
         title: 'Fetching deployed app',
-        enabled: () => setPermissions,
         task: async (ctx, task) => {
           const logABI = kernelABI.find(
             ({ type, name }) => type === 'event' && name === 'NewAppProxy'


### PR DESCRIPTION
# 🦅 Pull Request

Implementation to show proxy address was already developed.
The problem in some cases was that if no --set-permissions option was included on the command, the task to fetch deployed app would not run.

Is it correct to let the task run unconditionally?

If so, then it closes #451

## 🚨 Test instructions

## ✔️ PR Todo

- [ ] Included links to related issues/PRs
- [ ] Added/updated unit tests for this change
- [ ] Added/updated the necessary documentation
- [ ] Cleared dependencies on other modules that have to be released before merging this
