### PR TITLE
CLI: avoid coercing number arguments from strings to JS numbers

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/act.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/act.js
@@ -2,7 +2,7 @@ const ABI = require('web3-eth-abi')
 const execHandler = require('./utils/execHandler').handler
 const getAppKernel = require('./utils/app-kernel')
 const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const { parseStringIfPossible, ZERO_ADDRESS } = require('../../util')
+const { parseArgumentStringIfPossible, ZERO_ADDRESS } = require('../../util')
 
 const EXECUTE_FUNCTION_NAME = 'execute'
 
@@ -59,7 +59,7 @@ exports.handler = async function({
 }) {
   // TODO (daniel) refactor ConsoleReporter so we can do reporter.debug instead
   if (global.DEBUG_MODE) console.log('call-args before parsing', callArgs)
-  callArgs = callArgs.map(parseStringIfPossible)
+  callArgs = callArgs.map(parseArgumentStringIfPossible)
   if (global.DEBUG_MODE) console.log('call-args after parsing', callArgs)
 
   const web3 = await ensureWeb3(network)

--- a/packages/aragon-cli/src/commands/dao_cmds/exec.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/exec.js
@@ -1,6 +1,6 @@
 const execHandler = require('./utils/execHandler').handler
 const daoArg = require('./utils/daoArg')
-const { parseStringIfPossible } = require('../../util')
+const { parseArgumentStringIfPossible } = require('../../util')
 
 exports.command = 'exec <dao> <proxy-address> <fn> [fn-args..]'
 
@@ -33,7 +33,7 @@ exports.handler = async function({
 }) {
   // TODO (daniel) refactor ConsoleReporter so we can do reporter.debug instead
   if (global.DEBUG_MODE) console.log('fn-args before parsing', fnArgs)
-  fnArgs = fnArgs.map(parseStringIfPossible)
+  fnArgs = fnArgs.map(parseArgumentStringIfPossible)
   if (global.DEBUG_MODE) console.log('fn-args after parsing', fnArgs)
 
   const getTransactionPath = wrapper =>

--- a/packages/aragon-cli/src/commands/dao_cmds/token_cmds/new.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/token_cmds/new.js
@@ -6,7 +6,7 @@ const chalk = require('chalk')
 const web3Utils = require('web3-utils')
 const {
   getRecommendedGasLimit,
-  parseStringIfPossible,
+  parseArgumentStringIfPossible,
   ZERO_ADDRESS,
 } = require('../../../util')
 
@@ -66,7 +66,7 @@ exports.task = async ({
   if (chainId === 4)
     tokenFactoryAddress = tokenFactoryAddress || RINKEBY_MINIME_TOKEN_FACTORY
 
-  transferEnabled = parseStringIfPossible(transferEnabled)
+  transferEnabled = parseArgumentStringIfPossible(transferEnabled)
 
   return new TaskList(
     [

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -4,7 +4,6 @@ const execa = require('execa')
 const net = require('net')
 const fs = require('fs')
 const { readJson } = require('fs-extra')
-const web3Utils = require('web3-utils')
 const which = require('which')
 
 let cachedProjectRoot
@@ -199,30 +198,6 @@ const getRecommendedGasLimit = async (
 }
 
 /**
- *
- * Parse a String to Number, or throw an error.
- *
- * @param {string} target must be a string
- * @returns {number} the parsed value
- */
-const parseAsNumber = target => {
-  if (typeof target !== 'string') {
-    throw new Error(
-      `Expected ${target} to be of type string, not ${typeof target}`
-    )
-  }
-
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
-  const number = Number(target)
-
-  if (isNaN(number)) {
-    throw new Error(`Cannot parse ${target} as number`)
-  }
-
-  return number
-}
-
-/**
  * Parse a String to Boolean, or throw an error.
  *
  * The check is **case insensitive**! (Passing `"TRue"` will return `true`)
@@ -274,19 +249,12 @@ const parseAsArray = target => {
 }
 
 /**
- * Parse a String to Number or Boolean or Array, or throw an error.
+ * Parse a String to Boolean or Array, or throw an error.
  *
  * @param {string} target must be a string
- * @returns {number|boolean|Array} the parsed value
+ * @returns {boolean|Array} the parsed value
  */
-const parseStringIfPossible = target => {
-  // convert to number: '1' to 1
-  try {
-    if (!web3Utils.isAddress(target)) {
-      return parseAsNumber(target)
-    }
-  } catch (e) {}
-
+const parseArgumentStringIfPossible = target => {
   // convert to boolean: 'false' to false
   try {
     return parseAsBoolean(target)
@@ -312,7 +280,7 @@ function isValidAragonId(aragonId) {
 }
 
 module.exports = {
-  parseStringIfPossible,
+  parseArgumentStringIfPossible,
   debugLogger,
   findProjectRoot,
   isPortTaken,


### PR DESCRIPTION
# 🦅 Pull Request

```
dao act 0x510846E270759CC92131D3453c58e1073C191cD1 0xec67005c4e498ec7f55e092bd1d35cbc47c91892 "transfer(address,uint256)" 0x0d580ae50B58fe08514dEAB4e38c0DFdB0D30adC 1000000000000000000 --environment aragon:mainnet
```

Results in an

```
invalid number value (arg="", coderType="uint256", value=1000000000000000000)`
```

Error produced from web3-eth-abi.

## 🚨 Test instructions

Run

```
dao act 0x510846E270759CC92131D3453c58e1073C191cD1 0xec67005c4e498ec7f55e092bd1d35cbc47c91892 "transfer(address,uint256)" 0x0d580ae50B58fe08514dEAB4e38c0DFdB0D30adC 1000000000000000000 --environment aragon:mainnet
```

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

--------------

Note that web3-eth-abi does not like much else than a string; giving it a BN.js object or etc. does not work :(.

In general though, unless we need to do computation to a number, it's often best to keep it around as a string since Ethereum numbers are generally _large_.