### PR TITLE
Fix deploy command ctx properties typo

### DIFF
--- a/packages/aragon-cli/src/commands/deploy.js
+++ b/packages/aragon-cli/src/commands/deploy.js
@@ -109,6 +109,7 @@ exports.task = async ({
             throw new Error('Contract deployment failed')
           }
 
+          ctx.contractName = contractName
           ctx.contractAddress = address
           ctx.transactionHash = transactionHash
         },
@@ -155,7 +156,7 @@ exports.handler = async ({
 
   reporter.success(
     `Successfully deployed ${chalk.blue(ctx.contractName)} at: ${chalk.green(
-      ctx.contract
+      ctx.contractAddress
     )}`
   )
   reporter.info(`Transaction hash: ${chalk.blue(ctx.transactionHash)}`)


### PR DESCRIPTION
# 🦅 Pull Request

Fixes an error introduced in PR https://github.com/aragon/aragon-cli/pull/865 as part of the https://github.com/aragon/aragon-cli/issues/858 task.

Fix ctx properties names typo for:
 - contractName
 - contractAddress

which produce the unwanted final log:
```
lion@lion$ node ../../aragon-cli/packages/aragon-cli/dist/cli.js deploy
  ✔ Compile contracts
  ✔ Deploy 'CounterApp' to network
  ✔ Generate deployment artifacts
✔ Successfully deployed undefined at: undefined
ℹ Transaction hash: 0x20a1e9a02a498ed992f7645b374ba3b9f9b59f79f68cf51a2597469ae878d58b
```

## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->
```
node ./aragon-cli/packages/aragon-cli/dist/cli.js deploy
```


