### PR TITLE
WIP Syntax changes to boost code coverage

### DIFF
--- a/packages/aragon-cli/src/cli.js
+++ b/packages/aragon-cli/src/cli.js
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 import 'source-map-support/register'
-const Web3 = require('web3')
+import Web3 from 'web3'
+import { configCliMiddleware } from './middleware'
+import { findProjectRoot } from './util'
+import { ens } from '@aragon/aragen'
+import ConsoleReporter from '@aragon/cli-utils/src/reporters/ConsoleReporter'
+import url from 'url'
 
 const DEFAULT_GAS_PRICE = require('../package.json').aragon.defaultGasPrice
-
-const { configCliMiddleware } = require('./middleware')
-const { findProjectRoot } = require('./util')
-const { ens } = require('@aragon/aragen')
-const ConsoleReporter = require('@aragon/cli-utils/src/reporters/ConsoleReporter')
-const url = require('url')
 
 const reporter = new ConsoleReporter()
 

--- a/packages/aragon-cli/src/commands/apm.js
+++ b/packages/aragon-cli/src/commands/apm.js
@@ -1,10 +1,8 @@
-exports.command = 'apm <command>'
+export const command = 'apm <command>'
+export const describe = 'Publish and manage your aragonPM package'
+export const aliases = ['package']
 
-exports.describe = 'Publish and manage your aragonPM package'
-
-exports.aliases = ['package']
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs
     .commandDir('apm_cmds')
     .demandCommand(1, 'You need to specify a command')

--- a/packages/aragon-cli/src/commands/apm_cmds/grant.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/grant.js
@@ -1,12 +1,12 @@
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const chalk = require('chalk')
-const grantNewVersionsPermission = require('../../lib/apm/grantNewVersionsPermission')
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import chalk from 'chalk'
+import grantNewVersionsPermission from '../../lib/apm/grantNewVersionsPermission'
 
-exports.command = 'grant [grantees..]'
-exports.describe =
+export const command = 'grant [grantees..]'
+export const describe =
   'Grant an address permission to create new versions in this package'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs.positional('grantees', {
     description:
       'The address being granted the permission to publish to the repo',
@@ -15,7 +15,7 @@ exports.builder = function(yargs) {
   })
 }
 
-exports.handler = async function({
+export const handler = async function({
   // Globals
   reporter,
   gasPrice,

--- a/packages/aragon-cli/src/commands/apm_cmds/info.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/info.js
@@ -1,13 +1,12 @@
-const chalk = require('chalk')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const getApmRepo = require('../../lib/apm/getApmRepo')
+import chalk from 'chalk'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import getApmRepo from '../../lib/apm/getApmRepo'
 
-exports.command = 'info <apmRepo> [apmRepoVersion]'
+export const command = 'info <apmRepo> [apmRepoVersion]'
+export const describe = 'Get information about a package'
 
-exports.describe = 'Get information about a package'
-
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .option('apmRepo', {
       describe: 'Name of the aragonPM repo',
@@ -18,7 +17,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.handler = async function({
+export const handler = async function({
   apmRepo,
   apmRepoVersion,
   apm: apmOptions,

--- a/packages/aragon-cli/src/commands/apm_cmds/packages.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/packages.js
@@ -1,13 +1,12 @@
-const Table = require('cli-table')
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const getApmRegistryPackages = require('../../lib/apm/getApmRegistryPackages')
+import Table from 'cli-table'
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import getApmRegistryPackages from '../../lib/apm/getApmRegistryPackages'
 
-exports.command = 'packages [apmRegistry]'
+export const command = 'packages [apmRegistry]'
+export const describe = 'List all packages in the registry'
 
-exports.describe = 'List all packages in the registry'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs.option('apmRegistry', {
     description: 'The registry to inspect',
     type: 'string',
@@ -15,7 +14,11 @@ exports.builder = function(yargs) {
   })
 }
 
-exports.handler = async function({ apmRegistry, network, apm: apmOptions }) {
+export const handler = async function({
+  apmRegistry,
+  network,
+  apm: apmOptions,
+}) {
   const web3 = await ensureWeb3(network)
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
   let packages

--- a/packages/aragon-cli/src/commands/apm_cmds/publish.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/publish.js
@@ -1,29 +1,27 @@
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const tmp = require('tmp-promise')
-const path = require('path')
-const { readJson, writeJson, pathExistsSync } = require('fs-extra')
-const APM = require('@aragon/apm')
-const semver = require('semver')
-const TaskList = require('listr')
-const taskInput = require('listr-input')
-const inquirer = require('inquirer')
-const chalk = require('chalk')
-const { findProjectRoot, runScriptTask, ZERO_ADDRESS } = require('../../util')
-const { compileContracts } = require('../../helpers/truffle-runner')
-const web3Utils = require('web3').utils
-const deploy = require('../deploy')
-const startIPFS = require('../ipfs_cmds/start')
-const propagateIPFS = require('../ipfs_cmds/propagate')
-const execTask = require('../dao_cmds/utils/execHandler').task
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-
-const {
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import tmp from 'tmp-promise'
+import path from 'path'
+import { readJson, writeJson, pathExistsSync } from 'fs-extra'
+import APM from '@aragon/apm'
+import semver from 'semver'
+import TaskList from 'listr'
+import taskInput from 'listr-input'
+import inquirer from 'inquirer'
+import chalk from 'chalk'
+import { findProjectRoot, runScriptTask, ZERO_ADDRESS } from '../../util'
+import { compileContracts } from '../../helpers/truffle-runner'
+import { utils as web3Utils } from 'web3'
+import deploy from '../deploy'
+import startIPFS from '../ipfs_cmds/start'
+import propagateIPFS from '../ipfs_cmds/propagate'
+import { task as execTask } from '../dao_cmds/utils/execHandler'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import {
   prepareFilesForPublishing,
   MANIFEST_FILE,
   ARTIFACT_FILE,
-} = require('./util/preprare-files')
-
-const {
+} from './util/preprare-files'
+import {
   getMajor,
   sanityCheck,
   generateApplicationArtifact,
@@ -32,13 +30,12 @@ const {
   SOLIDITY_FILE,
   POSITIVE_ANSWERS,
   ANSWERS,
-} = require('./util/generate-artifact')
+} from './util/generate-artifact'
 
-exports.command = 'publish <bump> [contract]'
+export const command = 'publish <bump> [contract]'
+export const describe = 'Publish a new version of the application'
 
-exports.describe = 'Publish a new version of the application'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return deploy
     .builder(yargs) // inherit deploy options
     .positional('bump', {
@@ -140,7 +137,7 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.runSetupTask = ({
+export const runSetupTask = ({
   reporter,
 
   // Globals
@@ -311,7 +308,7 @@ exports.runSetupTask = ({
   )
 }
 
-exports.runPrepareForPublishTask = ({
+export const runPrepareForPublishTask = ({
   reporter,
 
   // Globals
@@ -515,7 +512,7 @@ exports.runPrepareForPublishTask = ({
   )
 }
 
-exports.runPublishTask = ({
+export const runPublishTask = ({
   reporter,
 
   // Globals
@@ -564,7 +561,7 @@ exports.runPublishTask = ({
   )
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
 
   // Globals
@@ -608,58 +605,54 @@ exports.handler = async function({
     version,
     contract: contractAddress,
     deployArtifacts,
-  } = await exports
-    .runSetupTask({
-      reporter,
-      gasPrice,
-      cwd,
-      web3,
-      network,
-      module,
-      apm: apmOptions,
-      silent,
-      debug,
-      prepublish,
-      prepublishScript,
-      build,
-      buildScript,
-      bump,
-      contract,
-      init,
-      reuse,
-      onlyContent,
-      onlyArtifacts,
-      ipfsCheck,
-      http,
-    })
-    .run()
+  } = await runSetupTask({
+    reporter,
+    gasPrice,
+    cwd,
+    web3,
+    network,
+    module,
+    apm: apmOptions,
+    silent,
+    debug,
+    prepublish,
+    prepublishScript,
+    build,
+    buildScript,
+    bump,
+    contract,
+    init,
+    reuse,
+    onlyContent,
+    onlyArtifacts,
+    ipfsCheck,
+    http,
+  }).run()
 
-  const { pathToPublish, intent } = await exports
-    .runPrepareForPublishTask({
-      reporter,
-      cwd,
-      web3,
-      network,
-      module,
-      apm: apmOptions,
-      silent,
-      debug,
-      publishDir,
-      files,
-      ignore,
-      httpServedFrom,
-      provider,
-      onlyArtifacts,
-      onlyContent,
-      http,
-      // context
-      initialRepo,
-      initialVersion,
-      version,
-      contractAddress,
-      deployArtifacts,
-    })
-    .run()
+  const { pathToPublish, intent } = await runPrepareForPublishTask({
+    reporter,
+    cwd,
+    web3,
+    network,
+    module,
+    apm: apmOptions,
+    silent,
+    debug,
+    publishDir,
+    files,
+    ignore,
+    httpServedFrom,
+    provider,
+    onlyArtifacts,
+    onlyContent,
+    http,
+    // context
+    initialRepo,
+    initialVersion,
+    version,
+    contractAddress,
+    deployArtifacts,
+  }).run()
 
   // Output publish info
 
@@ -714,25 +707,23 @@ exports.handler = async function({
     if (!confirmation) process.exit()
   }
 
-  const { receipt, transactionPath } = await exports
-    .runPublishTask({
-      reporter,
-      gasPrice,
-      web3,
-      wsProvider,
-      module,
-      apm: apmOptions,
-      silent,
-      debug,
-      onlyArtifacts,
-      onlyContent,
-      // context
-      dao,
-      proxyAddress,
-      methodName,
-      params,
-    })
-    .run()
+  const { receipt, transactionPath } = await runPublishTask({
+    reporter,
+    gasPrice,
+    web3,
+    wsProvider,
+    module,
+    apm: apmOptions,
+    silent,
+    debug,
+    onlyArtifacts,
+    onlyContent,
+    // context
+    dao,
+    proxyAddress,
+    methodName,
+    params,
+  }).run()
 
   const { transactionHash, status } = receipt
 

--- a/packages/aragon-cli/src/commands/apm_cmds/util/generate-artifact.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/util/generate-artifact.js
@@ -1,21 +1,21 @@
-const fs = require('fs')
-const path = require('path')
-const { readJson, writeJson } = require('fs-extra')
-const flattenCode = require('../../../helpers/flattenCode')
-const extract = require('../../../helpers/solidity-extractor')
-const namehash = require('eth-ens-namehash')
-const taskInput = require('listr-input')
-const { keccak256 } = require('web3').utils
+import fs from 'fs'
+import path from 'path'
+import { readJson, writeJson } from 'fs-extra'
+import flattenCode from '../../../helpers/flattenCode'
+import extract from '../../../helpers/solidity-extractor'
+import namehash from 'eth-ens-namehash'
+import taskInput from 'listr-input'
+import { keccak256 } from 'web3-utils'
+import { ARTIFACT_FILE } from './preprare-files'
 
-const { ARTIFACT_FILE } = require('./preprare-files')
-const SOLIDITY_FILE = 'code.sol'
+export const SOLIDITY_FILE = 'code.sol'
 const ARAPP_FILE = 'arapp.json'
 
-const POSITIVE_ANSWERS = ['yes', 'y']
-const NEGATIVE_ANSWERS = ['no', 'n', 'abort', 'a']
-const ANSWERS = POSITIVE_ANSWERS.concat(NEGATIVE_ANSWERS)
+export const POSITIVE_ANSWERS = ['yes', 'y']
+export const NEGATIVE_ANSWERS = ['no', 'n', 'abort', 'a']
+export const ANSWERS = POSITIVE_ANSWERS.concat(NEGATIVE_ANSWERS)
 
-const getMajor = version => version.split('.')[0]
+export const getMajor = version => version.split('.')[0]
 
 const getRoles = roles =>
   roles.map(role => Object.assign(role, { bytes: keccak256(role.id) }))
@@ -96,7 +96,7 @@ async function deprecatedFunctions(apm, artifact, web3, reporter) {
   return deprecatedFunctions
 }
 
-async function generateApplicationArtifact(
+export async function generateApplicationArtifact(
   cwd,
   apm,
   outputPath,
@@ -153,13 +153,13 @@ async function generateApplicationArtifact(
   return artifact
 }
 
-async function generateFlattenedCode(dir, sourcePath) {
+export async function generateFlattenedCode(dir, sourcePath) {
   const flattenedCode = await flattenCode([sourcePath])
   fs.writeFileSync(path.resolve(dir, SOLIDITY_FILE), flattenedCode)
 }
 
 // Sanity check artifact.json
-async function sanityCheck(cwd, newRoles, newContractPath, oldArtifact) {
+export async function sanityCheck(cwd, newRoles, newContractPath, oldArtifact) {
   const { roles, environments, abi, path } = oldArtifact
 
   const newContractRoles = await getRoles(newRoles)
@@ -174,7 +174,7 @@ async function sanityCheck(cwd, newRoles, newContractPath, oldArtifact) {
   )
 }
 
-async function copyCurrentApplicationArtifacts(
+export async function copyCurrentApplicationArtifacts(
   cwd,
   outputPath,
   apm,
@@ -235,16 +235,4 @@ async function copyCurrentApplicationArtifacts(
   copyArray.forEach(({ fileName, filePath, fileContent }) =>
     fs.writeFileSync(filePath, fileContent)
   )
-}
-
-module.exports = {
-  POSITIVE_ANSWERS,
-  NEGATIVE_ANSWERS,
-  ANSWERS,
-  SOLIDITY_FILE,
-  getMajor,
-  generateApplicationArtifact,
-  generateFlattenedCode,
-  sanityCheck,
-  copyCurrentApplicationArtifacts,
 }

--- a/packages/aragon-cli/src/commands/apm_cmds/util/preprare-files.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/util/preprare-files.js
@@ -1,12 +1,12 @@
-const path = require('path')
-const ignore = require('ignore')
-const fs = require('fs')
-const { findProjectRoot } = require('../../../util')
-const { copy, pathExistsSync } = require('fs-extra')
-const { promisify } = require('util')
+import path from 'path'
+import ignore from 'ignore'
+import fs from 'fs'
+import { findProjectRoot } from '../../../util'
+import { copy, pathExistsSync } from 'fs-extra'
+import { promisify } from 'util'
 
-const MANIFEST_FILE = 'manifest.json'
-const ARTIFACT_FILE = 'artifact.json'
+export const MANIFEST_FILE = 'manifest.json'
+export const ARTIFACT_FILE = 'artifact.json'
 
 /**
  * Moves the specified files to a temporary directory and returns the path to
@@ -16,7 +16,7 @@ const ARTIFACT_FILE = 'artifact.json'
  * @param {string} ignorePatterns An array of glob-like pattern of files to ignore
  * @return {string} The path to the temporary directory
  */
-async function prepareFilesForPublishing(
+export async function prepareFilesForPublishing(
   tmpDir,
   files = [],
   ignorePatterns = null
@@ -79,5 +79,3 @@ async function prepareFilesForPublishing(
 
   return tmpDir
 }
-
-module.exports = { MANIFEST_FILE, ARTIFACT_FILE, prepareFilesForPublishing }

--- a/packages/aragon-cli/src/commands/apm_cmds/version.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/version.js
@@ -1,12 +1,11 @@
-const fs = require('fs')
-const findUp = require('find-up')
-const semver = require('semver')
+import fs from 'fs'
+import findUp from 'find-up'
+import semver from 'semver'
 
-exports.command = 'version [bump]'
+export const command = 'version [bump]'
+export const describe = '(deprecated) Bump the application version'
 
-exports.describe = '(deprecated) Bump the application version'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs.positional('bump', {
     description: 'Type of bump (major, minor or patch) or version number',
     type: 'string',
@@ -15,7 +14,7 @@ exports.builder = function(yargs) {
 }
 
 // TODO: Fix always default bump when network is not development
-exports.handler = async function({ reporter, bump, cwd }) {
+export const handler = async function({ reporter, bump, cwd }) {
   const manifestLocation = await findUp('arapp.json', { cwd })
 
   const manifest = JSON.parse(fs.readFileSync(manifestLocation))

--- a/packages/aragon-cli/src/commands/apm_cmds/versions.js
+++ b/packages/aragon-cli/src/commands/apm_cmds/versions.js
@@ -1,15 +1,14 @@
-const chalk = require('chalk')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const TaskList = require('listr')
-const getApmRepoVersions = require('../../lib/apm/getApmRepoVersions')
+import chalk from 'chalk'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import TaskList from 'listr'
+import getApmRepoVersions from '../../lib/apm/getApmRepoVersions'
 
-exports.command = 'versions [apmRepo]'
-
-exports.describe =
+export const command = 'versions [apmRepo]'
+export const describe =
   'Shows all the previously published versions of a given repository'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs.option('apmRepo', {
     description: 'Name of the APM repository',
     type: 'string',
@@ -17,7 +16,7 @@ exports.builder = function(yargs) {
   })
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   apmRepo,
   module,

--- a/packages/aragon-cli/src/commands/contracts.js
+++ b/packages/aragon-cli/src/commands/contracts.js
@@ -1,10 +1,9 @@
-const { runTruffle } = require('../helpers/truffle-runner')
+import { runTruffle } from '../helpers/truffle-runner'
 
-exports.command = 'contracts'
+export const command = 'contracts'
+export const describe = 'Execute any Truffle command with arguments'
 
-exports.describe = 'Execute any Truffle command with arguments'
-
-exports.handler = async function({ reporter, cwd }) {
+export const handler = async function({ reporter, cwd }) {
   const truffleArgs = process.argv.slice(
     process.argv.indexOf('contracts') + 1,
     process.argv.length

--- a/packages/aragon-cli/src/commands/dao.js
+++ b/packages/aragon-cli/src/commands/dao.js
@@ -1,10 +1,9 @@
-const daoArg = require('./dao_cmds/utils/daoArg')
+import daoArg from './dao_cmds/utils/daoArg'
 
-exports.command = 'dao <command>'
+export const command = 'dao <command>'
+export const describe = 'Manage your Aragon DAO'
 
-exports.describe = 'Manage your Aragon DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   if (
     process.argv[3] !== 'new' &&
     process.argv[3] !== 'act' &&

--- a/packages/aragon-cli/src/commands/dao_cmds/acl.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl.js
@@ -1,12 +1,11 @@
-const viewCommand = require('./acl_cmds/view')
+import viewCommand from './acl_cmds/view'
 
-exports.command = 'acl <dao>'
-
-exports.describe =
+export const command = 'acl <dao>'
+export const describe =
   'View and manage your DAO permissions. Shortcut for aragon dao acl view <dao>'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs.commandDir('acl_cmds')
 }
 
-exports.handler = viewCommand.handler
+export const handler = viewCommand.handler

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/create.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/create.js
@@ -1,18 +1,18 @@
-const daoArg = require('../utils/daoArg')
-const aclExecHandler = require('./utils/aclExecHandler')
+import daoArg from '../utils/daoArg'
+import aclExecHandler from './utils/aclExecHandler'
 
 // Note: we usually order these values as entity, proxy, role but this order fits
 //       better with other CLI commands
-exports.command = 'create <dao> <app> <role> <entity> <manager>'
+export const command = 'create <dao> <app> <role> <entity> <manager>'
 
-exports.describe =
+export const describe =
   "Create a permission in a DAO (only usable for permissions that haven't been set)"
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   network,
   gasPrice,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/grant.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/grant.js
@@ -1,22 +1,22 @@
-const daoArg = require('../utils/daoArg')
-const aclExecHandler = require('./utils/aclExecHandler')
-const { convertStringToParam, encodeParam } = require('./utils/params')
+import daoArg from '../utils/daoArg'
+import aclExecHandler from './utils/aclExecHandler'
+import { convertStringToParam, encodeParam } from './utils/params'
 
 // Note: we usually order these values as entity, proxy, role but this order fits
 //       better with other CLI commands
-exports.command = 'grant <dao> <app> <role> <entity> [params...]'
+export const command = 'grant <dao> <app> <role> <entity> [params...]'
 
-exports.describe =
+export const describe =
   'Grant a permission in a DAO (only permission manager can do it)'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs).positional('params', {
     description: 'ACL parameters',
     default: [],
   })
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   app,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/remove-manager.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/remove-manager.js
@@ -1,18 +1,18 @@
-const daoArg = require('../utils/daoArg')
-const aclExecHandler = require('./utils/aclExecHandler')
+import daoArg from '../utils/daoArg'
+import aclExecHandler from './utils/aclExecHandler'
 
 // Note: we usually order these values as entity, proxy, role but this order fits
 //       better with other CLI commands
-exports.command = 'remove-manager <dao> <app> <role>'
+export const command = 'remove-manager <dao> <app> <role>'
 
-exports.describe =
+export const describe =
   'Remove permission manager for a permission (can be recreated)'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   app,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/revoke.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/revoke.js
@@ -1,17 +1,17 @@
-const daoArg = require('../utils/daoArg')
-const aclExecHandler = require('./utils/aclExecHandler')
+import daoArg from '../utils/daoArg'
+import aclExecHandler from './utils/aclExecHandler'
 
 // Note: we usually order these values as entity, proxy, role but this order fits
 //       better with other CLI commands
-exports.command = 'revoke <dao> <app> <role> <entity>'
+export const command = 'revoke <dao> <app> <role> <entity>'
 
-exports.describe = 'Revoke a permission in a DAO'
+export const describe = 'Revoke a permission in a DAO'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   app,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/set-manager.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/set-manager.js
@@ -1,18 +1,18 @@
-const daoArg = require('../utils/daoArg')
-const aclExecHandler = require('./utils/aclExecHandler')
+import daoArg from '../utils/daoArg'
+import aclExecHandler from './utils/aclExecHandler'
 
 // Note: we usually order these values as entity, proxy, role but this order fits
 //       better with other CLI commands
-exports.command = 'set-manager <dao> <app> <role> <new-manager>'
+export const command = 'set-manager <dao> <app> <role> <new-manager>'
 
-exports.describe =
+export const describe =
   'Set the permission manager for a permission (only the current permission manager can do it)'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   app,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/aclExecHandler.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/aclExecHandler.js
@@ -1,8 +1,8 @@
-const execHandler = require('../../utils/execHandler').handler
-const { keccak256 } = require('web3').utils
-const { ensureWeb3 } = require('../../../../helpers/web3-fallback')
+import { handler as execHandler } from '../../utils/execHandler'
+import { keccak256 } from 'web3-utils'
+import { ensureWeb3 } from '../../../../helpers/web3-fallback'
 
-module.exports = async function(
+export default async function(
   dao,
   method,
   params,

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/knownRoles.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/knownRoles.js
@@ -1,6 +1,6 @@
-const { keccak256 } = require('web3').utils
-const { keyBy } = require('lodash')
-const defaultAppsRoles = require('../../../../knownRoles.json')
+import { keccak256 } from 'web3-utils'
+import { keyBy } from 'lodash'
+import defaultAppsRoles from '../../../../knownRoles.json'
 
 /**
  * Returns this app roles and default known roles
@@ -9,11 +9,9 @@ const defaultAppsRoles = require('../../../../knownRoles.json')
  * @param {ArappConfig} module arapp.json contents
  * @return {Object.<string, RoleDefinition>} Unique known roles
  */
-const getKnownRoles = module => {
+export const getKnownRoles = module => {
   const currentAppRoles = module ? module.roles : []
   const allRoles = defaultAppsRoles.concat(currentAppRoles)
 
   return keyBy(allRoles, role => keccak256(role.id))
 }
-
-module.exports = { getKnownRoles }

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/params.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/utils/params.js
@@ -1,5 +1,5 @@
-const { isString } = require('lodash')
-const BN = require('bn.js')
+import { isString } from 'lodash'
+import BN from 'bn.js'
 
 /**
  * @typedef {Object} AclParam ACL parameter
@@ -12,7 +12,7 @@ const BN = require('bn.js')
  * ACL operators. See https://hack.aragon.org/docs/aragonos-ref#parameter-interpretation
  * for more information.
  */
-const Op = {
+export const Op = {
   NONE: '0',
   EQ: '1',
   NEQ: '2',
@@ -47,7 +47,7 @@ const ArgumentIds = {
  * @param {string} str String param
  * @returns {AclParam} Param object
  */
-function convertStringToParam(str) {
+export function convertStringToParam(str) {
   try {
     // Remove square brackets, quotes and spaces
     const cleanStr = str
@@ -76,7 +76,7 @@ function convertStringToParam(str) {
  * @param {AclParam} param ACL Parameter
  * @returns {string} Encoded param
  */
-function encodeParam(param) {
+export function encodeParam(param) {
   const encodedParam = new BN(param.id)
     .shln(248)
     .or(new BN(param.op).shln(240))
@@ -152,5 +152,3 @@ function parseNumber(number) {
     ? new BN(number.substr(2), 16)
     : new BN(number)
 }
-
-module.exports = { encodeParam, convertStringToParam, Op }

--- a/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/view.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/acl_cmds/view.js
@@ -1,24 +1,23 @@
-const chalk = require('chalk')
-const TaskList = require('listr')
-const daoArg = require('../utils/daoArg')
-const { listApps } = require('../utils/knownApps')
-const { getKnownRoles } = require('./utils/knownRoles')
-const { ensureWeb3 } = require('../../../helpers/web3-fallback')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const Table = require('cli-table')
-const { getDaoAddressPermissionsApps } = require('../../../lib/acl/view')
-const { formatAclPermissions } = require('../../../lib/acl/viewFormatter')
-require('../../../lib/acl/typedef') // Load JSDoc types ACL specific
-require('../../../lib/typedef') // Load JSDoc generic types
+import chalk from 'chalk'
+import TaskList from 'listr'
+import daoArg from '../utils/daoArg'
+import { listApps } from '../utils/knownApps'
+import { getKnownRoles } from './utils/knownRoles'
+import { ensureWeb3 } from '../../../helpers/web3-fallback'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import Table from 'cli-table'
+import { getDaoAddressPermissionsApps } from '../../../lib/acl/view'
+import { formatAclPermissions } from '../../../lib/acl/viewFormatter'
+import '../../../lib/acl/typedef' // Load JSDoc types ACL specific
+import '../../../lib/typedef'
+import { NO_MANAGER, ZERO_ADDRESS } from '../../../util' // Load JSDoc generic types
 
 const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
-const { NO_MANAGER, ZERO_ADDRESS } = require('../../../util')
 
-exports.command = 'view <dao>'
+export const command = 'view <dao>'
+export const describe = 'Inspect permissions in a DAO'
 
-exports.describe = 'Inspect permissions in a DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
 }
 
@@ -35,7 +34,7 @@ exports.builder = function(yargs) {
  * @param  {boolean} args.debug Debug flag
  * @return {Promise<TaskList>} void, will process.exit(0) if successful
  */
-const handler = async function({
+export const handler = async function({
   dao,
   network,
   apm,
@@ -143,12 +142,6 @@ const handler = async function({
     process.exit(0) // force exit, as aragonjs hangs
   })
 }
-
-// Exporting afterwards to solve documentation lint error:
-// ✖ documentation lint found some errors. Please fix them and try committing again.
-// ... /aragon-cli/src/commands/dao_cmds/acl_cmds/view.js
-// 39:1  warning  @memberof reference to view not found
-exports.handler = handler
 
 /**
  * Helper to short hex string for better readability

--- a/packages/aragon-cli/src/commands/dao_cmds/act.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/act.js
@@ -1,16 +1,15 @@
-const web3 = require('web3')
-const execHandler = require('./utils/execHandler').handler
-const getAppKernel = require('./utils/app-kernel')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const { parseArgumentStringIfPossible, ZERO_ADDRESS } = require('../../util')
+import web3 from 'web3'
+import { handler as execHandler } from './utils/execHandler'
+import getAppKernel from './utils/app-kernel'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import { parseArgumentStringIfPossible, ZERO_ADDRESS } from '../../util'
 
 const EXECUTE_FUNCTION_NAME = 'execute'
 
-exports.command = 'act <agent-address> <target> <signature> [call-args..]'
+export const command = 'act <agent-address> <target> <signature> [call-args..]'
+export const describe = 'Executes an action from the Agent app'
 
-exports.describe = 'Executes an action from the Agent app'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs
     .positional('agent-address', {
       description: 'Address of the Agent app proxy',
@@ -52,7 +51,7 @@ const encodeCalldata = (signature, params) => {
   return `${sigBytes}${paramBytes.slice(2)}`
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   apm,
   network,

--- a/packages/aragon-cli/src/commands/dao_cmds/apps.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/apps.js
@@ -1,21 +1,20 @@
 import { initAragonJS, getApps } from '../../helpers/aragonjs-wrapper'
-const TaskList = require('listr')
-const chalk = require('chalk')
-const daoArg = require('./utils/daoArg')
-const { listApps } = require('./utils/knownApps')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const { addressesEqual } = require('../../util')
-const Table = require('cli-table')
-const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
+import TaskList from 'listr'
+import chalk from 'chalk'
+import daoArg from './utils/daoArg'
+import { listApps } from './utils/knownApps'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import { addressesEqual } from '../../util'
+import Table from 'cli-table'
+import { abi as kernelAbi } from '@aragon/os/build/contracts/Kernel'
 
 let knownApps
 
-exports.command = 'apps <dao>'
+export const command = 'apps <dao>'
+export const describe = 'Get all the apps in a DAO'
 
-exports.describe = 'Get all the apps in a DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs).option('all', {
     description: 'Whether to include apps without permissions as well',
     boolean: true,
@@ -38,7 +37,7 @@ const printContent = content => {
   return `${content.provider}:${content.location}`
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   all,

--- a/packages/aragon-cli/src/commands/dao_cmds/exec.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/exec.js
@@ -1,12 +1,11 @@
-const execHandler = require('./utils/execHandler').handler
-const daoArg = require('./utils/daoArg')
-const { parseArgumentStringIfPossible } = require('../../util')
+import { handler as execHandler } from './utils/execHandler'
+import daoArg from './utils/daoArg'
+import { parseArgumentStringIfPossible } from '../../util'
 
-exports.command = 'exec <dao> <proxy-address> <fn> [fn-args..]'
+export const command = 'exec <dao> <proxy-address> <fn> [fn-args..]'
+export const describe = 'Executes a call in an app of a DAO'
 
-exports.describe = 'Executes a call in an app of a DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return daoArg(yargs)
     .positional('proxy-address', {
       description: 'Proxy address of the app with the function to be run',
@@ -21,7 +20,7 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   apm,

--- a/packages/aragon-cli/src/commands/dao_cmds/id-assign.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/id-assign.js
@@ -1,8 +1,8 @@
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const { green } = require('chalk')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const { isIdAssigned, assignId } = require('../../lib/dao/assign-id')
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import { green } from 'chalk'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import { isIdAssigned, assignId } from '../../lib/dao/assign-id'
 
 // dao id assign command
 const idAssignCommand = 'assign <dao> <aragon-id>'
@@ -20,10 +20,11 @@ const idAssignBuilder = yargs => {
 }
 
 // dao id shortcut
-exports.command = 'id <dao> <aragon-id>'
-exports.describe = 'Shortcut for `dao id assign`'
+export const command = 'id <dao> <aragon-id>'
 
-exports.builder = yargs => {
+export const describe = 'Shortcut for `dao id assign`'
+
+export const builder = yargs => {
   return idAssignBuilder(yargs).command(
     idAssignCommand,
     idAssignDescribe,
@@ -32,7 +33,7 @@ exports.builder = yargs => {
   )
 }
 
-exports.handler = async function({
+export const handler = async function({
   aragonId,
   reporter,
   network,

--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -1,28 +1,27 @@
-const execTask = require('./utils/execHandler').task
-const { resolveEnsDomain } = require('../../helpers/aragonjs-wrapper')
-const TaskList = require('listr')
-const daoArg = require('./utils/daoArg')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const APM = require('@aragon/apm')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const chalk = require('chalk')
-const startIPFS = require('../ipfs_cmds/start')
-const getRepoTask = require('./utils/getRepoTask')
-const encodeInitPayload = require('./utils/encodeInitPayload')
-const {
+import { task as execTask } from './utils/execHandler'
+import { resolveEnsDomain } from '../../helpers/aragonjs-wrapper'
+import TaskList from 'listr'
+import daoArg from './utils/daoArg'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import APM from '@aragon/apm'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import chalk from 'chalk'
+import startIPFS from '../ipfs_cmds/start'
+import getRepoTask from './utils/getRepoTask'
+import encodeInitPayload from './utils/encodeInitPayload'
+import {
   addressesEqual,
   ANY_ENTITY,
   NO_MANAGER,
   ZERO_ADDRESS,
-} = require('../../util')
-const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
+} from '../../util'
+import { abi as kernelAbi } from '@aragon/os/build/contracts/Kernel'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
 
-exports.command = 'install <dao> <apmRepo> [apmRepoVersion]'
+export const command = 'install <dao> <apmRepo> [apmRepoVersion]'
+export const describe = 'Install an app into a DAO'
 
-exports.describe = 'Install an app into a DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return getRepoTask
     .args(daoArg(yargs))
     .option('app-init', {
@@ -42,7 +41,7 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.task = async ({
+export const task = async ({
   wsProvider,
   web3,
   reporter,
@@ -221,7 +220,7 @@ exports.task = async ({
   return tasks
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   gasPrice,
@@ -237,7 +236,7 @@ exports.handler = async function({
   debug,
 }) {
   const web3 = await ensureWeb3(network)
-  const task = await exports.task({
+  const tasks = await task({
     web3,
     reporter,
     dao,
@@ -254,7 +253,7 @@ exports.handler = async function({
     debug,
   })
 
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     reporter.info(
       `Successfully executed: "${chalk.blue(
         ctx.transactionPath[0].description

--- a/packages/aragon-cli/src/commands/dao_cmds/new.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/new.js
@@ -1,35 +1,34 @@
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const APM = require('@aragon/apm')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const { green, bold } = require('chalk')
-const getRepoTask = require('./utils/getRepoTask')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const startIPFS = require('../ipfs_cmds/start')
-const {
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import APM from '@aragon/apm'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import { green, bold } from 'chalk'
+import getRepoTask from './utils/getRepoTask'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import startIPFS from '../ipfs_cmds/start'
+import {
   getRecommendedGasLimit,
   parseArgumentStringIfPossible,
-} = require('../../util')
-const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
-const assignIdTask = require('./id-assign').task
-
-exports.BARE_TEMPLATE = defaultAPMName('bare-template')
-exports.BARE_INSTANCE_FUNCTION = 'newInstance'
-exports.BARE_TEMPLATE_DEPLOY_EVENT = 'DeployDao'
-
-exports.OLD_BARE_TEMPLATE = defaultAPMName('bare-kit')
-exports.OLD_BARE_INSTANCE_FUNCTION = 'newBareInstance'
-exports.OLD_BARE_TEMPLATE_DEPLOY_EVENT = 'DeployInstance'
+} from '../../util'
+import { abi as kernelAbi } from '@aragon/os/build/contracts/Kernel'
+import { task as assignIdTask } from './id-assign'
 
 // TODO: Remove old template once is no longer supported
-const BARE_TEMPLATE_ABI = require('./utils/bare-template-abi')
-const OLD_BARE_TEMPLATE_ABI = require('./utils/old-bare-template-abi')
+import BARE_TEMPLATE_ABI from './utils/bare-template-abi'
 
-exports.command = 'new [template] [template-version]'
+import OLD_BARE_TEMPLATE_ABI from './utils/old-bare-template-abi'
 
-exports.describe = 'Create a new DAO'
+export const BARE_TEMPLATE = defaultAPMName('bare-template')
+export const BARE_INSTANCE_FUNCTION = 'newInstance'
+export const BARE_TEMPLATE_DEPLOY_EVENT = 'DeployDao'
+export const OLD_BARE_TEMPLATE = defaultAPMName('bare-kit')
+export const OLD_BARE_INSTANCE_FUNCTION = 'newBareInstance'
+export const OLD_BARE_TEMPLATE_DEPLOY_EVENT = 'DeployInstance'
 
-exports.builder = yargs => {
+export const command = 'new [template] [template-version]'
+export const describe = 'Create a new DAO'
+
+export const builder = yargs => {
   return yargs
     .positional('kit', {
       description: 'Name of the kit to use creating the DAO',
@@ -73,7 +72,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async ({
+export const task = async ({
   web3,
   reporter,
   gasPrice,
@@ -193,7 +192,7 @@ exports.task = async ({
   return tasks
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   network,
   kit,
@@ -214,7 +213,7 @@ exports.handler = async function({
   template = kit || template
   templateVersion = kitVersion || templateVersion
 
-  const task = await exports.task({
+  const tasks = await task({
     web3,
     reporter,
     network,
@@ -229,7 +228,7 @@ exports.handler = async function({
     silent,
     debug,
   })
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     if (aragonId) {
       reporter.success(
         `Created DAO: ${green(ctx.domain)} at ${green(ctx.daoAddress)}`

--- a/packages/aragon-cli/src/commands/dao_cmds/token.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/token.js
@@ -1,8 +1,7 @@
-exports.command = 'token <command>'
+export const command = 'token <command>'
+export const describe = 'Create and interact with MiniMe tokens'
 
-exports.describe = 'Create and interact with MiniMe tokens'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs
     .commandDir('token_cmds')
     .demandCommand(1, 'You need to specify a command')

--- a/packages/aragon-cli/src/commands/dao_cmds/token_cmds/change-controller.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/token_cmds/change-controller.js
@@ -1,15 +1,13 @@
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../../helpers/web3-fallback')
-const { getContract } = require('../../../util')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const chalk = require('chalk')
-const { getRecommendedGasLimit } = require('../../../util')
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../../helpers/web3-fallback'
+import { getContract, getRecommendedGasLimit } from '../../../util'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import chalk from 'chalk'
 
-exports.command = 'change-controller <token-address> <new-controller>'
+export const command = 'change-controller <token-address> <new-controller>'
+export const describe = 'Change the controller of a MiniMe token'
 
-exports.describe = 'Change the controller of a MiniMe token'
-
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .positional('token-address', {
       description: 'Address of the MiniMe token',
@@ -19,7 +17,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async ({
+export const task = async ({
   web3,
   gasPrice,
   tokenAddress,
@@ -67,7 +65,7 @@ exports.task = async ({
   )
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   gasPrice,
   network,
@@ -78,7 +76,7 @@ exports.handler = async function({
 }) {
   const web3 = await ensureWeb3(network)
 
-  const task = await exports.task({
+  const tasks = await task({
     web3,
     gasPrice,
     reporter,
@@ -87,7 +85,7 @@ exports.handler = async function({
     silent,
     debug,
   })
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     reporter.success(
       `Successfully changed the controller of ${chalk.green(
         tokenAddress

--- a/packages/aragon-cli/src/commands/dao_cmds/token_cmds/new.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/token_cmds/new.js
@@ -1,25 +1,21 @@
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../../helpers/web3-fallback')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const chalk = require('chalk')
-const web3Utils = require('web3').utils
-const { parseArgumentStringIfPossible } = require('../../../util')
-const {
-  deployMiniMeTokenFactory,
-  deployMiniMeToken,
-} = require('../../../lib/token')
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../../helpers/web3-fallback'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import chalk from 'chalk'
+import { utils as web3Utils } from 'web3'
+import { parseArgumentStringIfPossible } from '../../../util'
+import { deployMiniMeTokenFactory, deployMiniMeToken } from '../../../lib/token'
 
 const MAINNET_MINIME_TOKEN_FACTORY =
   '0xA29EF584c389c67178aE9152aC9C543f9156E2B3'
 const RINKEBY_MINIME_TOKEN_FACTORY =
   '0xad991658443c56b3dE2D7d7f5d8C68F339aEef29'
 
-exports.command =
+export const command =
   'new <token-name> <symbol> [decimal-units] [transfer-enabled] [token-factory-address]'
+export const describe = 'Create a new MiniMe token'
 
-exports.describe = 'Create a new MiniMe token'
-
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .positional('token-name', {
       description: 'Full name of the new Token',
@@ -41,7 +37,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async ({
+export const task = async ({
   web3,
   gasPrice,
   tokenName,
@@ -133,7 +129,7 @@ exports.task = async ({
   )
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   network,
   gasPrice,
@@ -147,7 +143,7 @@ exports.handler = async function({
 }) {
   const web3 = await ensureWeb3(network)
 
-  const task = await exports.task({
+  const tasks = await task({
     web3,
     gasPrice,
     tokenName,
@@ -158,7 +154,7 @@ exports.handler = async function({
     silent,
     debug,
   })
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     reporter.success(
       `Successfully deployed the token at ${chalk.green(ctx.tokenAddress)}`
     )

--- a/packages/aragon-cli/src/commands/dao_cmds/upgrade.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/upgrade.js
@@ -1,25 +1,24 @@
-const execTask = require('./utils/execHandler').task
-const { resolveEnsDomain } = require('../../helpers/aragonjs-wrapper')
-const TaskList = require('listr')
-const daoArg = require('./utils/daoArg')
-const { ensureWeb3 } = require('../../helpers/web3-fallback')
-const APM = require('@aragon/apm')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const chalk = require('chalk')
-const startIPFS = require('../ipfs_cmds/start')
-const getRepoTask = require('./utils/getRepoTask')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
+import { task as execTask } from './utils/execHandler'
+import { resolveEnsDomain } from '../../helpers/aragonjs-wrapper'
+import TaskList from 'listr'
+import daoArg from './utils/daoArg'
+import { ensureWeb3 } from '../../helpers/web3-fallback'
+import APM from '@aragon/apm'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import chalk from 'chalk'
+import startIPFS from '../ipfs_cmds/start'
+import getRepoTask from './utils/getRepoTask'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import { abi as kernelAbi } from '@aragon/os/build/contracts/Kernel'
 
-exports.command = 'upgrade <dao> <apmRepo> [apmRepoVersion]'
+export const command = 'upgrade <dao> <apmRepo> [apmRepoVersion]'
+export const describe = 'Upgrade an app into a DAO'
 
-exports.describe = 'Upgrade an app into a DAO'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return getRepoTask.args(daoArg(yargs))
 }
 
-exports.task = async ({
+export const task = async ({
   wsProvider,
   web3,
   reporter,
@@ -86,7 +85,7 @@ exports.task = async ({
   return tasks
 }
 
-exports.handler = async function({
+export const handler = async function({
   reporter,
   dao,
   gasPrice,
@@ -101,7 +100,7 @@ exports.handler = async function({
   const web3 = await ensureWeb3(network)
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
 
-  const task = await exports.task({
+  const tasks = await task({
     web3,
     reporter,
     dao,
@@ -115,7 +114,7 @@ exports.handler = async function({
     debug,
   })
 
-  return task.run().then(ctx => {
+  return tasks.run().then(ctx => {
     reporter.success(
       `Successfully executed: "${chalk.blue(
         ctx.transactionPath[0].description

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/app-kernel.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/app-kernel.js
@@ -1,6 +1,6 @@
-const aragonAppAbi = require('@aragon/os/build/contracts/AragonApp').abi
+import { abi as aragonAppAbi } from '@aragon/os/build/contracts/AragonApp'
 
-module.exports = (web3, appAddress) => {
+export default (web3, appAddress) => {
   const app = new web3.eth.Contract(aragonAppAbi, appAddress)
   return app.methods.kernel().call()
 }

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/bare-template-abi.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/bare-template-abi.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     inputs: [
       {

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/daoArg.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/daoArg.js
@@ -1,7 +1,7 @@
 const isAddress = addr => /0x[a-fA-F0-9]{40}/.test(addr)
 const isValidAragonID = dao => /[a-z0-9]+\.eth/.test(dao)
 
-module.exports = yargs => {
+export default yargs => {
   return yargs.positional('dao', {
     description: 'Address of the Kernel or AragonID',
     type: 'string',

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/encodeInitPayload.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/encodeInitPayload.js
@@ -1,4 +1,4 @@
-module.exports = (web3, abi, initFunctionName, initArgs) => {
+export default (web3, abi, initFunctionName, initArgs) => {
   const methodABI = abi.find(method => method.name === initFunctionName)
 
   if (!methodABI) {

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/execHandler.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/execHandler.js
@@ -2,11 +2,11 @@ import {
   initAragonJS,
   getTransactionPath,
 } from '../../../helpers/aragonjs-wrapper'
-const chalk = require('chalk')
-const startIPFS = require('../../ipfs_cmds/start')
-const TaskList = require('listr')
-const { ensureWeb3 } = require('../../../helpers/web3-fallback')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
+import chalk from 'chalk'
+import startIPFS from '../../ipfs_cmds/start'
+import TaskList from 'listr'
+import { ensureWeb3 } from '../../../helpers/web3-fallback'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
 
 /**
  * Return a task list for executing a method on a
@@ -27,7 +27,7 @@ const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
  * @param {boolean} params.debug Debug mode
  * @returns {Promise<TaskList>} Execution task list
  */
-async function task({
+export async function task({
   dao,
   app,
   method,
@@ -113,7 +113,7 @@ async function task({
  * @param {boolean} args.debug Debug mode
  * @returns {Promise} Execution promise
  */
-async function handler(args) {
+export async function handler(args) {
   args = {
     ...args,
     web3: await ensureWeb3(args.network),
@@ -129,9 +129,4 @@ async function handler(args) {
     )
     process.exit()
   })
-}
-
-module.exports = {
-  handler,
-  task,
 }

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/getRepoTask.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/getRepoTask.js
@@ -1,43 +1,43 @@
-const pkg = require('../../../../package.json')
+import pkg from '../../../../package.json'
+
 const LATEST_VERSION = 'latest'
 const DEFAULT_IPFS_TIMEOUT = pkg.aragon.defaultIpfsTimeout
 
-module.exports = {
-  args: yargs => {
-    return yargs
-      .option('apmRepo', {
-        describe: 'Name of the aragonPM repo',
-      })
-      .option('apmRepoVersion', {
-        describe: 'Version of the package upgrading to',
-        default: 'latest',
-      })
-  },
-  task: ({
-    apm,
-    apmRepo,
-    apmRepoVersion = LATEST_VERSION,
-    artifactRequired = true,
-  }) => {
-    return async ctx => {
-      if (apmRepoVersion === LATEST_VERSION) {
-        ctx.repo = await apm.getLatestVersion(apmRepo, DEFAULT_IPFS_TIMEOUT)
-      } else {
-        ctx.repo = await apm.getVersion(
-          apmRepo,
-          apmRepoVersion.split('.'),
-          DEFAULT_IPFS_TIMEOUT
-        )
-      }
+export const args = yargs => {
+  return yargs
+    .option('apmRepo', {
+      describe: 'Name of the aragonPM repo',
+    })
+    .option('apmRepoVersion', {
+      describe: 'Version of the package upgrading to',
+      default: 'latest',
+    })
+}
 
-      // appId is loaded from artifact.json in IPFS
-      if (artifactRequired && !ctx.repo.appId) {
-        // TODO: load ipfs aragon node and fetch repo again. If this time we have the artifact then return otherwise throw Error.
-
-        throw new Error(
-          'Cannot find artifacts in aragonPM repo. Please make sure the package is published and IPFS or your HTTP server running.'
-        )
-      }
+export const task = ({
+  apm,
+  apmRepo,
+  apmRepoVersion = LATEST_VERSION,
+  artifactRequired = true,
+}) => {
+  return async ctx => {
+    if (apmRepoVersion === LATEST_VERSION) {
+      ctx.repo = await apm.getLatestVersion(apmRepo, DEFAULT_IPFS_TIMEOUT)
+    } else {
+      ctx.repo = await apm.getVersion(
+        apmRepo,
+        apmRepoVersion.split('.'),
+        DEFAULT_IPFS_TIMEOUT
+      )
     }
-  },
+
+    // appId is loaded from artifact.json in IPFS
+    if (artifactRequired && !ctx.repo.appId) {
+      // TODO: load ipfs aragon node and fetch repo again. If this time we have the artifact then return otherwise throw Error.
+
+      throw new Error(
+        'Cannot find artifacts in aragonPM repo. Please make sure the package is published and IPFS or your HTTP server running.'
+      )
+    }
+  }
 }

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/knownApps.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/knownApps.js
@@ -1,5 +1,5 @@
-const namehash = require('eth-ens-namehash').hash
-const { keccak256 } = require('web3').utils
+import { hash as namehash } from 'eth-ens-namehash'
+import { keccak256 } from 'web3-utils'
 
 const knownAppNames = [
   'voting',
@@ -19,7 +19,7 @@ const knownAppNames = [
 
 const knownAPMRegistries = ['aragonpm.eth', 'open.aragonpm.eth']
 
-const listApps = (userApps = []) => {
+export const listApps = (userApps = []) => {
   const appNames = knownAppNames
     .reduce(
       (acc, appName) =>
@@ -39,5 +39,3 @@ const listApps = (userApps = []) => {
     appIds
   )
 }
-
-module.exports = { listApps }

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/old-bare-template-abi.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/old-bare-template-abi.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     constant: true,
     inputs: [],

--- a/packages/aragon-cli/src/commands/deploy.js
+++ b/packages/aragon-cli/src/commands/deploy.js
@@ -1,19 +1,17 @@
-const path = require('path')
-const TaskList = require('listr')
-const chalk = require('chalk')
+import path from 'path'
+import TaskList from 'listr'
+import chalk from 'chalk'
+import { compileContracts } from '../helpers/truffle-runner'
+import { findProjectRoot } from '../util'
+import { ensureWeb3 } from '../helpers/web3-fallback'
+import deployArtifacts from '../helpers/truffle-deploy-artifacts'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import { linkLibraries, deployContract } from '../lib/deploy'
 
-const { compileContracts } = require('../helpers/truffle-runner')
-const { findProjectRoot } = require('../util')
-const { ensureWeb3 } = require('../helpers/web3-fallback')
-const deployArtifacts = require('../helpers/truffle-deploy-artifacts')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const { linkLibraries, deployContract } = require('../lib/deploy')
+export const command = 'deploy [contract]'
+export const describe = 'Deploys contract code of the app to the chain'
 
-exports.command = 'deploy [contract]'
-
-exports.describe = 'Deploys contract code of the app to the chain'
-
-exports.arappContract = () => {
+export const arappContract = () => {
   const contractPath = require(path.resolve(findProjectRoot(), 'arapp.json'))
     .path
   const contractName = path.basename(contractPath).split('.')[0]
@@ -21,7 +19,7 @@ exports.arappContract = () => {
   return contractName
 }
 
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .positional('contract', {
       description:
@@ -34,7 +32,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async ({
+export const task = async ({
   module,
   network,
   gasPrice,
@@ -47,7 +45,7 @@ exports.task = async ({
   debug,
 }) => {
   if (!contract) {
-    contract = exports.arappContract()
+    contract = arappContract()
   }
   apmOptions.ensRegistryAddress = apmOptions['ens-registry']
 
@@ -128,7 +126,7 @@ exports.task = async ({
   return tasks
 }
 
-exports.handler = async ({
+export const handler = async ({
   module,
   reporter,
   gasPrice,
@@ -140,7 +138,7 @@ exports.handler = async ({
   silent,
   debug,
 }) => {
-  const task = await exports.task({
+  const tasks = await task({
     module,
     reporter,
     gasPrice,
@@ -152,7 +150,7 @@ exports.handler = async ({
     silent,
     debug,
   })
-  const ctx = await task.run()
+  const ctx = await tasks.run()
 
   reporter.success(
     `Successfully deployed ${chalk.blue(ctx.contractName)} at: ${chalk.green(

--- a/packages/aragon-cli/src/commands/devchain.js
+++ b/packages/aragon-cli/src/commands/devchain.js
@@ -1,9 +1,9 @@
-const startCommand = require('./devchain_cmds/start')
+import startCommand from './devchain_cmds/start'
 
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return startCommand.builder(yargs).commandDir('devchain_cmds')
 }
 
-exports.command = 'devchain'
-exports.describe = 'Shortcut for `aragon devchain start`.'
-exports.handler = startCommand.handler
+export const command = 'devchain'
+export const describe = 'Shortcut for `aragon devchain start`.'
+export const handler = startCommand.handler

--- a/packages/aragon-cli/src/commands/devchain_cmds/start.js
+++ b/packages/aragon-cli/src/commands/devchain_cmds/start.js
@@ -1,3 +1,3 @@
-const { start } = require('@aragon/aragen').commands
+import { commands } from '@aragon/aragen'
 
-Object.assign(exports, start)
+Object.assign(exports, commands.start)

--- a/packages/aragon-cli/src/commands/devchain_cmds/status.js
+++ b/packages/aragon-cli/src/commands/devchain_cmds/status.js
@@ -1,3 +1,3 @@
-const { status } = require('@aragon/aragen').commands
+import { commands } from '@aragon/aragen'
 
-Object.assign(exports, status)
+Object.assign(exports, commands.status)

--- a/packages/aragon-cli/src/commands/extract-functions.js
+++ b/packages/aragon-cli/src/commands/extract-functions.js
@@ -1,13 +1,12 @@
-const path = require('path')
-const chalk = require('chalk')
-const extractContractInfoToFile = require('../lib/extractContractInfoToFile')
-const TaskList = require('listr')
+import path from 'path'
+import chalk from 'chalk'
+import extractContractInfoToFile from '../lib/extractContractInfoToFile'
+import TaskList from 'listr'
 
-exports.command = 'extract-functions [contract]'
+export const command = 'extract-functions [contract]'
+export const describe = 'Extract function information from a Solidity file'
 
-exports.describe = 'Extract function information from a Solidity file'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs
     .positional('contract', {
       description: 'Path to the Solidity file to extract functions from',
@@ -21,7 +20,7 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.handler = async function({ cwd, reporter, contract, output }) {
+export const handler = async function({ cwd, reporter, contract, output }) {
   let outputPath
 
   const tasks = new TaskList([

--- a/packages/aragon-cli/src/commands/init.js
+++ b/packages/aragon-cli/src/commands/init.js
@@ -1,17 +1,17 @@
 import { checkProjectExists, prepareTemplate } from '../lib/init'
-const { promisify } = require('util')
+import { promisify } from 'util'
+import TaskList from 'listr'
+import { installDeps, isValidAragonId } from '../util'
+import defaultAPMName from '@aragon/cli-utils/src/helpers/default-apm'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+
 const clone = promisify(require('git-clone'))
-const TaskList = require('listr')
-const { installDeps, isValidAragonId } = require('../util')
-const defaultAPMName = require('@aragon/cli-utils/src/helpers/default-apm')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
 
-exports.command = 'init <name> [template]'
-
-exports.describe =
+export const command = 'init <name> [template]'
+export const describe =
   '(deprecated) Initialise a new application. Deprecated in favor of `npx create-aragon-app <name> [template]`'
 
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .positional('name', {
       description: 'The application name (appname.aragonpm.eth)',
@@ -45,7 +45,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.handler = function({ reporter, name, template, silent, debug }) {
+export const handler = function({ reporter, name, template, silent, debug }) {
   name = defaultAPMName(name)
   const basename = name.split('.')[0]
 

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -1,42 +1,39 @@
-const TaskList = require('listr')
-const Web3 = require('web3')
-const chalk = require('chalk')
-const path = require('path')
-const devchain = require('./devchain_cmds/start')
-const start = require('./start')
-const deploy = require('./deploy')
-const newDAO = require('./dao_cmds/new')
-const startIPFS = require('./ipfs_cmds/start')
-const encodeInitPayload = require('./dao_cmds/utils/encodeInitPayload')
-const fs = require('fs-extra')
-const pkg = require('../../package.json')
-const listrOpts = require('@aragon/cli-utils/src/helpers/listr-options')
-const APM = require('@aragon/apm')
-const getRepoTask = require('./dao_cmds/utils/getRepoTask')
-
-const {
+import TaskList from 'listr'
+import Web3 from 'web3'
+import chalk from 'chalk'
+import path from 'path'
+import devchain from './devchain_cmds/start'
+import start from './start'
+import deploy from './deploy'
+import newDAO from './dao_cmds/new'
+import startIPFS from './ipfs_cmds/start'
+import encodeInitPayload from './dao_cmds/utils/encodeInitPayload'
+import fs from 'fs-extra'
+import pkg from '../../package.json'
+import listrOpts from '@aragon/cli-utils/src/helpers/listr-options'
+import APM from '@aragon/apm'
+import getRepoTask from './dao_cmds/utils/getRepoTask'
+import {
   runSetupTask,
   runPrepareForPublishTask,
   runPublishTask,
-} = require('./apm_cmds/publish')
-const {
+} from './apm_cmds/publish'
+import {
   findProjectRoot,
   isHttpServerOpen,
   isPortTaken,
   parseArgumentStringIfPossible,
-} = require('../util')
-
-const url = require('url')
+} from '../util'
+import url from 'url'
 
 const DEFAULT_CLIENT_REPO = pkg.aragon.clientRepo
 const DEFAULT_CLIENT_VERSION = pkg.aragon.clientVersion
 const DEFAULT_CLIENT_PORT = pkg.aragon.clientPort
 
-exports.command = 'run'
+export const command = 'run'
+export const describe = 'Run the current app locally'
 
-exports.describe = 'Run the current app locally'
-
-exports.builder = function(yargs) {
+export const builder = function(yargs) {
   return yargs
     .option('client', {
       description: 'Just run the smart contracts, without the Aragon client',
@@ -176,7 +173,7 @@ exports.builder = function(yargs) {
     })
 }
 
-exports.handler = async function({
+export const handler = async function({
   // Globals
   reporter,
   gasPrice,

--- a/packages/aragon-cli/src/commands/start.js
+++ b/packages/aragon-cli/src/commands/start.js
@@ -5,20 +5,19 @@ import {
   startClient,
   openClient,
 } from '../lib/start'
-const chalk = require('chalk')
-const TaskList = require('listr')
-const pkg = require('../../package.json')
-const { installDeps } = require('../util')
+import chalk from 'chalk'
+import TaskList from 'listr'
+import pkg from '../../package.json'
+import { installDeps } from '../util'
 
 const DEFAULT_CLIENT_REPO = pkg.aragon.clientRepo
 const DEFAULT_CLIENT_VERSION = pkg.aragon.clientVersion
 const DEFAULT_CLIENT_PORT = pkg.aragon.clientPort
 
-exports.command = 'start [client-repo] [client-version]'
+export const command = 'start [client-repo] [client-version]'
+export const describe = 'Start the Aragon GUI (graphical user interface)'
 
-exports.describe = 'Start the Aragon GUI (graphical user interface)'
-
-exports.builder = yargs => {
+export const builder = yargs => {
   return yargs
     .positional('client-repo', {
       description:
@@ -40,7 +39,7 @@ exports.builder = yargs => {
     })
 }
 
-exports.task = async function({
+export const task = async function({
   clientRepo,
   clientVersion,
   clientPort,
@@ -96,20 +95,20 @@ exports.task = async function({
   return tasks
 }
 
-exports.handler = async ({
+export const handler = async ({
   reporter,
   clientRepo,
   clientVersion,
   clientPort,
   clientPath,
 }) => {
-  const task = await exports.task({
+  const tasks = await task({
     clientRepo,
     clientVersion,
     clientPort,
     clientPath,
   })
-  return task
+  return tasks
     .run()
     .then(() =>
       reporter.info(

--- a/packages/aragon-cli/src/helpers/flattenCode.js
+++ b/packages/aragon-cli/src/helpers/flattenCode.js
@@ -1,6 +1,6 @@
-const flatten = require('truffle-flattener')
+import flatten from 'truffle-flattener'
 
-module.exports = async sourcePaths => {
+export default async sourcePaths => {
   try {
     return flatten(sourcePaths)
   } catch (error) {

--- a/packages/aragon-cli/src/helpers/solidity-extractor.js
+++ b/packages/aragon-cli/src/helpers/solidity-extractor.js
@@ -1,6 +1,7 @@
-const fs = require('fs')
-const { promisify } = require('util')
-const { keccak256 } = require('web3').utils
+import fs from 'fs'
+import { promisify } from 'util'
+import { keccak256 } from 'web3-utils'
+
 const readFile = promisify(fs.readFile)
 
 // See https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#types
@@ -158,4 +159,4 @@ const extractContractInfo = async sourceCodePath => {
   }
 }
 
-module.exports = extractContractInfo
+export default extractContractInfo

--- a/packages/aragon-cli/src/helpers/truffle-config.js
+++ b/packages/aragon-cli/src/helpers/truffle-config.js
@@ -1,7 +1,7 @@
-const fs = require('fs')
-const { findProjectRoot } = require('../util')
+import fs from 'fs'
+import { findProjectRoot } from '../util'
 
-const getTruffleConfig = () => {
+export const getTruffleConfig = () => {
   try {
     if (fs.existsSync(`${findProjectRoot()}/truffle.js`)) {
       const truffleConfig = require(`${findProjectRoot()}/truffle`)
@@ -20,5 +20,3 @@ const getTruffleConfig = () => {
 
   throw new Error(`Didn't find any truffle.js file`)
 }
-
-module.exports = { getTruffleConfig }

--- a/packages/aragon-cli/src/helpers/truffle-deploy-artifacts.js
+++ b/packages/aragon-cli/src/helpers/truffle-deploy-artifacts.js
@@ -1,7 +1,7 @@
-const flattenCode = require('../helpers/flattenCode')
-const { getTruffleConfig } = require('./truffle-config')
+import flattenCode from '../helpers/flattenCode'
+import { getTruffleConfig } from './truffle-config'
 
-module.exports = async contractArtifacts => {
+export default async contractArtifacts => {
   const {
     contractName,
     sourcePath,

--- a/packages/aragon-cli/src/helpers/truffle-runner.js
+++ b/packages/aragon-cli/src/helpers/truffle-runner.js
@@ -1,10 +1,10 @@
-const execa = require('execa')
-const devnull = require('dev-null')
-const { getBinary } = require('../util')
+import execa from 'execa'
+import devnull from 'dev-null'
+import { getBinary } from '../util'
 
 const truffleBin = getBinary('truffle')
 
-const runTruffle = (args, { stdout, stderr, stdin }) => {
+export const runTruffle = (args, { stdout, stderr, stdin }) => {
   return new Promise((resolve, reject) => {
     const truffle = execa(truffleBin, args)
     let errMsg = ''
@@ -21,7 +21,7 @@ const runTruffle = (args, { stdout, stderr, stdin }) => {
   })
 }
 
-const compileContracts = async () => {
+export const compileContracts = async () => {
   try {
     await runTruffle(['compile'], { stdout: devnull() })
   } catch (err) {
@@ -29,5 +29,3 @@ const compileContracts = async () => {
     process.exit(1)
   }
 }
-
-module.exports = { runTruffle, compileContracts }

--- a/packages/aragon-cli/src/helpers/web3-fallback.js
+++ b/packages/aragon-cli/src/helpers/web3-fallback.js
@@ -1,6 +1,6 @@
-const Web3 = require('web3')
+import Web3 from 'web3'
 
-const ensureWeb3 = async network => {
+export const ensureWeb3 = async network => {
   let web3
 
   try {
@@ -15,5 +15,3 @@ Make sure 'aragon devchain' is running or your provider settings are correct.
 For more info you can check the Truffle docs on network configuration: https://truffleframework.com/docs/truffle/reference/configuration#networks`)
   }
 }
-
-module.exports = { ensureWeb3 }

--- a/packages/aragon-cli/src/lib/acl/view.js
+++ b/packages/aragon-cli/src/lib/acl/view.js
@@ -18,7 +18,12 @@ import { initAragonJS, getApps } from '../../helpers/aragonjs-wrapper'
  * @param  {ApmConfig} args.apm APM config
  * @return {Promise<ReturnData>} void, will process.exit(0) if successful
  */
-const getDaoAddressPermissionsApps = ({ dao, web3Provider, ipfsConf, apm }) => {
+export const getDaoAddressPermissionsApps = ({
+  dao,
+  web3Provider,
+  ipfsConf,
+  apm,
+}) => {
   return new Promise((resolve, reject) => {
     /**
      * @type {AclPermissions}
@@ -60,8 +65,4 @@ const getDaoAddressPermissionsApps = ({ dao, web3Provider, ipfsConf, apm }) => {
         reject(err)
       })
   })
-}
-
-module.exports = {
-  getDaoAddressPermissionsApps,
 }

--- a/packages/aragon-cli/src/lib/acl/viewFormatter.js
+++ b/packages/aragon-cli/src/lib/acl/viewFormatter.js
@@ -5,7 +5,7 @@ import './typedef'
  * @param {AclPermissions} permissions Permissions
  * @return {AclPermission[]} acl permissions data
  */
-const flattenAclPermissions = permissions => {
+export const flattenAclPermissions = permissions => {
   const aclPermissions = []
   for (const [to, roles] of Object.entries(permissions)) {
     for (const [roleHash, data] of Object.entries(roles)) {
@@ -29,7 +29,12 @@ const flattenAclPermissions = permissions => {
  * @param {KnownRoles} knownRoles Known roles
  * @return {AclPermissionFormatted} with human readable names if any
  */
-const formatAclPermission = (aclPermission, apps, knownApps, knownRoles) => {
+export const formatAclPermission = (
+  aclPermission,
+  apps,
+  knownApps,
+  knownRoles
+) => {
   const {
     to: toAddress,
     role: roleHash,
@@ -73,14 +78,8 @@ const formatAclPermission = (aclPermission, apps, knownApps, knownRoles) => {
  * @param  {KnownRoles} knownRoles Known roles
  * @return {AclPermissionFormatted[]} Formated acl permissions data
  */
-function formatAclPermissions(permissions, apps, knownApps, knownRoles) {
+export function formatAclPermissions(permissions, apps, knownApps, knownRoles) {
   return flattenAclPermissions(permissions).map(aclPermission =>
     formatAclPermission(aclPermission, apps, knownApps, knownRoles)
   )
-}
-
-module.exports = {
-  flattenAclPermissions,
-  formatAclPermission,
-  formatAclPermissions,
 }

--- a/packages/aragon-cli/src/lib/apm/getApmRegistryPackages.js
+++ b/packages/aragon-cli/src/lib/apm/getApmRegistryPackages.js
@@ -1,4 +1,4 @@
-const APM = require('@aragon/apm')
+import APM from '@aragon/apm'
 
 /**
  * Return packages for a given APM registry.
@@ -12,7 +12,7 @@ const APM = require('@aragon/apm')
  * @param {function(number)} progressHandler Progress handler
  * @returns {void}
  */
-module.exports = async (
+export default async (
   web3,
   apmRegistryName,
   apmOptions,

--- a/packages/aragon-cli/src/lib/apm/getApmRepo.js
+++ b/packages/aragon-cli/src/lib/apm/getApmRepo.js
@@ -1,5 +1,5 @@
-const pkg = require('../../../package.json')
-const aragonPM = require('@aragon/apm')
+import pkg from '../../../package.json'
+import aragonPM from '@aragon/apm'
 
 const LATEST_VERSION = 'latest'
 const DEFAULT_IPFS_TIMEOUT = pkg.aragon.defaultIpfsTimeout
@@ -17,7 +17,7 @@ const DEFAULT_IPFS_TIMEOUT = pkg.aragon.defaultIpfsTimeout
  * @param {*} progressHandler todo
  * @returns {*} todo
  */
-module.exports = async (
+export default async (
   web3,
   apmRepoName,
   apmRepoVersion,

--- a/packages/aragon-cli/src/lib/apm/getApmRepoVersions.js
+++ b/packages/aragon-cli/src/lib/apm/getApmRepoVersions.js
@@ -1,6 +1,6 @@
-const APM = require('@aragon/apm')
+import APM from '@aragon/apm'
 
-module.exports = async (web3, apmRepoName, apmOptions) => {
+export default async (web3, apmRepoName, apmOptions) => {
   // Ensure the ens-registry property is present,
   // and available with the name "ensRegistryAddress".
   if (!apmOptions.ensRegistryAddress) {

--- a/packages/aragon-cli/src/lib/apm/grantNewVersionsPermission.js
+++ b/packages/aragon-cli/src/lib/apm/grantNewVersionsPermission.js
@@ -1,7 +1,7 @@
-const APM = require('@aragon/apm')
-const ACL = require('./util/acl')
+import APM from '@aragon/apm'
+import ACL from './util/acl'
 
-module.exports = async (
+export default async (
   web3,
   apmRepoName,
   apmOptions,

--- a/packages/aragon-cli/src/lib/apm/util/acl.js
+++ b/packages/aragon-cli/src/lib/apm/util/acl.js
@@ -1,10 +1,10 @@
-const { getRecommendedGasLimit } = require('../../../util')
-const aclAbi = require('@aragon/os/build/contracts/ACL').abi
-const aragonAppAbi = require('@aragon/os/build/contracts/AragonApp').abi
-const kernelAbi = require('@aragon/os/build/contracts/Kernel').abi
-const repoAbi = require('@aragon/os/build/contracts/Repo').abi
+import { getRecommendedGasLimit } from '../../../util'
+import { abi as aclAbi } from '@aragon/os/build/contracts/ACL'
+import { abi as aragonAppAbi } from '@aragon/os/build/contracts/AragonApp'
+import { abi as kernelAbi } from '@aragon/os/build/contracts/Kernel'
+import { abi as repoAbi } from '@aragon/os/build/contracts/Repo'
 
-module.exports = web3 => {
+export default web3 => {
   const getACL = async repoAddr => {
     const repo = new web3.eth.Contract(aragonAppAbi, repoAddr)
     const daoAddr = await repo.methods.kernel().call()

--- a/packages/aragon-cli/src/lib/configEnvironment.js
+++ b/packages/aragon-cli/src/lib/configEnvironment.js
@@ -1,8 +1,7 @@
-const Web3 = require('web3')
-const { merge } = require('lodash')
-
-const defaultEnvironments = require('../../config/environments.default')
-const defaultNetworks = require('../../config/truffle.default')
+import Web3 from 'web3'
+import { merge } from 'lodash'
+import defaultEnvironments from '../../config/environments.default'
+import defaultNetworks from '../../config/truffle.default'
 
 const FRAME_ENDPOINT = 'ws://localhost:1248'
 const FRAME_ORIGIN = 'aragonCLI'

--- a/packages/aragon-cli/src/lib/dao/assign-id.js
+++ b/packages/aragon-cli/src/lib/dao/assign-id.js
@@ -1,8 +1,8 @@
-const { convertDAOIdToSubdomain, ARAGON_DOMAIN } = require('../../util')
-const ENS = require('ethereum-ens')
-const ififsResolvingRegistrarAbi = require('@aragon/id/build/contracts/IFIFSResolvingRegistrar')
-  .abi
-const { sha3, isAddress } = require('web3').utils
+import { convertDAOIdToSubdomain, ARAGON_DOMAIN } from '../../util'
+import ENS from 'ethereum-ens'
+import { abi as ififsResolvingRegistrarAbi } from '@aragon/id/build/contracts/IFIFSResolvingRegistrar'
+import { isAddress, sha3 } from 'web3-utils'
+
 const REGISTRAR_GAS_LIMIT = '1000000'
 
 /**
@@ -16,7 +16,7 @@ const REGISTRAR_GAS_LIMIT = '1000000'
  * @param {string} options.gasPrice Gas price
  * @returns {void}
  */
-async function assignId(daoAddress, daoId, options) {
+export async function assignId(daoAddress, daoId, options) {
   const { web3, ensRegistry, gasPrice } = options
 
   if (!isAddress(daoAddress)) throw new Error(`Invalid address: ${daoAddress}`)
@@ -43,7 +43,7 @@ async function assignId(daoAddress, daoId, options) {
  * @param {string} options.ensRegistry ENS registry address
  * @returns {Promise<boolean>} true if already assigned
  */
-async function isIdAssigned(daoId, options) {
+export async function isIdAssigned(daoId, options) {
   const daoUrl = convertDAOIdToSubdomain(daoId)
   const ens = new ENS(options.web3.currentProvider, options.ensRegistry)
 
@@ -57,5 +57,3 @@ async function isIdAssigned(daoId, options) {
     return false
   }
 }
-
-module.exports = { isIdAssigned, assignId }

--- a/packages/aragon-cli/src/lib/deploy.js
+++ b/packages/aragon-cli/src/lib/deploy.js
@@ -1,4 +1,4 @@
-const { getRecommendedGasLimit, expandLink } = require('../util')
+import { getRecommendedGasLimit, expandLink } from '../util'
 
 /**
  * @typedef {Object} LibraryLink
@@ -13,7 +13,7 @@ const { getRecommendedGasLimit, expandLink } = require('../util')
  * @param  {LibraryLink[]} links Library links
  * @return {string} bytecode with replaced library addresses
  */
-const linkLibraries = (bytecode, links) => {
+export const linkLibraries = (bytecode, links) => {
   for (const link of links.map(expandLink)) {
     bytecode = bytecode.replace(link.regex, link.addressBytes)
     if (!bytecode.includes(link.addressBytes)) {
@@ -39,7 +39,7 @@ const linkLibraries = (bytecode, links) => {
  * @param  {Object} param.web3 Web3 initialized object
  * @return {Promise<DeployContractReturnData>} Tx hash and deployed contract address
  */
-const deployContract = async ({
+export const deployContract = async ({
   bytecode,
   abi,
   initArguments,
@@ -71,9 +71,4 @@ const deployContract = async ({
     transactionHash,
     address: instance.options.address,
   }
-}
-
-module.exports = {
-  linkLibraries,
-  deployContract,
 }

--- a/packages/aragon-cli/src/lib/extractContractInfoToFile.js
+++ b/packages/aragon-cli/src/lib/extractContractInfoToFile.js
@@ -1,7 +1,7 @@
-const extract = require('../helpers/solidity-extractor')
-const { writeJson } = require('fs-extra')
+import extract from '../helpers/solidity-extractor'
+import { writeJson } from 'fs-extra'
 
-module.exports = async (contractPath, outputPath) => {
+export default async (contractPath, outputPath) => {
   const contractInfo = await extract(contractPath)
 
   await writeJson(outputPath, contractInfo, { spaces: '\t' })

--- a/packages/aragon-cli/src/lib/loadConfigFiles.js
+++ b/packages/aragon-cli/src/lib/loadConfigFiles.js
@@ -1,8 +1,9 @@
-const path = require('path')
-const fs = require('fs-extra')
-const { findProjectRoot } = require('../util')
-const Ajv = require('ajv')
-const arappSchema = require('../../schemas/arapp.schema')
+import path from 'path'
+import fs from 'fs-extra'
+import { findProjectRoot } from '../util'
+import Ajv from 'ajv'
+import arappSchema from '../../schemas/arapp.schema'
+
 const ajv = new Ajv({ allErrors: true })
 
 /**

--- a/packages/aragon-cli/src/lib/start/download-client.js
+++ b/packages/aragon-cli/src/lib/start/download-client.js
@@ -2,8 +2,9 @@ import path from 'path'
 import { existsSync, ensureDirSync } from 'fs-extra'
 import os from 'os'
 import { promisify } from 'util'
+import pkg from '../../../package.json'
+
 const clone = promisify(require('git-clone'))
-const pkg = require('../../../package.json')
 
 export async function downloadClient({
   ctx,

--- a/packages/aragon-cli/src/middleware/index.js
+++ b/packages/aragon-cli/src/middleware/index.js
@@ -1,11 +1,11 @@
-const { getTruffleConfig } = require('../helpers/truffle-config')
-const { loadManifestFile, loadArappFile } = require('../lib/loadConfigFiles')
-const {
+import { getTruffleConfig } from '../helpers/truffle-config'
+import { loadManifestFile, loadArappFile } from '../lib/loadConfigFiles'
+import {
   configEnvironment,
   NoEnvironmentInArapp,
   NoEnvironmentInDefaults,
   NoNetworkInTruffleConfig,
-} = require('../lib/configEnvironment')
+} from '../lib/configEnvironment'
 
 class InvalidArguments extends Error {}
 

--- a/packages/aragon-cli/src/util.js
+++ b/packages/aragon-cli/src/util.js
@@ -1,20 +1,20 @@
-const findUp = require('find-up')
-const path = require('path')
-const execa = require('execa')
-const net = require('net')
-const fs = require('fs')
-const { readJson } = require('fs-extra')
-const which = require('which')
-const { request } = require('http')
-const inquirer = require('inquirer')
+import findUp from 'find-up'
+import path from 'path'
+import execa from 'execa'
+import net from 'net'
+import fs from 'fs'
+import { readJson } from 'fs-extra'
+import which from 'which'
+import { request } from 'http'
+import inquirer from 'inquirer'
 
 let cachedProjectRoot
 
 const PGK_MANAGER_BIN_NPM = 'npm'
-const debugLogger = process.env.DEBUG ? console.log : () => {}
+export const debugLogger = process.env.DEBUG ? console.log : () => {}
 
-const ARAGON_DOMAIN = 'aragonid.eth'
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
+export const ARAGON_DOMAIN = 'aragonid.eth'
+export const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 /**
  * Check eth address equality without checksums
@@ -22,13 +22,13 @@ const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
  * @param {string} second address
  * @returns {boolean} address equality
  */
-function addressesEqual(first, second) {
+export function addressesEqual(first, second) {
   first = first && first.toLowerCase()
   second = second && second.toLowerCase()
   return first === second
 }
 
-const findProjectRoot = () => {
+export const findProjectRoot = () => {
   if (!cachedProjectRoot) {
     try {
       cachedProjectRoot = path.dirname(findUp.sync('arapp.json'))
@@ -40,7 +40,7 @@ const findProjectRoot = () => {
   return cachedProjectRoot
 }
 
-const isPortTaken = async (port, opts) => {
+export const isPortTaken = async (port, opts) => {
   opts = Object.assign({ timeout: 1000 }, opts)
 
   return new Promise(resolve => {
@@ -67,7 +67,7 @@ const isPortTaken = async (port, opts) => {
  * @param {string} url Server url
  * @returns {boolean} true if server is returning a valid response
  */
-function isHttpServerOpen(url) {
+export function isHttpServerOpen(url) {
   return new Promise(resolve => {
     request(url, { method: 'HEAD' }, r => {
       resolve(r.statusCode >= 200 && r.statusCode < 400)
@@ -77,11 +77,11 @@ function isHttpServerOpen(url) {
   })
 }
 
-const getNodePackageManager = () => {
+export const getNodePackageManager = () => {
   return PGK_MANAGER_BIN_NPM
 }
 
-const installDeps = (cwd, task) => {
+export const installDeps = (cwd, task) => {
   const bin = getNodePackageManager()
   const installTask = execa(bin, ['install'], { cwd })
   installTask.stdout.on('data', log => {
@@ -102,7 +102,7 @@ const installDeps = (cwd, task) => {
  * @param {string} binaryName e.g.: `ipfs`
  * @returns {string} the path to the binary, `null` if unsuccessful
  */
-const getBinary = binaryName => {
+export const getBinary = binaryName => {
   let binaryPath = getLocalBinary(binaryName)
 
   if (binaryPath === null) {
@@ -118,7 +118,7 @@ const getBinary = binaryName => {
   return binaryPath
 }
 
-const getLocalBinary = (binaryName, projectRoot) => {
+export const getLocalBinary = (binaryName, projectRoot) => {
   if (!projectRoot) {
     // __dirname evaluates to the directory of this file (util.js)
     // e.g.: `../dist/` or `../src/`
@@ -152,7 +152,7 @@ const getLocalBinary = (binaryName, projectRoot) => {
   return null
 }
 
-const getGlobalBinary = binaryName => {
+export const getGlobalBinary = binaryName => {
   debugLogger(`Searching binary ${binaryName} in the global PATH variable.`)
 
   try {
@@ -163,7 +163,7 @@ const getGlobalBinary = binaryName => {
 }
 
 // TODO: Add a cwd paramter
-const runScriptTask = async (task, scriptName) => {
+export const runScriptTask = async (task, scriptName) => {
   if (!fs.existsSync('package.json')) {
     task.skip('No package.json found')
     return
@@ -191,13 +191,13 @@ const runScriptTask = async (task, scriptName) => {
   })
 }
 
-const getContract = (pkg, contract) => {
+export const getContract = (pkg, contract) => {
   const artifact = require(`${pkg}/build/contracts/${contract}.json`)
   return artifact
 }
 
-const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
-const NO_MANAGER = '0x0000000000000000000000000000000000000000'
+export const ANY_ENTITY = '0xffffffffffffffffffffffffffffffffffffffff'
+export const NO_MANAGER = '0x0000000000000000000000000000000000000000'
 const DEFAULT_GAS_FUZZ_FACTOR = 1.5
 const LAST_BLOCK_GAS_LIMIT_FACTOR = 0.95
 
@@ -210,7 +210,7 @@ const LAST_BLOCK_GAS_LIMIT_FACTOR = 0.95
  * @param {number} gasFuzzFactor defaults to 1.5
  * @returns {number} gasLimit
  */
-const getRecommendedGasLimit = async (
+export const getRecommendedGasLimit = async (
   web3,
   estimatedGas,
   gasFuzzFactor = DEFAULT_GAS_FUZZ_FACTOR
@@ -228,7 +228,7 @@ const getRecommendedGasLimit = async (
   return upperGasLimit
 }
 
-const expandLink = link => {
+export const expandLink = link => {
   const { name, address } = link
   const placeholder = `__${name}${'_'.repeat(38 - name.length)}`
   link.placeholder = placeholder
@@ -294,7 +294,7 @@ const parseAsArray = target => {
  * @param {string} target must be a string
  * @returns {boolean|Array} the parsed value
  */
-const parseArgumentStringIfPossible = target => {
+export const parseArgumentStringIfPossible = target => {
   // convert to boolean: 'false' to false
   try {
     return parseAsBoolean(target)
@@ -315,7 +315,7 @@ const parseArgumentStringIfPossible = target => {
  * @param {string} aragonId Aragon Id
  * @returns {boolean} `true` if valid
  */
-function isValidAragonId(aragonId) {
+export function isValidAragonId(aragonId) {
   return /^[a-z0-9-]+$/.test(aragonId)
 }
 
@@ -325,7 +325,7 @@ function isValidAragonId(aragonId) {
  * @param {string} aragonId Aragon Id
  * @returns {string} DAO subdomain
  */
-function convertDAOIdToSubdomain(aragonId) {
+export function convertDAOIdToSubdomain(aragonId) {
   // If already a subdomain, return
   if (new RegExp(`^([a-z0-9-]+).${ARAGON_DOMAIN}$`).test(aragonId))
     return aragonId
@@ -335,7 +335,7 @@ function convertDAOIdToSubdomain(aragonId) {
   return `${aragonId}.${ARAGON_DOMAIN}`
 }
 
-const askForInput = async message => {
+export const askForInput = async message => {
   const { reply } = await inquirer.prompt([
     {
       type: 'input',
@@ -346,7 +346,7 @@ const askForInput = async message => {
   return reply
 }
 
-const askForChoice = async (message, choices) => {
+export const askForChoice = async (message, choices) => {
   const { reply } = await inquirer.prompt([
     {
       type: 'list',
@@ -358,7 +358,7 @@ const askForChoice = async (message, choices) => {
   return reply
 }
 
-const askForConfirmation = async message => {
+export const askForConfirmation = async message => {
   const { reply } = await inquirer.prompt([
     {
       type: 'confirm',
@@ -367,31 +367,4 @@ const askForConfirmation = async message => {
     },
   ])
   return reply
-}
-
-module.exports = {
-  addressesEqual,
-  parseArgumentStringIfPossible,
-  debugLogger,
-  findProjectRoot,
-  isHttpServerOpen,
-  isPortTaken,
-  installDeps,
-  runScriptTask,
-  getNodePackageManager,
-  getBinary,
-  getLocalBinary,
-  getGlobalBinary,
-  getContract,
-  isValidAragonId,
-  convertDAOIdToSubdomain,
-  ARAGON_DOMAIN,
-  ANY_ENTITY,
-  NO_MANAGER,
-  ZERO_ADDRESS,
-  getRecommendedGasLimit,
-  expandLink,
-  askForInput,
-  askForChoice,
-  askForConfirmation,
 }

--- a/packages/aragon-cli/test/lib/apm/extractContractInfoToFile.test.js
+++ b/packages/aragon-cli/test/lib/apm/extractContractInfoToFile.test.js
@@ -1,8 +1,8 @@
 import test from 'ava'
-const path = require('path')
-const fs = require('fs')
-const tmp = require('tmp')
-const extractContractInfoToFile = require('../../../src/lib/extractContractInfoToFile')
+import path from 'path'
+import fs from 'fs'
+import tmp from 'tmp'
+import extractContractInfoToFile from '../../../src/lib/extractContractInfoToFile'
 
 let tempDir, contractPath, outputPath
 

--- a/packages/aragon-cli/test/lib/apm/getApmRegistryPackages.test.js
+++ b/packages/aragon-cli/test/lib/apm/getApmRegistryPackages.test.js
@@ -20,7 +20,7 @@ test.beforeEach('setup', t => {
     getLatestVersion: async () => {},
   })
 
-  const getApmRegistryPackages = proxyquire
+  const { default: getApmRegistryPackages } = proxyquire
     .noCallThru()
     .load('../../../src/lib/apm/getApmRegistryPackages', {
       '@aragon/apm': apmStub,

--- a/packages/aragon-cli/test/lib/apm/getApmRepo.test.js
+++ b/packages/aragon-cli/test/lib/apm/getApmRepo.test.js
@@ -23,7 +23,7 @@ test.beforeEach('setup', t => {
     getLatestVersion: async () => {},
   })
 
-  const getApmRepo = proxyquire
+  const { default: getApmRepo } = proxyquire
     .noCallThru()
     .load('../../../src/lib/apm/getApmRepo', {
       '@aragon/apm': apmStub,

--- a/packages/aragon-cli/test/lib/apm/getApmRepoVersions.test.js
+++ b/packages/aragon-cli/test/lib/apm/getApmRepoVersions.test.js
@@ -16,7 +16,7 @@ test.beforeEach('setup', t => {
     getAllVersions: async () => {},
   })
 
-  const getApmRepoVersions = proxyquire
+  const { default: getApmRepoVersions } = proxyquire
     .noCallThru()
     .load('../../../src/lib/apm/getApmRepoVersions', {
       '@aragon/apm': apmStub,

--- a/packages/aragon-cli/test/lib/apm/grantNewVersionsPermission.test.js
+++ b/packages/aragon-cli/test/lib/apm/grantNewVersionsPermission.test.js
@@ -43,7 +43,7 @@ test.beforeEach('setup', t => {
     },
   })
 
-  const grantNewVersionsPermission = proxyquire
+  const { default: grantNewVersionsPermission } = proxyquire
     .noCallThru()
     .load('../../../src/lib/apm/grantNewVersionsPermission', {
       '@aragon/apm': apmStub,


### PR DESCRIPTION
This PR has been opened to trigger `codecov` runs

- **Convert CommonJS to ES6 modules**. Absolutely no change was made to the logic of the files. The bulk of the changes were made leveraging the code transformation tool `cjs-to-es6` to assist in the process. Additionally, some tweaks were made:
  - In some commands, a variable `task` was renamed to `tasks` to resolve a scope conflict now that the exported function `task` is used as a normal variable instead of `export.task`
  - Import `web3` utils from `web3-utils` instead of from `web3` directly
  - Change `export default { libA, libB }` to `export const libA` and `export const libB`
  - In tests consuming modules with default exports via `proxyquire` the import was changed from `const fn = proxyquire('../fn')` to `const { default: fn } = proxyquire('../fn')`




