### PR TITLE
allow arrays to be passed via --app-init-params

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/utils/encodeInitPayload.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/encodeInitPayload.js
@@ -5,6 +5,14 @@ module.exports = (web3, abi, initFunctionName, initArgs) => {
     return '0x'
   } else {
     try {
+      // parse array parameters from string inputs
+      for (var i in methodABI.inputs) {
+        if (methodABI.inputs[i].type.includes('[')) {
+          initArgs[i] = JSON.parse(
+            initArgs[i].replace(new RegExp("'", 'g'), '"')
+          )
+        }
+      }
       return web3.eth.abi.encodeFunctionCall(methodABI, initArgs)
     } catch (e) {
       throw new Error(


### PR DESCRIPTION
web3.eth.abi.encodeFunctionCall expects a javascript array, which needs to be parse from the CLI input

# 🦅 Pull Request

Closes #320

run command doesn't support arrays as --app-init-params

## 🚨 Test instructions

create a contract that takes an `address[]` type as a param for the `initialize()` function. Try executing run command with `--app-init-params ["<address>"]`