### PR TITLE
Extract logic from dao install command

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -1,5 +1,4 @@
 const execTask = require('./utils/execHandler').task
-const { resolveEnsDomain } = require('../../helpers/aragonjs-wrapper')
 const TaskList = require('listr')
 const daoArg = require('./utils/daoArg')
 const { ensureWeb3 } = require('../../helpers/web3-fallback')
@@ -21,6 +20,7 @@ const {
   getAppProxyAddressFromReceipt,
   getAppBase,
 } = require('../../lib/dao/kernel')
+const { resolveAddressOrEnsDomain } = require('../../lib/dao/utils')
 
 exports.command = 'install <dao> <apmRepo> [apmRepoVersion]'
 
@@ -66,13 +66,7 @@ exports.task = async ({
   const apm = await APM(web3, apmOptions)
 
   apmRepo = defaultAPMName(apmRepo)
-
-  dao = /0x[a-fA-F0-9]{40}/.test(dao)
-    ? dao
-    : await resolveEnsDomain(dao, {
-        provider: web3.currentProvider,
-        registryAddress: apmOptions.ensRegistryAddress,
-      })
+  dao = await resolveAddressOrEnsDomain(dao, web3, apmOptions['ens-registry'])
 
   const tasks = new TaskList(
     [

--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -46,22 +46,23 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.task = async ({
-  wsProvider,
-  web3,
+exports.handler = async function({
   reporter,
   dao,
   gasPrice,
   network,
-  apmOptions,
+  apm: apmOptions,
   apmRepo,
   apmRepoVersion,
   appInit,
   appInitArgs,
   setPermissions,
+  wsProvider,
   silent,
   debug,
-}) => {
+}) {
+  const web3 = await ensureWeb3(network)
+
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
   const apm = await APM(web3, apmOptions)
 
@@ -189,43 +190,7 @@ exports.task = async ({
     listrOpts(silent, debug)
   )
 
-  return tasks
-}
-
-exports.handler = async function({
-  reporter,
-  dao,
-  gasPrice,
-  network,
-  apm: apmOptions,
-  apmRepo,
-  apmRepoVersion,
-  appInit,
-  appInitArgs,
-  setPermissions,
-  wsProvider,
-  silent,
-  debug,
-}) {
-  const web3 = await ensureWeb3(network)
-  const task = await exports.task({
-    web3,
-    reporter,
-    dao,
-    gasPrice,
-    network,
-    apmOptions,
-    apmRepo,
-    apmRepoVersion,
-    appInit,
-    appInitArgs,
-    setPermissions,
-    wsProvider,
-    silent,
-    debug,
-  })
-
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     reporter.info(
       `Successfully executed: "${chalk.blue(
         ctx.transactionPath[0].description

--- a/packages/aragon-cli/src/lib/dao/kernel.js
+++ b/packages/aragon-cli/src/lib/dao/kernel.js
@@ -1,0 +1,69 @@
+const web3EthAbi = require('web3-eth-abi')
+const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
+const { addressesEqual } = require('../../util')
+
+const newAppProxyLogName = 'NewAppProxy'
+const newAppProxyLogAbi = kernelAbi.find(
+  ({ type, name }) => type === 'event' && name === newAppProxyLogName
+)
+// This check is run outside the function body so it can be catched
+// on every any run when it happens, instead on a specific function call
+if (!newAppProxyLogAbi) {
+  throw new Error(`aragonCLI is out of sync with aragon/os, please report this issue:
+Kernel ABI does not include expected log '${newAppProxyLogName}'`)
+}
+
+/**
+ * Returns aclAddress for a DAO
+ *
+ * @param {string} dao DAO address
+ * @param {Object} web3 Web3 initialized object
+ * @return {Promise<string>} aclAddress
+ */
+async function getAclAddress(dao, web3) {
+  const daoInstance = new web3.eth.Contract(kernelAbi, dao)
+  return daoInstance.methods.acl().call()
+}
+
+/**
+ * Returns new app proxy contract address
+ *
+ * @param {string} dao DAO address
+ * @param {Object} receipt Web3 receipt object
+ * @return {string|undefined} app proxy contract address
+ */
+function getAppProxyAddressFromReceipt(dao, receipt) {
+  const logTopic = web3EthAbi.encodeEventSignature(newAppProxyLogAbi)
+
+  const deployLog = receipt.logs.find(({ topics, address }) => {
+    return topics[0] === logTopic && addressesEqual(dao, address)
+  })
+
+  if (!deployLog) return
+
+  const log = web3EthAbi.decodeLog(newAppProxyLogAbi.inputs, deployLog.data)
+  if (!log.proxy)
+    throw new Error(`aragonCLI is out of sync with aragon/os, please report this issue:
+Kernel ABI log ${newAppProxyLogName} does not have expected argument 'log'`)
+  return log.proxy
+}
+
+/**
+ * Returns the current app base address for an appId
+ *
+ * @param {string} dao DAO address
+ * @param {string} appId APP id to get the base of
+ * @param {Object} web3 Web3 initialized object
+ * @return {Promise<string>} currentBaseAddress
+ */
+async function getAppBase(dao, appId, web3) {
+  const kernel = new web3.eth.Contract(kernelAbi, dao)
+  const basesNamespace = await kernel.methods.APP_BASES_NAMESPACE().call()
+  return kernel.methods.getApp(basesNamespace, appId).call()
+}
+
+module.exports = {
+  getAclAddress,
+  getAppProxyAddressFromReceipt,
+  getAppBase,
+}

--- a/packages/aragon-cli/src/lib/dao/utils.js
+++ b/packages/aragon-cli/src/lib/dao/utils.js
@@ -1,0 +1,21 @@
+const web3Utils = require('web3-utils')
+const { resolveEnsDomain } = require('../../helpers/aragonjs-wrapper')
+
+/**
+ * Returns aclAddress for a DAO
+ *
+ * @param {string} dao DAO address or ENS domain
+ * @param {Object} web3 Web3 initialized object
+ * @param {string} ensRegistryAddress ENS registry address
+ * @return {Promise<string>} aclAddress
+ */
+async function resolveAddressOrEnsDomain(dao, web3, registryAddress) {
+  return web3Utils.isAddress(dao)
+    ? dao
+    : resolveEnsDomain(dao, {
+        provider: web3.currentProvider,
+        registryAddress,
+      })
+}
+
+module.exports = { resolveAddressOrEnsDomain }

--- a/packages/aragon-cli/test/lib/dao/kernel.test.js
+++ b/packages/aragon-cli/test/lib/dao/kernel.test.js
@@ -1,0 +1,57 @@
+import test from 'ava'
+import { getAppProxyAddressFromReceipt } from '../../../src/lib/dao/kernel'
+
+test('getAppProxyAddressFromReceipt', t => {
+  /**
+   * Sample receipt got from a console.log() in
+   *
+   *   packages/aragon-cli/src/commands/dao_cmds/install.js: 'Fetching deployed app' task
+   *
+   * After running
+   *
+   *  aragon dao install 0x6A84F290D9CCC3dFe8784bD4DD8ebbf69168D058 vault --debug
+   *
+   */
+  const dao = '0x6A84F290D9CCC3dFe8784bD4DD8ebbf69168D058'
+  const sampleReceipt = {
+    transactionHash:
+      '0xc92b673122081c519825bd2110b673e291a6649af4bcad9f667971a12637d7fc',
+    transactionIndex: 0,
+    blockHash:
+      '0x9edf4a589095bd7af855436dfdc47ba6d4b827d87e0f2523d0216effa9809fab',
+    blockNumber: 94,
+    from: '0xb4124ceb3451635dacedd11767f004d8a28c6ee7',
+    to: '0x6a84f290d9ccc3dfe8784bd4dd8ebbf69168d058',
+    gasUsed: 372564,
+    cumulativeGasUsed: 372564,
+    contractAddress: null,
+    logs: [
+      {
+        logIndex: 0,
+        transactionIndex: 0,
+        transactionHash:
+          '0xc92b673122081c519825bd2110b673e291a6649af4bcad9f667971a12637d7fc',
+        blockHash:
+          '0x9edf4a589095bd7af855436dfdc47ba6d4b827d87e0f2523d0216effa9809fab',
+        blockNumber: 94,
+        address: '0x6A84F290D9CCC3dFe8784bD4DD8ebbf69168D058',
+        data:
+          '0x000000000000000000000000b1abaadbbe50d99c5cdf6f2a3a3bbf6a900c278500000000000000000000000000000000000000000000000000000000000000017e852e0fcfce6551c13800f1e7476f982525c2b5277ba14b24339c68416336d1',
+        topics: [
+          '0xd880e726dced8808d727f02dd0e6fdd3a945b24bfee77e13367bcbe61ddbaf47',
+        ],
+        type: 'mined',
+        id: 'log_94de402a',
+      },
+    ],
+    status: true,
+    logsBloom:
+      '0x00000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000',
+    v: '0x1c',
+    r: '0x54a1cf5ec0e6444d2986c8eb270100af6fe122dbe604da31914c686715a97754',
+    s: '0x2cc8fb50eeb41374f93b05a19dd65b2d136d97a715ec1d18ea91cbe8b95f74de',
+  }
+
+  const appAddress = getAppProxyAddressFromReceipt(dao, sampleReceipt)
+  t.is(appAddress, '0xb1abaADBBe50d99C5CdF6F2A3a3BBf6a900C2785')
+})


### PR DESCRIPTION
Subtask of https://github.com/aragon/aragon-cli/pull/874

This PR extracts part of the logic of the command, only that that is extractable without modifying code which is shared by other commands. To fully refactor this command there will have to be coordination with other top-level commands so it's best to leave it for the next iteration.

Three new functions are added to `/lib`
- `getAclAddress`: simple web3 wrapper
- `getBasesNamespace`: simple web3 wrapper
- `getAppBase`: simple web3 wrapper
- `getAppProxyAddressFromReceipt`: pure function, tested. This function's logic was mildly refactored to prevent using custom ABI parsing logic that is included in `web3`. The change is covered and verified by a test.

The code in `exports.task` is merged into `exports.handler` to make it explicit that this task is not used by any other module.