### PR TITLE
Bump @aragon/wrapper from 5.0.0-rc.9 to 5.0.0-rc.12

### DIFF
--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -48,7 +48,7 @@
     "@aragon/apps-shared-minime": "^1.0.1",
     "@aragon/aragen": "^4.0.0",
     "@aragon/os": "^4.0.0",
-    "@aragon/wrapper": "5.0.0-rc.9",
+    "@aragon/wrapper": "^5.0.0-rc.9",
     "@babel/polyfill": "^7.0.0",
     "ajv": "^6.6.2",
     "byte-size": "^5.0.1",


### PR DESCRIPTION
# 🦅 Pull Request

Now that we merge https://github.com/aragon/aragon-cli/pull/567 we should be able to bump the wrapper.

TODO:

- [x] Test `aragon apm publish` thoroughly