### PR TITLE
Detect if IPFS is initialized in a more robust way, to resolve #744

### DIFF
--- a/packages/aragon-cli/src/helpers/ipfs-daemon.js
+++ b/packages/aragon-cli/src/helpers/ipfs-daemon.js
@@ -1,7 +1,4 @@
 const execa = require('execa')
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
 const ipfsAPI = require('ipfs-api')
 const { getBinary, isPortTaken } = require('../util')
 
@@ -14,7 +11,10 @@ const ensureIPFSInitialized = async () => {
     )
   }
 
-  if (!fs.existsSync(path.join(os.homedir(), '.ipfs'))) {
+  try {
+    // 'ipfs config show' exits with 1 if ipfs is not initialized
+    await execa(ipfsBin, ['config', 'show'])
+  } catch (e) {
     // We could use 'ipfs daemon --init' when https://github.com/ipfs/go-ipfs/issues/3913 is solved
     await execa(ipfsBin, ['init'])
   }


### PR DESCRIPTION
# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->
Detect if IPFS is initialized in a more robust way, by calling
```
ipfs config show
```
which exits with 1 if IPFS is not initialized and with 0 if it is. 

Fixes https://github.com/aragon/aragon-cli/issues/744

## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

Install IPFS using SNAP
Run `aragon ipfs`

The current version produces this output
```
  ⠼ Start IPFS
    → Starting IPFS at port: 5001
    Add local files
(node:16693) UnhandledPromiseRejectionWarning: Error: Command failed: /snap/bin/ipfs init
Error: ipfs configuration file already exists!
Reinitializing would overwrite your keys.


initializing IPFS node at /home/lion/snap/ipfs/1170/.ipfs

    at makeError (/home/lion/aragon-cli/packages/aragon-cli/node_modules/execa/index.js:174:9)
    at Promise.all.then.arr (/home/lion/aragon-cli/packages/aragon-cli/node_modules/execa/index.js:278:16)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:16693) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside   ✖ Start IPFS
    → Starting IPFS timed out:
    Add local files
✖ Starting IPFS timed out:
```
and with this PR
```
  ✔ Start IPFS
  ✔ Add local files
ℹ IPFS daemon is now running. Stopping this process will stop IPFS
```

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
