### PR TITLE
Transform truffle config to v5

### DIFF
--- a/packages/cli/src/helpers/truffle-config.js
+++ b/packages/cli/src/helpers/truffle-config.js
@@ -2,16 +2,38 @@ import fs from 'fs'
 //
 import { findProjectRoot } from '../util'
 
+const transformToTruffle5 = config => {
+  if (Object.prototype.hasOwnProperty.call(config, 'solc')) {
+    const v5Config = {
+      ...config,
+      compilers: {
+        solc: {
+          version: '0.4.24',
+          settings: {
+            ...config.solc,
+          },
+        },
+      },
+    }
+
+    // remove v4 key
+    delete v5Config.solc
+
+    return v5Config
+  }
+  return config
+}
+
 export const getTruffleConfig = () => {
   try {
     if (fs.existsSync(`${findProjectRoot()}/truffle.js`)) {
       const truffleConfig = require(`${findProjectRoot()}/truffle`)
-      return truffleConfig
+      return transformToTruffle5(truffleConfig)
     }
 
     if (fs.existsSync(`${findProjectRoot()}/truffle-config.js`)) {
       const truffleConfig = require(`${findProjectRoot()}/truffle-config.js`)
-      return truffleConfig
+      return transformToTruffle5(truffleConfig)
     }
   } catch (err) {
     console.log(err)


### PR DESCRIPTION
# 🦅 Pull Request

Fixes #1104 

## 🚨 Test instructions

Use `aragon run` on an old project that includes a truffle config with v4.

