### PR TITLE
More explicit and self-descriptive names for getRepoTask exports

### DIFF
--- a/packages/aragon-cli/src/commands/dao_cmds/install.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/install.js
@@ -20,14 +20,14 @@ import listrOpts from '../../helpers/listr-options'
 import defaultAPMName from '../../helpers/default-apm'
 import encodeInitPayload from '../../helpers/encodeInitPayload'
 import { task as execTask } from './utils/execHandler'
-import { task as getRepoTask, args } from './utils/getRepoTask'
+import { getRepoTask, getRepoBuilder } from './utils/getRepoTask'
 import daoArg from './utils/daoArg'
 
 export const command = 'install <dao> <apmRepo> [apmRepoVersion]'
 export const describe = 'Install an app into a DAO'
 
 export const builder = function(yargs) {
-  return args(daoArg(yargs))
+  return getRepoBuilder(daoArg(yargs))
     .option('app-init', {
       description:
         'Name of the function that will be called to initialize an app. Set it to "none" to skip initialization',

--- a/packages/aragon-cli/src/commands/dao_cmds/upgrade.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/upgrade.js
@@ -10,13 +10,13 @@ import listrOpts from '../../helpers/listr-options'
 import defaultAPMName from '../../helpers/default-apm'
 import daoArg from './utils/daoArg'
 import { task as execTask } from './utils/execHandler'
-import { task as getRepoTask, args } from './utils/getRepoTask'
+import { getRepoTask, getRepoBuilder } from './utils/getRepoTask'
 
 export const command = 'upgrade <dao> <apmRepo> [apmRepoVersion]'
 export const describe = 'Upgrade an app into a DAO'
 
 export const builder = function(yargs) {
-  return args(daoArg(yargs))
+  return getRepoBuilder(daoArg(yargs))
 }
 
 export const handler = async function({

--- a/packages/aragon-cli/src/commands/dao_cmds/utils/getRepoTask.js
+++ b/packages/aragon-cli/src/commands/dao_cmds/utils/getRepoTask.js
@@ -2,7 +2,7 @@ import { DEFAULT_IPFS_TIMEOUT } from '@aragon/toolkit/dist/helpers/constants'
 //
 const LATEST_VERSION = 'latest'
 
-export const args = function(yargs) {
+export function getRepoBuilder(yargs) {
   return yargs
     .option('apmRepo', {
       describe: 'Name of the aragonPM repo',
@@ -13,12 +13,12 @@ export const args = function(yargs) {
     })
 }
 
-export const task = async ({
+export async function getRepoTask({
   apm,
   apmRepo,
   apmRepoVersion = LATEST_VERSION,
   artifactRequired = true,
-}) => {
+}) {
   return async ctx => {
     if (apmRepoVersion === LATEST_VERSION) {
       ctx.repo = await apm.getLatestVersion(apmRepo, DEFAULT_IPFS_TIMEOUT)

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -13,7 +13,7 @@ import { blue, green, bold } from 'chalk'
 import encodeInitPayload from '../helpers/encodeInitPayload'
 
 import listrOpts from '../helpers/listr-options'
-import { task as getRepoTask } from './dao_cmds/utils/getRepoTask'
+import { getRepoTask } from './dao_cmds/utils/getRepoTask'
 import pkg from '../../package.json'
 import {
   findProjectRoot,


### PR DESCRIPTION
Review for https://github.com/aragon/aragon-cli/pull/995

More explicit and self-descriptive names for getRepoTask exports