### PR TITLE
Fix toolkit export in the cli

### DIFF
--- a/packages/aragon-cli/src/toolkit.js
+++ b/packages/aragon-cli/src/toolkit.js
@@ -1,3 +1,1 @@
-import * as toolkit from '@aragon/toolkit'
-
-export default toolkit
+export * from '@aragon/toolkit'


### PR DESCRIPTION
# 🦅 Pull Request

<!-- Please let us know why do you wish to include this change. 👇 -->
With this change we can do:

```
const { killProcessOnPort } = require('@aragon/cli')
```

instead of 

```
const { killProcessOnPort } = require('@aragon/cli').default
```


## 🚨 Test instructions

<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
