### PR TITLE
Extract logic and fix "contracts" command

### DIFF
--- a/packages/aragon-cli/src/commands/contracts.js
+++ b/packages/aragon-cli/src/commands/contracts.js
@@ -1,20 +1,12 @@
-const { runTruffle } = require('../helpers/truffle-runner')
+const { contracts, extractTruffleArgs } = require('../lib/contracts')
 
-exports.command = 'contracts'
+exports.command = 'contracts [command]'
 
 exports.describe = 'Execute any Truffle command with arguments'
 
-exports.handler = async function({ reporter, cwd }) {
-  const truffleArgs = process.argv.slice(
-    process.argv.indexOf('contracts') + 1,
-    process.argv.length
-  )
-
+exports.handler = async function({ reporter }) {
+  console.log(process.argv)
   reporter.info('Passing the command to Truffle')
-  try {
-    await runTruffle(truffleArgs, {})
-  } catch (err) {
-    console.error(err)
-  }
+  await contracts(extractTruffleArgs(process.argv))
   process.exit(0)
 }

--- a/packages/aragon-cli/src/commands/contracts.js
+++ b/packages/aragon-cli/src/commands/contracts.js
@@ -2,7 +2,16 @@ const { contracts, extractTruffleArgs } = require('../lib/contracts')
 
 exports.command = 'contracts [command]'
 
-exports.describe = 'Execute any Truffle command with arguments'
+// yargs interprets `aragon contracts help` as its own help,
+// so advise users to type `aragon contracts` for Truffle's help.
+exports.describe =
+  'Execute any Truffle command with arguments. Type "aragon contracts" to display Truffle\'s help.'
+
+exports.builder = yargs => {
+  return yargs.positional('command', {
+    description: 'Truffle command',
+  })
+}
 
 exports.handler = async function({ reporter }) {
   reporter.info('Passing the command to Truffle')

--- a/packages/aragon-cli/src/commands/contracts.js
+++ b/packages/aragon-cli/src/commands/contracts.js
@@ -5,7 +5,6 @@ exports.command = 'contracts [command]'
 exports.describe = 'Execute any Truffle command with arguments'
 
 exports.handler = async function({ reporter }) {
-  console.log(process.argv)
   reporter.info('Passing the command to Truffle')
   await contracts(extractTruffleArgs(process.argv))
   process.exit(0)

--- a/packages/aragon-cli/src/lib/contracts.js
+++ b/packages/aragon-cli/src/lib/contracts.js
@@ -18,7 +18,12 @@ const extractTruffleArgs = argv => {
  * @returns {Promise<void>}
  */
 const contracts = async (truffleArgs, options = {}) => {
-  return runTruffle(truffleArgs, options)
+  try {
+    return await runTruffle(truffleArgs, options)
+  } catch (err) {
+    // Truffle returns a `code 1` for the help command and makes execa
+    // throw an exception but the output is still valid.
+  }
 }
 
 module.exports = { extractTruffleArgs, contracts }

--- a/packages/aragon-cli/src/lib/contracts.js
+++ b/packages/aragon-cli/src/lib/contracts.js
@@ -1,0 +1,24 @@
+const { runTruffle } = require('../helpers/truffle-runner')
+
+/**
+ * Extracts arguments to pass down to truffle
+ *
+ * @param {string[]} argv Process arguments
+ * @returns {string[]} Truffle arguments
+ */
+const extractTruffleArgs = argv => {
+  return argv.slice(argv.indexOf('contracts') + 1)
+}
+
+/**
+ * Aragon contracts command. Runs a truffle command.
+ *
+ * @param {string[]} truffleArgs Arguments to pass to truffle
+ * @param {Object} options IO options
+ * @returns {Promise<void>}
+ */
+const contracts = async (truffleArgs, options = {}) => {
+  return runTruffle(truffleArgs, options)
+}
+
+module.exports = { extractTruffleArgs, contracts }

--- a/packages/aragon-cli/test/lib/contracts.test.js
+++ b/packages/aragon-cli/test/lib/contracts.test.js
@@ -1,0 +1,46 @@
+import test from 'ava'
+import { extractTruffleArgs, contracts } from '../../src/lib/contracts'
+import { Writable } from 'stream'
+
+test('extractTruffleArgs should output the correct arguments', t => {
+  t.deepEqual(extractTruffleArgs(['node', 'aragon', 'contracts', 'compile']), [
+    'compile',
+  ])
+
+  t.deepEqual(extractTruffleArgs(['aragon', 'contracts', 'help', 'compile']), [
+    'help',
+    'compile',
+  ])
+
+  t.deepEqual(
+    extractTruffleArgs([
+      '/Users/test/.nvm/versions/node/v11.15.0/bin/node',
+      'cli.js',
+      'contracts',
+      'arg1',
+      'arg2',
+      'arg3',
+    ]),
+    ['arg1', 'arg2', 'arg3']
+  )
+})
+
+test('contracts ["version"] displays truffle verion', async t => {
+  const stdout = stringStream()
+  await contracts(['version'], { stdout })
+
+  t.true(stdout.output.includes('Truffle v'))
+})
+
+const stringStream = () => {
+  const stream = new Writable({
+    objectMode: true,
+    write: (data, _, done) => {
+      stream.output += data.toString()
+      done()
+    },
+  })
+  stream.output = ''
+
+  return stream
+}

--- a/packages/aragon-cli/test/lib/contracts.test.js
+++ b/packages/aragon-cli/test/lib/contracts.test.js
@@ -32,6 +32,13 @@ test('contracts ["version"] displays truffle verion', async t => {
   t.true(stdout.output.includes('Truffle v'))
 })
 
+test('contracts ["help"] displays truffle help', async t => {
+  const stdout = stringStream()
+  // Truffle outputs the help command in stderr
+  await contracts(['help'], { stdout, stderr: stdout })
+  t.true(stdout.output.includes('Usage: truffle '))
+})
+
 const stringStream = () => {
   const stream = new Writable({
     objectMode: true,


### PR DESCRIPTION
# 🦅 Pull Request

- Fix broken `contracts` command
- Extract logic to `lib` folder
- Add tests

We should probably add more tests to this, but it's currently difficult because the command relies on `process.cwd()`. In a next iteration, we should add a `cwd` param so we can run it in the directory of our choice.

~~Another note: truffle returns a **code 1** for the help command, so it's basically considered as an error by `execa` and it throws an exception. We may want to detect this and handle it correctly in a future iteration.~~  -> Fixed.

## 🚨 Test instructions

`aragpn contracts`
