### PR TITLE
Read arapp for contract name

### DIFF
--- a/packages/buidler/arapp.json
+++ b/packages/buidler/arapp.json
@@ -17,5 +17,5 @@
       "appName": "counter.aragonpm.eth"
     }
   },
-  "path": "contracts/CounterApp.sol"
+  "path": "contracts/Counter.sol"
 }

--- a/packages/buidler/package.json
+++ b/packages/buidler/package.json
@@ -24,6 +24,11 @@
     "@types/node": "^13.1.4",
     "filewatcher": "^3.0.1",
     "ts-node": "^8.5.4",
-    "typescript": "^3.7.4"
+    "typescript": "^3.7.4",
+    "web3": "^1.2.4"
+  },
+  "prettier": {
+    "singleQuote": true,
+    "bracketSpacing": true
   }
 }

--- a/packages/buidler/tasks/task-names.ts
+++ b/packages/buidler/tasks/task-names.ts
@@ -1,5 +1,9 @@
 export const TASK_START = 'start';
 export const TASK_START_NEW_DAO = 'start:new-dao';
 export const TASK_START_NEW_APP_PROXY = 'start:new-app-proxy';
-export const TASK_START_UPDATE_PROXY_IMPLEMENTATION = 'start:update-proxy-implementation';
-export const TASK_START_WATCH_CONTRACTS = 'start:watch-contracts'
+export const TASK_START_UPDATE_PROXY_IMPLEMENTATION =
+  'start:update-proxy-implementation';
+export const TASK_START_WATCH_CONTRACTS = 'start:watch-contracts';
+
+// buidler built-in
+export const TASK_COMPILE = 'compile';


### PR DESCRIPTION
Part of https://github.com/aragon/aragon-cli/issues/1178
- Reads arapp.json to get contract name
- Declare `internalTask`s at the top of the module
- Type buidler env argument
- Add prettier settings and format