### PR TITLE
Sanitize CLI options

### DIFF
--- a/packages/aragon-cli/npm-shrinkwrap.json
+++ b/packages/aragon-cli/npm-shrinkwrap.json
@@ -487,6 +487,342 @@
         "listr-silent-renderer": "^1.1.1",
         "listr-update-renderer": "^0.5.0",
         "listr-verbose-renderer": "^0.5.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+          "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "cli-truncate": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+          "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+          "requires": {
+            "slice-ansi": "0.0.4",
+            "string-width": "^1.0.1"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+        },
+        "elegant-spinner": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+          "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+        },
+        "figures": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-3.0.0.tgz",
+          "integrity": "sha512-HKri+WoWoUgr83pehn/SIgLOMZ9nAWC6dcGj26RY2R4F50u4+RTUz0RCrUlOV3nKRAICW1UGzyb+kcX2qK1S/g==",
+          "requires": {
+            "escape-string-regexp": "^1.0.5"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "listr-silent-renderer": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+          "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
+        },
+        "listr-update-renderer": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
+          "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+          "requires": {
+            "chalk": "^1.1.3",
+            "cli-truncate": "^0.2.1",
+            "elegant-spinner": "^1.0.1",
+            "figures": "^1.7.0",
+            "indent-string": "^3.0.0",
+            "log-symbols": "^1.0.2",
+            "log-update": "^2.3.0",
+            "strip-ansi": "^3.0.1"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "figures": {
+              "version": "1.7.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+              "requires": {
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "listr-verbose-renderer": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
+          "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+          "requires": {
+            "chalk": "^2.4.1",
+            "cli-cursor": "^2.1.0",
+            "date-fns": "^1.27.2",
+            "figures": "^2.0.0"
+          },
+          "dependencies": {
+            "figures": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+              "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+              "requires": {
+                "escape-string-regexp": "^1.0.5"
+              }
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "requires": {
+            "chalk": "^1.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+            },
+            "chalk": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+              "requires": {
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+            }
+          }
+        },
+        "log-update": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
+          "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+          "requires": {
+            "ansi-escapes": "^3.0.0",
+            "cli-cursor": "^2.0.0",
+            "wrap-ansi": "^3.0.1"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+          "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
+          "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+          "requires": {
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+              "requires": {
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+              "requires": {
+                "ansi-regex": "^3.0.0"
+              }
+            }
+          }
+        }
       }
     },
     "@aragon/os": {
@@ -545,6 +881,14 @@
         "@babel/runtime": "^7.1.2",
         "rxjs": "^6.5.2",
         "uuid": "^3.2.1"
+      }
+    },
+    "@aragon/truffle-config-v4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@aragon/truffle-config-v4/-/truffle-config-v4-1.0.0.tgz",
+      "integrity": "sha512-8o6+51gFqFf0ILkEJJK4EyRbydk+h1UBOQyDvIzeOeq46NnzVBGP0/8W8mwBq8Y9ELDRB9iJdKAhyBf73GMTJg==",
+      "requires": {
+        "@truffle/hdwallet-provider": "^1.0.0"
       }
     },
     "@aragon/wrapper": {
@@ -2210,6 +2554,109 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@truffle/hdwallet-provider": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.22.tgz",
+      "integrity": "sha512-V07zTK4KrD273EGEBSrpvkGyZnI0c5ttvOhHKjThu2KPN1xHDGj73GfEHr6Gt/PI+8U2LWSG0xWZcwxQNyT8vA==",
+      "requires": {
+        "any-promise": "^1.3.0",
+        "bindings": "^1.5.0",
+        "bip39": "^2.4.2",
+        "ethereum-protocol": "^1.0.1",
+        "ethereumjs-tx": "^1.0.0",
+        "ethereumjs-util": "^6.1.0",
+        "ethereumjs-wallet": "^0.6.3",
+        "web3": "1.2.1",
+        "web3-provider-engine": "git+https://github.com/trufflesuite/provider-engine.git#web3-one"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-block-tracker": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/eth-block-tracker/-/eth-block-tracker-3.0.1.tgz",
+          "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
+          "requires": {
+            "eth-query": "^2.1.0",
+            "ethereumjs-tx": "^1.3.3",
+            "ethereumjs-util": "^5.1.3",
+            "ethjs-util": "^0.1.3",
+            "json-rpc-engine": "^3.6.0",
+            "pify": "^2.3.0",
+            "tape": "^4.6.3"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "web3-provider-engine": {
+          "version": "git+https://github.com/trufflesuite/provider-engine.git#3538c60bc4836b73ccae1ac3f64c8fed8ef19c1a",
+          "from": "git+https://github.com/trufflesuite/provider-engine.git#web3-one",
+          "requires": {
+            "async": "^2.5.0",
+            "backoff": "^2.5.0",
+            "clone": "^2.0.0",
+            "cross-fetch": "^2.1.0",
+            "eth-block-tracker": "^3.0.0",
+            "eth-json-rpc-infura": "^3.1.0",
+            "eth-sig-util": "^1.4.2",
+            "ethereumjs-block": "^1.2.2",
+            "ethereumjs-tx": "^1.2.0",
+            "ethereumjs-util": "^5.1.5",
+            "ethereumjs-vm": "^2.3.4",
+            "json-rpc-error": "^2.0.0",
+            "json-stable-stringify": "^1.0.1",
+            "promise-to-callback": "^1.0.0",
+            "readable-stream": "^2.2.9",
+            "request": "^2.85.0",
+            "semaphore": "^1.0.3",
+            "ws": "^5.1.1",
+            "xhr": "^2.2.0",
+            "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "ethereumjs-util": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+              "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+              "requires": {
+                "bn.js": "^4.11.0",
+                "create-hash": "^1.1.2",
+                "ethjs-util": "^0.1.3",
+                "keccak": "^1.0.2",
+                "rlp": "^2.0.0",
+                "safe-buffer": "^5.1.1",
+                "secp256k1": "^3.0.1"
+              }
+            }
+          }
+        },
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -3779,6 +4226,14 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
+    },
     "bail": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.4.tgz",
@@ -5259,6 +5714,27 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
+      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "requires": {
+        "node-fetch": "2.1.2",
+        "whatwg-fetch": "2.0.4"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
+          "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U="
+        },
+        "whatwg-fetch": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+        }
       }
     },
     "cross-spawn": {
@@ -7126,6 +7602,58 @@
         "js-sha3": "^0.5.7"
       }
     },
+    "eth-json-rpc-infura": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-infura/-/eth-json-rpc-infura-3.2.1.tgz",
+      "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
+      "requires": {
+        "cross-fetch": "^2.1.1",
+        "eth-json-rpc-middleware": "^1.5.0",
+        "json-rpc-engine": "^3.4.0",
+        "json-rpc-error": "^2.0.0"
+      }
+    },
+    "eth-json-rpc-middleware": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eth-json-rpc-middleware/-/eth-json-rpc-middleware-1.6.0.tgz",
+      "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
+      "requires": {
+        "async": "^2.5.0",
+        "eth-query": "^2.1.2",
+        "eth-tx-summary": "^3.1.2",
+        "ethereumjs-block": "^1.6.0",
+        "ethereumjs-tx": "^1.3.3",
+        "ethereumjs-util": "^5.1.2",
+        "ethereumjs-vm": "^2.1.0",
+        "fetch-ponyfill": "^4.0.0",
+        "json-rpc-engine": "^3.6.0",
+        "json-rpc-error": "^2.0.0",
+        "json-stable-stringify": "^1.0.1",
+        "promise-to-callback": "^1.0.0",
+        "tape": "^4.6.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
     "eth-lib": {
       "version": "0.1.27",
       "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz",
@@ -7186,6 +7714,44 @@
         }
       }
     },
+    "eth-tx-summary": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/eth-tx-summary/-/eth-tx-summary-3.2.4.tgz",
+      "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
+      "requires": {
+        "async": "^2.1.2",
+        "clone": "^2.0.0",
+        "concat-stream": "^1.5.1",
+        "end-of-stream": "^1.1.0",
+        "eth-query": "^2.0.2",
+        "ethereumjs-block": "^1.4.1",
+        "ethereumjs-tx": "^1.1.1",
+        "ethereumjs-util": "^5.0.1",
+        "ethereumjs-vm": "^2.6.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "ethereumjs-util": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
+          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "requires": {
+            "bn.js": "^4.11.0",
+            "create-hash": "^1.1.2",
+            "ethjs-util": "^0.1.3",
+            "keccak": "^1.0.2",
+            "rlp": "^2.0.0",
+            "safe-buffer": "^5.1.1",
+            "secp256k1": "^3.0.1"
+          }
+        }
+      }
+    },
     "ethereum-common": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ethereum-common/-/ethereum-common-0.2.0.tgz",
@@ -7208,6 +7774,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ethereum-ens-network-map/-/ethereum-ens-network-map-1.0.0.tgz",
       "integrity": "sha1-Q812ac6VCnieFRABEY1NZfIQ7rc="
+    },
+    "ethereum-protocol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz",
+      "integrity": "sha512-3KLX1mHuEsBW0dKG+c6EOJS1NBNqdCICvZW9sInmZTt5aY0oxmHVggYRE0lJu1tcnMD1K+AKHdLi6U43Awm1Vg=="
     },
     "ethereumjs-abi": {
       "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
@@ -27637,6 +28208,11 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -30566,17 +31142,6 @@
         }
       }
     },
-    "truffle-hdwallet-provider": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider/-/truffle-hdwallet-provider-1.0.17.tgz",
-      "integrity": "sha512-s6DvSP83jiIAc6TUcpr7Uqnja1+sLGJ8og3X7n41vfyC4OCaKmBtXL5HOHf+SsU3iblOvnbFDgmN6Y1VBL/fsg==",
-      "requires": {
-        "any-promise": "^1.3.0",
-        "bindings": "^1.3.1",
-        "web3": "1.2.1",
-        "websocket": "^1.0.28"
-      }
-    },
     "truffle-hdwallet-provider-privkey": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/truffle-hdwallet-provider-privkey/-/truffle-hdwallet-provider-privkey-0.3.0.tgz",
@@ -31729,6 +32294,32 @@
         "underscore": "1.9.1",
         "web3-core-helpers": "1.2.1",
         "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        },
+        "websocket": {
+          "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
+          "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
+          "requires": {
+            "debug": "^2.2.0",
+            "es5-ext": "^0.10.50",
+            "nan": "^2.14.0",
+            "typedarray-to-buffer": "^3.1.5",
+            "yaeti": "^0.0.6"
+          }
+        }
       }
     },
     "web3-shh": {
@@ -31776,32 +32367,6 @@
     "webcrypto-shim": {
       "version": "github:dignifiedquire/webcrypto-shim#190bc9ec341375df6025b17ae12ddb2428ea49c8",
       "from": "github:dignifiedquire/webcrypto-shim#master"
-    },
-    "websocket": {
-      "version": "1.0.29",
-      "resolved": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
-      "requires": {
-        "debug": "^2.2.0",
-        "es5-ext": "^0.10.50",
-        "nan": "^2.14.0",
-        "typedarray-to-buffer": "^3.1.5",
-        "yaeti": "^0.0.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        }
-      }
     },
     "websocket-driver": {
       "version": "0.7.3",

--- a/packages/aragon-cli/src/commands/apm_cmds/publish.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/publish.js
@@ -45,10 +45,10 @@ exports.builder = function(yargs) {
   const cmd = deploy.builder(yargs) // inherit deploy options
 
   cmd
-    .positional('bump', {
-      description: 'Type of bump (major, minor or patch) or version number',
-      type: 'string',
-    })
+    // .positional('bump', {
+    //   description: 'Type of bump (major, minor or patch) or version number',
+    //   type: 'string',
+    // })
     .positional('contract', {
       description:
         "The address or name of the contract to publish in this version. If it isn't provided, it will default to the current version's contract.",
@@ -92,11 +92,11 @@ exports.builder = function(yargs) {
       boolean: true,
       default: true,
     })
-    .option('publish-dir', {
-      description:
-        'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
-      default: null,
-    })
+    // .option('publish-dir', {
+    //   description:
+    //     'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
+    //   default: null,
+    // })
     .option('only-content', {
       description:
         'Whether to skip contract compilation, deployment and contract artifact generation',
@@ -123,15 +123,15 @@ exports.builder = function(yargs) {
     //   description: 'The npm script that will be run before publishing the app',
     //   default: 'prepublishOnly',
     // })
-    .option('http', {
-      description: 'URL for where your app is served e.g. localhost:1234',
-      default: null,
-    })
-    .option('http-served-from', {
-      description:
-        'Directory where your files is being served from e.g. ./dist',
-      default: null,
-    })
+    // .option('http', {
+    //   description: 'URL for where your app is served e.g. localhost:1234',
+    //   default: null,
+    // })
+    // .option('http-served-from', {
+    //   description:
+    //     'Directory where your files is being served from e.g. ./dist',
+    //   default: null,
+    // })
     .option('propagate-content', {
       description: 'Whether to propagate the content once published',
       boolean: true,
@@ -143,6 +143,10 @@ exports.builder = function(yargs) {
       default: false,
     })
 
+  addOption(cmd, options.BUMP, true)
+  addOption(cmd, options.HTTP)
+  addOption(cmd, options.HTTP_SERVED_FROM)
+  addOption(cmd, options.PUBLISH_DIR)
   addOption(cmd, options.FILES)
   addOption(cmd, options.BUILD)
   addOption(cmd, options.BUILD_SCRIPT)

--- a/packages/aragon-cli/src/commands/apm_cmds/publish.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/publish.js
@@ -18,6 +18,7 @@ const execTask = require('../dao_cmds/utils/execHandler').task
 const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
 const { map, filter, first } = require('rxjs/operators')
 const { addressesEqual } = require('../../util')
+const { options, addOption } = require('../../helpers/options')
 
 const {
   prepareFilesForPublishing,
@@ -41,8 +42,9 @@ exports.command = 'publish <bump> [contract]'
 exports.describe = 'Publish a new version of the application'
 
 exports.builder = function(yargs) {
-  return deploy
-    .builder(yargs) // inherit deploy options
+  const cmd = deploy.builder(yargs) // inherit deploy options
+
+  cmd
     .positional('bump', {
       description: 'Type of bump (major, minor or patch) or version number',
       type: 'string',
@@ -73,12 +75,12 @@ exports.builder = function(yargs) {
       default: false,
       boolean: true,
     })
-    .option('files', {
-      description:
-        'Path(s) to directories containing files to publish. Specify multiple times to include multiple files.',
-      default: ['.'],
-      array: true,
-    })
+    // .option('files', {
+    //   description:
+    //     'Path(s) to directories containing files to publish. Specify multiple times to include multiple files.',
+    //   default: ['.'],
+    //   array: true,
+    // })
     .option('ignore', {
       description:
         'A gitignore pattern of files to ignore. Specify multiple times to add multiple patterns.',
@@ -101,26 +103,26 @@ exports.builder = function(yargs) {
       default: false,
       boolean: true,
     })
-    .option('build', {
-      description:
-        'Whether publish should try to build the app before publishing, running the script specified in --build-script',
-      default: true,
-      boolean: true,
-    })
-    .option('build-script', {
-      description: 'The npm script that will be run when building the app',
-      default: 'build',
-    })
-    .option('prepublish', {
-      description:
-        'Whether publish should run prepublish script specified in --prepublish-script before publishing',
-      default: true,
-      boolean: true,
-    })
-    .option('prepublish-script', {
-      description: 'The npm script that will be run before publishing the app',
-      default: 'prepublishOnly',
-    })
+    // .option('build', {
+    //   description:
+    //     'Whether publish should try to build the app before publishing, running the script specified in --build-script',
+    //   default: true,
+    //   boolean: true,
+    // })
+    // .option('build-script', {
+    //   description: 'The npm script that will be run when building the app',
+    //   default: 'build',
+    // })
+    // .option('prepublish', {
+    //   description:
+    //     'Whether publish should run prepublish script specified in --prepublish-script before publishing',
+    //   default: true,
+    //   boolean: true,
+    // })
+    // .option('prepublish-script', {
+    //   description: 'The npm script that will be run before publishing the app',
+    //   default: 'prepublishOnly',
+    // })
     .option('http', {
       description: 'URL for where your app is served e.g. localhost:1234',
       default: null,
@@ -140,6 +142,14 @@ exports.builder = function(yargs) {
       boolean: true,
       default: false,
     })
+
+  addOption(cmd, options.FILES)
+  addOption(cmd, options.BUILD)
+  addOption(cmd, options.BUILD_SCRIPT)
+  addOption(cmd, options.PREPUBLISH)
+  addOption(cmd, options.PREPUBLISH_SCRIPT)
+
+  return cmd
 }
 
 exports.runSetupTask = ({

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -116,11 +116,11 @@ exports.builder = function(yargs) {
     //   description: 'The npm script that will be run when building the app',
     //   default: 'build',
     // })
-    .option('publish-dir', {
-      description:
-        'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
-      default: null,
-    })
+    // .option('publish-dir', {
+    //   description:
+    //     'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
+    //   default: null,
+    // })
     // .option('prepublish', {
     //   description:
     //     'Whether publish should run prepublish script specified in --prepublish-script before publishing',
@@ -131,24 +131,24 @@ exports.builder = function(yargs) {
     //   description: 'The npm script that will be run before publishing the app',
     //   default: 'prepublishOnly',
     // })
-    .option('bump', {
-      description:
-        'Type of bump (major, minor or patch) or version number to publish the app',
-      type: 'string',
-      default: 'major',
-    })
-    .option('http', {
-      description: 'URL for where your app is served from e.g. localhost:1234',
-      default: null,
-      coerce: url => {
-        return url && url.substr(0, 7) !== 'http://' ? `http://${url}` : url
-      },
-    })
-    .option('http-served-from', {
-      description:
-        'Directory where your files is being served from e.g. ./dist',
-      default: null,
-    })
+    // .option('bump', {
+    //   description:
+    //     'Type of bump (major, minor or patch) or version number to publish the app',
+    //   type: 'string',
+    //   default: 'major',
+    // })
+    // .option('http', {
+    //   description: 'URL for where your app is served from e.g. localhost:1234',
+    //   default: null,
+    //   coerce: url => {
+    //     return url && url.substr(0, 7) !== 'http://' ? `http://${url}` : url
+    //   },
+    // })
+    // .option('http-served-from', {
+    //   description:
+    //     'Directory where your files is being served from e.g. ./dist',
+    //   default: null,
+    // })
     .option('app-init', {
       description:
         'Name of the function that will be called to initialize an app',
@@ -176,6 +176,10 @@ exports.builder = function(yargs) {
       default: null,
     })
 
+  addOption(cmd, options.BUMP)
+  addOption(cmd, options.HTTP)
+  addOption(cmd, options.HTTP_SERVED_FROM)
+  addOption(cmd, options.PUBLISH_DIR)
   addOption(cmd, options.FILES)
   addOption(cmd, options.BUILD)
   addOption(cmd, options.BUILD_SCRIPT)

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -13,6 +13,7 @@ const pkg = require('../../package.json')
 const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
 const APM = require('@aragon/apm')
 const getRepoTask = require('./dao_cmds/utils/getRepoTask')
+const { options, addOption } = require('../helpers/options')
 
 const {
   runSetupTask,
@@ -37,18 +38,18 @@ exports.command = 'run'
 exports.describe = 'Run the current app locally'
 
 exports.builder = function(yargs) {
-  return yargs
+  const cmd = yargs
     .option('client', {
       description: 'Just run the smart contracts, without the Aragon client',
       default: true,
       boolean: true,
     })
-    .option('files', {
-      description:
-        'Path(s) to directories containing files to publish. Specify multiple times to include multiple files.',
-      default: ['.'],
-      array: true,
-    })
+    // .option('files', {
+    //   description:
+    //     'Path(s) to directories containing files to publish. Specify multiple times to include multiple files.',
+    //   default: ['.'],
+    //   array: true,
+    // })
     .option('port', {
       description: 'Port to start devchain at',
       default: '8545',
@@ -105,31 +106,31 @@ exports.builder = function(yargs) {
         return args.map(parseArgumentStringIfPossible)
       },
     })
-    .option('build', {
-      description:
-        'Whether publish should try to build the app before publishing, running the script specified in --build-script',
-      default: true,
-      boolean: true,
-    })
-    .option('build-script', {
-      description: 'The npm script that will be run when building the app',
-      default: 'build',
-    })
+    // .option('build', {
+    //   description:
+    //     'Whether publish should try to build the app before publishing, running the script specified in --build-script',
+    //   default: true,
+    //   boolean: true,
+    // })
+    // .option('build-script', {
+    //   description: 'The npm script that will be run when building the app',
+    //   default: 'build',
+    // })
     .option('publish-dir', {
       description:
         'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
       default: null,
     })
-    .option('prepublish', {
-      description:
-        'Whether publish should run prepublish script specified in --prepublish-script before publishing',
-      default: true,
-      boolean: true,
-    })
-    .option('prepublish-script', {
-      description: 'The npm script that will be run before publishing the app',
-      default: 'prepublishOnly',
-    })
+    // .option('prepublish', {
+    //   description:
+    //     'Whether publish should run prepublish script specified in --prepublish-script before publishing',
+    //   default: true,
+    //   boolean: true,
+    // })
+    // .option('prepublish-script', {
+    //   description: 'The npm script that will be run before publishing the app',
+    //   default: 'prepublishOnly',
+    // })
     .option('bump', {
       description:
         'Type of bump (major, minor or patch) or version number to publish the app',
@@ -174,6 +175,14 @@ exports.builder = function(yargs) {
       description: 'A path pointing to an existing Aragon client installation',
       default: null,
     })
+
+  addOption(cmd, options.FILES)
+  addOption(cmd, options.BUILD)
+  addOption(cmd, options.BUILD_SCRIPT)
+  addOption(cmd, options.PREPUBLISH)
+  addOption(cmd, options.PREPUBLISH_SCRIPT)
+
+  return cmd
 }
 
 exports.handler = async function({

--- a/packages/aragon-cli/src/helpers/options.js
+++ b/packages/aragon-cli/src/helpers/options.js
@@ -1,0 +1,56 @@
+const options = {
+  BUILD: {
+    name: 'build',
+    data: {
+      description:
+        'Whether publish should try to build the app before publishing, running the script specified in --build-script',
+      default: true,
+      boolean: true,
+    },
+  },
+  BUILD_SCRIPT: {
+    name: 'build-script',
+    data: {
+      description: 'The npm script that will be run when building the app',
+      default: 'build',
+    },
+  },
+  PREPUBLISH: {
+    name: 'prepublish',
+    data: {
+      description:
+        'Whether publish should run prepublish script specified in --prepublish-script before publishing',
+      default: true,
+      boolean: true,
+    },
+  },
+  PREPUBLISH_SCRIPT: {
+    name: 'prepublish-script',
+    data: {
+      description: 'The npm script that will be run before publishing the app',
+      default: 'prepublishOnly',
+    },
+  },
+  FILES: {
+    name: 'files',
+    data: {
+      description:
+        'Path(s) to directories containing files to publish. Specify multiple times to include multiple files.',
+      default: ['.'],
+      array: true,
+    },
+  },
+}
+
+const addOption = (command, option) => {
+  if (!option) {
+    throw new Error('Unrecognized option')
+  }
+
+  command.option(option.name, option.data)
+}
+
+module.exports = {
+  options,
+  addOption,
+}

--- a/packages/aragon-cli/src/helpers/options.js
+++ b/packages/aragon-cli/src/helpers/options.js
@@ -40,14 +40,53 @@ const options = {
       array: true,
     },
   },
+  BUMP: {
+    name: 'bump',
+    data: {
+      description:
+        'Type of bump (major, minor or patch) or version number to publish the app',
+      type: 'string',
+      default: 'major',
+    },
+  },
+  PUBLISH_DIR: {
+    name: 'publish-dir',
+    data: {
+      description:
+        'Temporary directory where files will be copied before publishing. Defaults to temp dir.',
+      default: null,
+    },
+  },
+  HTTP: {
+    name: 'http',
+    data: {
+      description: 'URL for where your app is served from e.g. localhost:1234',
+      default: null,
+      coerce: url => {
+        return url && url.substr(0, 7) !== 'http://' ? `http://${url}` : url
+      },
+    },
+  },
+  HTTP_SERVED_FROM: {
+    name: 'http-served-from',
+    data: {
+      description:
+        'Directory where your files is being served from e.g. ./dist',
+      default: null,
+    },
+  },
 }
 
-const addOption = (command, option) => {
+const addOption = (command, option, isPositional = false) => {
   if (!option) {
     throw new Error('Unrecognized option')
   }
 
-  command.option(option.name, option.data)
+  if (isPositional) {
+    command.positional(option.name, option.data)
+  } else {
+    command.option(option.name, option.data)
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
WIP

Fix #282

This PR is not just going to fix the issue mentioned, but do a general sanitation of the usage of options in the CLI. There is a lot of duplicate options being declared, so first we need to remove those duplicates. Once that is done, we can begin moving out options out of cli.js and set them specifically in commands.