### PR TITLE
Project name validation

### DIFF
--- a/packages/aragon-cli/src/commands/init.js
+++ b/packages/aragon-cli/src/commands/init.js
@@ -58,7 +58,7 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
           if (!isValidEnsName(basename)) {
             throw new Error(
               reporter.error(
-                'Invalid project name. Please only use lowercase alphanumeric and "-" characters.'
+                'Invalid project name. Please only use lowercase alphanumeric and hyphen characters.'
               )
             )
           }

--- a/packages/aragon-cli/src/commands/init.js
+++ b/packages/aragon-cli/src/commands/init.js
@@ -57,7 +57,9 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
           task.output = 'Checking if project folder already exists...'
           if (!isValidEnsName(basename)) {
             throw new Error(
-              'Invalid project name. Please only use lowercase alphanumeric characters.'
+              reporter.error(
+                'Invalid project name. Please only use lowercase alphanumeric and "-" characters.'
+              )
             )
           }
 

--- a/packages/aragon-cli/src/commands/init.js
+++ b/packages/aragon-cli/src/commands/init.js
@@ -2,7 +2,7 @@ import { checkProjectExists, prepareTemplate } from '../lib/init'
 const { promisify } = require('util')
 const clone = promisify(require('git-clone'))
 const TaskList = require('listr')
-const { installDeps, isValidEnsName } = require('../util')
+const { installDeps, isValidAragonId } = require('../util')
 const defaultAPMName = require('../helpers/default-apm')
 const listrOpts = require('../helpers/listr-options')
 
@@ -55,7 +55,7 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
         title: 'Preparing initialization',
         task: async (ctx, task) => {
           task.output = 'Checking if project folder already exists...'
-          if (!isValidEnsName(basename)) {
+          if (!isValidAragonId(basename)) {
             throw new Error(
               reporter.error(
                 'Invalid project name. Please only use lowercase alphanumeric and hyphen characters.'

--- a/packages/aragon-cli/src/commands/init.js
+++ b/packages/aragon-cli/src/commands/init.js
@@ -2,7 +2,7 @@ import { checkProjectExists, prepareTemplate } from '../lib/init'
 const { promisify } = require('util')
 const clone = promisify(require('git-clone'))
 const TaskList = require('listr')
-const { installDeps } = require('../util')
+const { installDeps, isValidEnsName } = require('../util')
 const defaultAPMName = require('../helpers/default-apm')
 const listrOpts = require('../helpers/listr-options')
 
@@ -55,6 +55,12 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
         title: 'Preparing initialization',
         task: async (ctx, task) => {
           task.output = 'Checking if project folder already exists...'
+          if (!isValidEnsName(basename)) {
+            throw new Error(
+              'Invalid project name. Please only use lowercase alphanumeric characters.'
+            )
+          }
+
           await checkProjectExists(basename)
         },
       },

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -302,6 +302,15 @@ const parseStringIfPossible = target => {
   return target
 }
 
+/**
+ * Validates an Aragon ENS subdomain name
+ * @param {string} name Name
+ * @returns {boolean} `true` if valid
+ */
+function isValidEnsName(name) {
+  return /^[a-z0-9]+$/.test(name)
+}
+
 module.exports = {
   parseStringIfPossible,
   debugLogger,
@@ -314,6 +323,7 @@ module.exports = {
   getLocalBinary,
   getGlobalBinary,
   getContract,
+  isValidEnsName,
   ANY_ENTITY,
   NO_MANAGER,
   ZERO_ADDRESS,

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -308,7 +308,7 @@ const parseStringIfPossible = target => {
  * @returns {boolean} `true` if valid
  */
 function isValidEnsName(name) {
-  return /^[a-z0-9]+$/.test(name)
+  return /^[a-z0-9-]+$/.test(name)
 }
 
 module.exports = {

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -303,12 +303,12 @@ const parseStringIfPossible = target => {
 }
 
 /**
- * Validates an Aragon ENS subdomain name
- * @param {string} name Name
+ * Validates an Aragon Id
+ * @param {string} aragonId Aragon Id
  * @returns {boolean} `true` if valid
  */
-function isValidEnsName(name) {
-  return /^[a-z0-9-]+$/.test(name)
+function isValidAragonId(aragonId) {
+  return /^[a-z0-9-]+$/.test(aragonId)
 }
 
 module.exports = {
@@ -323,7 +323,7 @@ module.exports = {
   getLocalBinary,
   getGlobalBinary,
   getContract,
-  isValidEnsName,
+  isValidAragonId,
   ANY_ENTITY,
   NO_MANAGER,
   ZERO_ADDRESS,

--- a/packages/aragon-cli/test/commands/init.test.js
+++ b/packages/aragon-cli/test/commands/init.test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import fs from 'fs-extra'
 
 import { checkProjectExists, prepareTemplate } from '../../src/lib/init'
-import { isValidEnsName } from '../../src/util'
+import { isValidAragonId } from '../../src/util'
 
 import defaultAPMName from '../../src/helpers/default-apm'
 
@@ -26,12 +26,12 @@ test('check if project folder already exists', async t => {
 })
 
 test('project name validation', t => {
-  t.is(isValidEnsName('testproject'), true)
-  t.is(isValidEnsName('project2'), true)
-  t.is(isValidEnsName('test-project'), true)
+  t.is(isValidAragonId('testproject'), true)
+  t.is(isValidAragonId('project2'), true)
+  t.is(isValidAragonId('test-project'), true)
 
-  t.is(isValidEnsName('testProject'), false)
-  t.is(isValidEnsName('test_project'), false)
+  t.is(isValidAragonId('testProject'), false)
+  t.is(isValidAragonId('test_project'), false)
 })
 
 test('prepare project template', async t => {

--- a/packages/aragon-cli/test/commands/init.test.js
+++ b/packages/aragon-cli/test/commands/init.test.js
@@ -16,7 +16,7 @@ test.afterEach(t => {
   fs.removeSync(projectPath)
 })
 
-test('check if project folder already exists', async t => {
+test.serial('check if project folder already exists', async t => {
   try {
     await checkProjectExists(projectPath)
     t.fail()
@@ -34,7 +34,7 @@ test('project name validation', t => {
   t.is(isValidAragonId('test_project'), false)
 })
 
-test('prepare project template', async t => {
+test.serial('prepare project template', async t => {
   const repoPath = `${projectPath}/.git`
   const arappPath = `${projectPath}/arapp.json`
   const packageJsonPath = `${projectPath}/package.json`

--- a/packages/aragon-cli/test/commands/init.test.js
+++ b/packages/aragon-cli/test/commands/init.test.js
@@ -28,9 +28,9 @@ test('check if project folder already exists', async t => {
 test('project name validation', t => {
   t.is(isValidEnsName('testproject'), true)
   t.is(isValidEnsName('project2'), true)
+  t.is(isValidEnsName('test-project'), true)
 
   t.is(isValidEnsName('testProject'), false)
-  t.is(isValidEnsName('test-project'), false)
   t.is(isValidEnsName('test_project'), false)
 })
 

--- a/packages/aragon-cli/test/commands/init.test.js
+++ b/packages/aragon-cli/test/commands/init.test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import fs from 'fs-extra'
 
 import { checkProjectExists, prepareTemplate } from '../../src/lib/init'
+import { isValidEnsName } from '../../src/util'
 
 import defaultAPMName from '../../src/helpers/default-apm'
 
@@ -22,6 +23,15 @@ test('check if project folder already exists', async t => {
   } catch (err) {
     t.pass()
   }
+})
+
+test('project name validation', t => {
+  t.is(isValidEnsName('testproject'), true)
+  t.is(isValidEnsName('project2'), true)
+
+  t.is(isValidEnsName('testProject'), false)
+  t.is(isValidEnsName('test-project'), false)
+  t.is(isValidEnsName('test_project'), false)
 })
 
 test('prepare project template', async t => {

--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -58,7 +58,7 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
           if (!isValidEnsName(basename)) {
             throw new Error(
               reporter.error(
-                'Invalid project name. Please only use lowercase alphanumeric and "-" characters.'
+                'Invalid project name. Please only use lowercase alphanumeric and hyphen characters.'
               )
             )
           }

--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -57,7 +57,9 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
           task.output = 'Checking if project folder already exists...'
           if (!isValidEnsName(basename)) {
             throw new Error(
-              'Invalid project name. Please only use lowercase alphanumeric characters.'
+              reporter.error(
+                'Invalid project name. Please only use lowercase alphanumeric and "-" characters.'
+              )
             )
           }
 

--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -2,7 +2,7 @@ import { checkProjectExists, prepareTemplate } from '../lib'
 const { promisify } = require('util')
 const clone = promisify(require('git-clone'))
 const TaskList = require('listr')
-const { installDeps, isValidEnsName } = require('../util')
+const { installDeps, isValidAragonId } = require('../util')
 const defaultAPMName = require('../helpers/default-apm')
 const listrOpts = require('../helpers/listr-options')
 
@@ -55,7 +55,7 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
         title: 'Preparing initialization',
         task: async (ctx, task) => {
           task.output = 'Checking if project folder already exists...'
-          if (!isValidEnsName(basename)) {
+          if (!isValidAragonId(basename)) {
             throw new Error(
               reporter.error(
                 'Invalid project name. Please only use lowercase alphanumeric and hyphen characters.'

--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -2,7 +2,7 @@ import { checkProjectExists, prepareTemplate } from '../lib'
 const { promisify } = require('util')
 const clone = promisify(require('git-clone'))
 const TaskList = require('listr')
-const { installDeps } = require('../util')
+const { installDeps, isValidEnsName } = require('../util')
 const defaultAPMName = require('../helpers/default-apm')
 const listrOpts = require('../helpers/listr-options')
 
@@ -55,6 +55,12 @@ exports.handler = function({ reporter, name, template, silent, debug }) {
         title: 'Preparing initialization',
         task: async (ctx, task) => {
           task.output = 'Checking if project folder already exists...'
+          if (!isValidEnsName(basename)) {
+            throw new Error(
+              'Invalid project name. Please only use lowercase alphanumeric characters.'
+            )
+          }
+
           await checkProjectExists(basename)
         },
       },

--- a/packages/create-aragon-app/src/util.js
+++ b/packages/create-aragon-app/src/util.js
@@ -22,16 +22,16 @@ const installDeps = (cwd, task) => {
 }
 
 /**
- * Validates an Aragon ENS subdomain name
- * @param {string} name Name
+ * Validates an Aragon Id
+ * @param {string} aragonId Aragon Id
  * @returns {boolean} `true` if valid
  */
-function isValidEnsName(name) {
-  return /^[a-z0-9-]+$/.test(name)
+function isValidAragonId(aragonId) {
+  return /^[a-z0-9-]+$/.test(aragonId)
 }
 
 module.exports = {
   installDeps,
-  isValidEnsName,
+  isValidAragonId,
   getNodePackageManager,
 }

--- a/packages/create-aragon-app/src/util.js
+++ b/packages/create-aragon-app/src/util.js
@@ -21,7 +21,17 @@ const installDeps = (cwd, task) => {
   })
 }
 
+/**
+ * Validates an Aragon ENS subdomain name
+ * @param {string} name Name
+ * @returns {boolean} `true` if valid
+ */
+function isValidEnsName(name) {
+  return /^[a-z0-9]+$/.test(name)
+}
+
 module.exports = {
   installDeps,
+  isValidEnsName,
   getNodePackageManager,
 }

--- a/packages/create-aragon-app/src/util.js
+++ b/packages/create-aragon-app/src/util.js
@@ -27,7 +27,7 @@ const installDeps = (cwd, task) => {
  * @returns {boolean} `true` if valid
  */
 function isValidEnsName(name) {
-  return /^[a-z0-9]+$/.test(name)
+  return /^[a-z0-9-]+$/.test(name)
 }
 
 module.exports = {

--- a/packages/create-aragon-app/test/create-aragon-app.test.js
+++ b/packages/create-aragon-app/test/create-aragon-app.test.js
@@ -16,7 +16,7 @@ test.afterEach(t => {
   fs.removeSync(projectPath)
 })
 
-test('check if project folder already exists', async t => {
+test.serial('check if project folder already exists', async t => {
   try {
     await checkProjectExists(projectPath)
     t.fail()
@@ -34,7 +34,7 @@ test('project name validation', t => {
   t.is(isValidAragonId('test_project'), false)
 })
 
-test('prepare project template', async t => {
+test.serial('prepare project template', async t => {
   const repoPath = `${projectPath}/.git`
   const arappPath = `${projectPath}/arapp.json`
   const packageJsonPath = `${projectPath}/package.json`

--- a/packages/create-aragon-app/test/create-aragon-app.test.js
+++ b/packages/create-aragon-app/test/create-aragon-app.test.js
@@ -28,9 +28,9 @@ test('check if project folder already exists', async t => {
 test('project name validation', t => {
   t.is(isValidEnsName('testproject'), true)
   t.is(isValidEnsName('project2'), true)
+  t.is(isValidEnsName('test-project'), true)
 
   t.is(isValidEnsName('testProject'), false)
-  t.is(isValidEnsName('test-project'), false)
   t.is(isValidEnsName('test_project'), false)
 })
 

--- a/packages/create-aragon-app/test/create-aragon-app.test.js
+++ b/packages/create-aragon-app/test/create-aragon-app.test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import fs from 'fs-extra'
 
 import { checkProjectExists, prepareTemplate } from '../src/lib'
+import { isValidEnsName } from '../src/util'
 
 import defaultAPMName from '../src/helpers/default-apm'
 
@@ -22,6 +23,15 @@ test('check if project folder already exists', async t => {
   } catch (err) {
     t.pass()
   }
+})
+
+test('project name validation', t => {
+  t.is(isValidEnsName('testproject'), true)
+  t.is(isValidEnsName('project2'), true)
+
+  t.is(isValidEnsName('testProject'), false)
+  t.is(isValidEnsName('test-project'), false)
+  t.is(isValidEnsName('test_project'), false)
 })
 
 test('prepare project template', async t => {

--- a/packages/create-aragon-app/test/create-aragon-app.test.js
+++ b/packages/create-aragon-app/test/create-aragon-app.test.js
@@ -2,7 +2,7 @@ import test from 'ava'
 import fs from 'fs-extra'
 
 import { checkProjectExists, prepareTemplate } from '../src/lib'
-import { isValidEnsName } from '../src/util'
+import { isValidAragonId } from '../src/util'
 
 import defaultAPMName from '../src/helpers/default-apm'
 
@@ -26,12 +26,12 @@ test('check if project folder already exists', async t => {
 })
 
 test('project name validation', t => {
-  t.is(isValidEnsName('testproject'), true)
-  t.is(isValidEnsName('project2'), true)
-  t.is(isValidEnsName('test-project'), true)
+  t.is(isValidAragonId('testproject'), true)
+  t.is(isValidAragonId('project2'), true)
+  t.is(isValidAragonId('test-project'), true)
 
-  t.is(isValidEnsName('testProject'), false)
-  t.is(isValidEnsName('test_project'), false)
+  t.is(isValidAragonId('testProject'), false)
+  t.is(isValidAragonId('test_project'), false)
 })
 
 test('prepare project template', async t => {


### PR DESCRIPTION
# 🦅 Pull Request

Closes #147. Displays an error during initialization when project name contains invalid chars.

## 🚨 Test instructions

`aragon init my_app_name`
or
`create-aragon-app my_app_name`

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [ ] (N/A) Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

