### PR TITLE
aragon-run: Add option for --client-repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ All changes to this project will be documented in this file.
 
 ---
 
+## v6.2.4
+
+Release date: **2019-09-20**  
+[Compare code changes][v6.2.4] (🌳 STABLE)
+
+### What’s changed in aragonCLI
+
+## 💡 Feature updates
+
+- Iterate `aragon run`: add `--client-repo` optional argument
+
+---
+
 ## v6.2.3
 
 Release date: **2019-08-07**  

--- a/docs/Main-commands.md
+++ b/docs/Main-commands.md
@@ -32,6 +32,7 @@ Available options to customize the `run` command:
 - `bump`: Type of bump (major, minor or patch) or version number to publish the app.
 - `--client`: Whether to start the Aragon client or not. Defaults to `true`.
 - `--client-version`: Version of Aragon client used to run your sandboxed app.
+- `--client-repo`: Repository of Aragon client to clone and run in your sandboxed app. Defaults to `https://github.com/aragon/aragon`.
 - `--client-port`: Port being used by Aragon client.
 - `--client-path`: A path pointing to an existing Aragon client installation.
 - `--app-init`: Name of the function that will be called to initialize an app. Defaults to `initialize`.

--- a/packages/aragon-cli/package.json
+++ b/packages/aragon-cli/package.json
@@ -141,6 +141,7 @@
     ]
   },
   "aragon": {
+    "clientRepo": "https://github.com/aragon/aragon",
     "clientVersion": "d8066daad8bf3be6a83f7ee374032995ebd994cf",
     "clientPort": "3000",
     "defaultGasPrice": "2",

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -24,6 +24,7 @@ const { findProjectRoot, isPortTaken } = require('../util')
 
 const url = require('url')
 
+const DEFAULT_CLIENT_REPO = pkg.aragon.clientRepo
 const DEFAULT_CLIENT_VERSION = pkg.aragon.clientVersion
 const DEFAULT_CLIENT_PORT = pkg.aragon.clientPort
 
@@ -147,6 +148,10 @@ exports.builder = function(yargs) {
       array: true,
       default: [],
     })
+    .option('client-repo', {
+      description: 'Repo of Aragon client used to run your sandboxed app',
+      default: DEFAULT_CLIENT_REPO,
+    })
     .option('client-version', {
       description: 'Version of Aragon client used to run your sandboxed app',
       default: DEFAULT_CLIENT_VERSION,
@@ -196,6 +201,7 @@ exports.handler = function({
   httpServedFrom,
   appInit,
   appInitArgs,
+  clientRepo,
   clientVersion,
   clientPort,
   clientPath,
@@ -364,7 +370,7 @@ exports.handler = function({
         title: 'Open DAO',
         enabled: () => client === true,
         task: async (ctx, task) =>
-          start.task({ clientVersion, clientPort, clientPath }),
+          start.task({ clientRepo, clientVersion, clientPort, clientPath }),
       },
     ],
     listrOpts(silent, debug)

--- a/packages/aragon-cli/src/commands/start.js
+++ b/packages/aragon-cli/src/commands/start.js
@@ -10,6 +10,7 @@ const TaskList = require('listr')
 const pkg = require('../../package.json')
 const { installDeps } = require('../util')
 
+const DEFAULT_CLIENT_REPO = pkg.aragon.clientRepo
 const DEFAULT_CLIENT_VERSION = pkg.aragon.clientVersion
 const DEFAULT_CLIENT_PORT = pkg.aragon.clientPort
 
@@ -19,6 +20,11 @@ exports.describe = 'Start the Aragon GUI (graphical user interface)'
 
 exports.builder = yargs => {
   return yargs
+    .positional('client-repo', {
+      description:
+        'Repo of Aragon client used to run your sandboxed app (valid git repository using https or ssh protocol)',
+      default: DEFAULT_CLIENT_REPO,
+    })
     .positional('client-version', {
       description:
         'Version of Aragon client used to run your sandboxed app (commit hash, branch name or tag name)',
@@ -34,7 +40,12 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async function({ clientVersion, clientPort, clientPath }) {
+exports.task = async function({
+  clientRepo,
+  clientVersion,
+  clientPort,
+  clientPath,
+}) {
   const tasks = new TaskList([
     {
       title: 'Fetching client from aragen',
@@ -50,7 +61,7 @@ exports.task = async function({ clientVersion, clientPort, clientPath }) {
       skip: ctx => !!clientPath,
       task: async (ctx, task) => {
         task.output = 'Downloading client...'
-        await downloadClient(ctx, task, clientVersion)
+        await downloadClient({ ctx, task, clientRepo, clientVersion })
       },
       enabled: ctx => !ctx.clientFetch,
     },
@@ -87,18 +98,24 @@ exports.task = async function({ clientVersion, clientPort, clientPath }) {
 
 exports.handler = async ({
   reporter,
+  clientRepo,
   clientVersion,
   clientPort,
   clientPath,
 }) => {
-  const task = await exports.task({ clientVersion, clientPort, clientPath })
+  const task = await exports.task({
+    clientRepo,
+    clientVersion,
+    clientPort,
+    clientPath,
+  })
   return task
     .run()
     .then(() =>
       reporter.info(
-        `Aragon client version ${chalk.blue(
+        `Aragon client from ${chalk.blue(clientRepo)} version ${chalk.blue(
           clientVersion
-        )}, started on port ${chalk.blue(clientPort)}`
+        )} started on port ${chalk.blue(clientPort)}`
       )
     )
 }

--- a/packages/aragon-cli/src/lib/start/download-client.js
+++ b/packages/aragon-cli/src/lib/start/download-client.js
@@ -3,8 +3,14 @@ import { existsSync, ensureDirSync } from 'fs-extra'
 import os from 'os'
 import { promisify } from 'util'
 const clone = promisify(require('git-clone'))
+const pkg = require('../../../package.json')
 
-export async function downloadClient(ctx, task, clientVersion) {
+export async function downloadClient({
+  ctx,
+  task,
+  clientRepo = pkg.aragon.clientRepo,
+  clientVersion,
+}) {
   const CLIENT_PATH = `${os.homedir()}/.aragon/client-${clientVersion}`
   ctx.clientPath = CLIENT_PATH
 
@@ -19,7 +25,5 @@ export async function downloadClient(ctx, task, clientVersion) {
   ensureDirSync(CLIENT_PATH)
 
   // Clone client
-  return clone('https://github.com/aragon/aragon', CLIENT_PATH, {
-    checkout: clientVersion,
-  })
+  return clone(clientRepo, CLIENT_PATH, { checkout: clientVersion })
 }


### PR DESCRIPTION
This option allows setting the repo from which to download the aragon client, allowing dev teams to temporarily use a forked client while working on experimental features.

# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->

We at Autark are working toward our mainnet release. To get Projects working correctly, we need to test-drive some experimental changes to aragonAPI and the wrapper (https://github.com/aragon/aragon.js/pull/361). We've set up custom repos for each of these (https://github.com/AutarkLabs/aragon-api & https://github.com/AutarkLabs/aragon-wrapper) and a version of the client that uses our experimental wrapper (https://github.com/AutarkLabs/aragon/pull/27), and now we need to use that client from our Open Enterprise repo as shown here: https://github.com/AutarkLabs/open-enterprise/pull/1249/files#diff-7c6178980acb266af0692d351cfdba1cR9

## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

Verify that passing the `--client-repo` command to `aragon run` downloads the client from the specified repository, just as `--client-versoin` allows specifying the commit hash.

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change _[I did not see any tests for `--client-version`, so I have not added any for `--client-repo`]_
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
