### PR TITLE
Handle IPFS not being installed

### DIFF
--- a/packages/aragon-cli/src/commands/ipfs_cmds/start.js
+++ b/packages/aragon-cli/src/commands/ipfs_cmds/start.js
@@ -67,23 +67,17 @@ exports.task = ({ apmOptions, silent, debug }) => {
   )
 }
 
-exports.handler = function({ reporter, apm: apmOptions }) {
+exports.handler = async function({ reporter, apm: apmOptions }) {
   const task = exports.task({ apmOptions })
 
-  task
-    .run()
-    .then(ctx => {
-      if (ctx.started) {
-        reporter.info(
-          'IPFS daemon is now running. Stopping this process will stop IPFS'
-        )
-      } else {
-        reporter.warning(chalk.yellow('Didnt start IPFS, port busy'))
-        process.exit()
-      }
-    })
-    .catch(err => {
-      reporter.error(err)
-      process.exit(1)
-    })
+  const ctx = await task.run()
+
+  if (ctx.started) {
+    reporter.info(
+      'IPFS daemon is now running. Stopping this process will stop IPFS'
+    )
+  } else {
+    reporter.warning(chalk.yellow("Didn't start IPFS, port busy"))
+    process.exit()
+  }
 }

--- a/packages/aragon-cli/src/helpers/ipfs-daemon.js
+++ b/packages/aragon-cli/src/helpers/ipfs-daemon.js
@@ -8,6 +8,12 @@ const { getBinary, isPortTaken } = require('../util')
 const ipfsBin = getBinary('ipfs')
 
 const ensureIPFSInitialized = async () => {
+  if (!ipfsBin) {
+    throw new Error(
+      'IPFS is not installed. Use `aragon ipfs install` before proceeding.'
+    )
+  }
+
   if (!fs.existsSync(path.join(os.homedir(), '.ipfs'))) {
     // We could use 'ipfs daemon --init' when https://github.com/ipfs/go-ipfs/issues/3913 is solved
     await execa(ipfsBin, ['init'])
@@ -15,6 +21,12 @@ const ensureIPFSInitialized = async () => {
 }
 
 const startIPFSDaemon = () => {
+  if (!ipfsBin) {
+    throw new Error(
+      'IPFS is not installed. Use `aragon ipfs install` before proceeding.'
+    )
+  }
+
   const IPFS_START_TIMEOUT = 20000 // 20s for timeout, may need to be tweaked
 
   let startOutput = ''


### PR DESCRIPTION
# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->
Before:
```sh
daniel@zen5-ub:~$ aragon ipfs
(node:13665) UnhandledPromiseRejectionWarning: TypeError [ERR_INVALID_ARG_TYPE]: The "file" argument must be of type string. Received type object
    at validateString (internal/validators.js:125:11)
    at normalizeSpawnArguments (child_process.js:416:3)
    at Object.spawn (child_process.js:555:16)
    at module.exports (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/execa/index.js:205:26)
    at execa (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/src/helpers/ipfs-daemon.js:31:22)
    at tryCatch (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:45:40)
    at Generator.invoke [as _invoke] (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:271:22)
    at Generator.prototype.(anonymous function) [as next] (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:97:21)
    at asyncGeneratorStep (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/dist/helpers/ipfs-daemon.js:35:103)
    at _next (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/dist/helpers/ipfs-daemon.js:37:194)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
(node:13665) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 4)
(node:13665) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:13665) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'on' of undefined
    at on (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/src/helpers/ipfs-daemon.js:33:21)
    at tryCatch (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:45:40)
    at Generator.invoke [as _invoke] (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:271:22)
    at Generator.prototype.(anonymous function) [as next] (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/node_modules/regenerator-runtime/runtime.js:97:21)
    at asyncGeneratorStep (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/dist/helpers/ipfs-daemon.js:35:103)
    at _next (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/dist/helpers/ipfs-daemon.js:37:194)
    at processTicksAndRejections (internal/process/task_queues.js:86:5)
(node:13665) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 5)
  ✖ Start IPFS
    → Starting IPFS timed out:
    Add local files
✖ { Error: Starting IPFS timed out:

    at Timeout._onTimeout (/home/daniel/r/ar/aragon-cli/packages/aragon-cli/src/helpers/ipfs-daemon.js:25:14)
    at listOnTimeout (internal/timers.js:535:17)
    at processTimers (internal/timers.js:479:7) context: [Object: null prototype] {} }

```

After:
```sh
daniel@zen5-ub:~$ aragon ipfs
  ✖ Start IPFS
    → IPFS is not installed. Use `aragon ipfs install` before proceeding.
    Add local files
✖ IPFS is not installed. Use `aragon ipfs install` before proceeding.
```
## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
