### PR TITLE
Fixing global option detection removing yargs strict

### DIFF
--- a/packages/aragon-cli/src/cli.js
+++ b/packages/aragon-cli/src/cli.js
@@ -35,7 +35,7 @@ const MIDDLEWARES = [
 
 // Set up commands
 const cmd = require('yargs')
-  .strict()
+  // .strict() TODO: Fix to detect global options
   .parserConfiguration({
     'parse-numbers': false,
   })


### PR DESCRIPTION
# 🦅 Pull Request

Fix global options as `--use-frame` that didn't work if we use yargs `strict` mode.
