### PR TITLE
Patch to prevent long running commands to call onFinishCommand hook

### DIFF
--- a/packages/aragon-cli/src/commands/devchain_cmds/start.js
+++ b/packages/aragon-cli/src/commands/devchain_cmds/start.js
@@ -1,3 +1,16 @@
 const { start } = require('@aragon/aragen').commands
 
-Object.assign(exports, start)
+// Using verbose approach for transparency, instead of `Object.assign(exports, start)`
+exports.command = start.command
+exports.describe = start.describe
+exports.builder = start.builder
+exports.task = start.task
+exports.printAccounts = start.printAccounts
+exports.printMnemonic = start.printMnemonic
+exports.printResetNotice = start.printResetNotice
+exports.handler = async args => {
+  await start.handler(args)
+
+  // Patch to prevent calling the onFinishCommand hook
+  await new Promise((resolve, reject) => {})
+}

--- a/packages/aragon-cli/src/commands/run.js
+++ b/packages/aragon-cli/src/commands/run.js
@@ -442,5 +442,8 @@ exports.handler = async function({
     } else if (!manifest.start_url) {
       reporter.warning('No front-end detected (no start_url defined)')
     }
+
+    // Patch to prevent calling the onFinishCommand hook
+    await new Promise((resolve, reject) => {})
   })
 }

--- a/packages/aragon-cli/src/commands/start.js
+++ b/packages/aragon-cli/src/commands/start.js
@@ -118,13 +118,15 @@ exports.handler = async ({
     clientPort,
     clientPath,
   })
-  return task
-    .run()
-    .then(() =>
-      reporter.info(
-        `Aragon client from ${blue(clientRepo)} version ${blue(
-          clientVersion
-        )} started on port ${blue(clientPort)}`
-      )
-    )
+
+  await task.run()
+
+  reporter.info(
+    `Aragon client from ${blue(clientRepo)} version ${blue(
+      clientVersion
+    )} started on port ${blue(clientPort)}`
+  )
+
+  // Patch to prevent calling the onFinishCommand hook
+  await new Promise((resolve, reject) => {})
 }


### PR DESCRIPTION
# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->

Fixes a regression introduced in https://github.com/aragon/aragon-cli/pull/992 where commands that are supposed to run until the user stop them, stopped automatically.
- devchain_cmds/start.js
- start.js
- run.js

This patch will not be necessary once the onFinishCommand hook is removed, which should happen in a short-medium future.

## 🚨 Test instructions

Run 
```
node dist/cli.js devchain
```
```
node dist/cli.js start
```
```
node dist/cli.js run
```

And the command should not finish after successful completion

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
