### PR TITLE
Move logic #3

### DIFF
--- a/packages/cli/npm-shrinkwrap.json
+++ b/packages/cli/npm-shrinkwrap.json
@@ -7949,25 +7949,29 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"dev": true,
 					"optional": true
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"dev": true,
 					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"dev": true,
 					"optional": true
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -7977,13 +7981,15 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"dev": true,
 					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -7993,37 +7999,43 @@
 				},
 				"chownr": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
+					"integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
 					"dev": true,
 					"optional": true
 				},
 				"code-point-at": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"dev": true,
 					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"dev": true,
 					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"dev": true,
 					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"dev": true,
 					"optional": true
 				},
 				"debug": {
 					"version": "3.2.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8032,25 +8044,29 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"dev": true,
 					"optional": true
 				},
 				"delegates": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"dev": true,
 					"optional": true
 				},
 				"detect-libc": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"dev": true,
 					"optional": true
 				},
 				"fs-minipass": {
 					"version": "1.2.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+					"integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8059,13 +8075,15 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"dev": true,
 					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8081,7 +8099,8 @@
 				},
 				"glob": {
 					"version": "7.1.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+					"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8095,13 +8114,15 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"dev": true,
 					"optional": true
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8110,7 +8131,8 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+					"integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8119,7 +8141,8 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8129,19 +8152,22 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 					"dev": true,
 					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"dev": true,
 					"optional": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8150,13 +8176,15 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"dev": true,
 					"optional": true
 				},
 				"minimatch": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8165,13 +8193,15 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"dev": true,
 					"optional": true
 				},
 				"minipass": {
 					"version": "2.9.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+					"integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8181,7 +8211,8 @@
 				},
 				"minizlib": {
 					"version": "1.3.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+					"integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8190,7 +8221,8 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8199,13 +8231,15 @@
 				},
 				"ms": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true,
 					"optional": true
 				},
 				"needle": {
 					"version": "2.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+					"integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8216,7 +8250,8 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.14.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+					"integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8234,7 +8269,8 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8244,7 +8280,8 @@
 				},
 				"npm-bundled": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+					"integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8253,13 +8290,15 @@
 				},
 				"npm-normalize-package-bin": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+					"integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
 					"version": "1.4.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.7.tgz",
+					"integrity": "sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8269,7 +8308,8 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8281,19 +8321,22 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"dev": true,
 					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"dev": true,
 					"optional": true
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8302,19 +8345,22 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"dev": true,
 					"optional": true
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"dev": true,
 					"optional": true
 				},
 				"osenv": {
 					"version": "0.1.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8324,19 +8370,22 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+					"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
 					"version": "1.2.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8348,7 +8397,8 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
-							"bundled": true,
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"dev": true,
 							"optional": true
 						}
@@ -8356,7 +8406,8 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8371,7 +8422,8 @@
 				},
 				"rimraf": {
 					"version": "2.7.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+					"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8380,43 +8432,50 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"dev": true,
 					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"dev": true,
 					"optional": true
 				},
 				"sax": {
 					"version": "1.2.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"dev": true,
 					"optional": true
 				},
 				"semver": {
 					"version": "5.7.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true,
 					"optional": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true,
 					"optional": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true,
 					"optional": true
 				},
 				"string-width": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8427,7 +8486,8 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8436,7 +8496,8 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8445,13 +8506,15 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"dev": true,
 					"optional": true
 				},
 				"tar": {
 					"version": "4.4.13",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+					"integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8466,13 +8529,15 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"dev": true,
 					"optional": true
 				},
 				"wide-align": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -8481,13 +8546,15 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true,
 					"optional": true
 				},
 				"yallist": {
 					"version": "3.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+					"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 					"dev": true,
 					"optional": true
 				}
@@ -8516,12 +8583,14 @@
 			"dependencies": {
 				"ansi-regex": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
 					"dev": true
 				},
 				"ansi-styles": {
 					"version": "3.2.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
@@ -8529,7 +8598,8 @@
 				},
 				"bindings": {
 					"version": "1.5.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+					"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
 					"dev": true,
 					"requires": {
 						"file-uri-to-path": "1.0.0"
@@ -8537,7 +8607,8 @@
 				},
 				"bip66": {
 					"version": "1.1.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+					"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
 					"dev": true,
 					"requires": {
 						"safe-buffer": "^5.0.1"
@@ -8545,17 +8616,20 @@
 				},
 				"bn.js": {
 					"version": "4.11.8",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
 					"dev": true
 				},
 				"brorand": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+					"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
 					"dev": true
 				},
 				"browserify-aes": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+					"integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
 					"dev": true,
 					"requires": {
 						"buffer-xor": "^1.0.3",
@@ -8568,22 +8642,26 @@
 				},
 				"buffer-from": {
 					"version": "1.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+					"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 					"dev": true
 				},
 				"buffer-xor": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+					"integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
 					"dev": true
 				},
 				"camelcase": {
 					"version": "5.3.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 					"dev": true
 				},
 				"cipher-base": {
 					"version": "1.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+					"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -8592,7 +8670,8 @@
 				},
 				"cliui": {
 					"version": "5.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
 					"dev": true,
 					"requires": {
 						"string-width": "^3.1.0",
@@ -8602,7 +8681,8 @@
 				},
 				"color-convert": {
 					"version": "1.9.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
 					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
@@ -8610,12 +8690,14 @@
 				},
 				"color-name": {
 					"version": "1.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
 					"dev": true
 				},
 				"create-hash": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+					"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
 					"dev": true,
 					"requires": {
 						"cipher-base": "^1.0.1",
@@ -8627,7 +8709,8 @@
 				},
 				"create-hmac": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+					"integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
 					"dev": true,
 					"requires": {
 						"cipher-base": "^1.0.3",
@@ -8640,7 +8723,8 @@
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
 						"nice-try": "^1.0.4",
@@ -8652,12 +8736,14 @@
 				},
 				"decamelize": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
 					"dev": true
 				},
 				"drbg.js": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+					"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
 					"dev": true,
 					"requires": {
 						"browserify-aes": "^1.0.6",
@@ -8667,7 +8753,8 @@
 				},
 				"elliptic": {
 					"version": "6.5.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
+					"integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
 					"dev": true,
 					"requires": {
 						"bn.js": "^4.4.0",
@@ -8681,12 +8768,14 @@
 				},
 				"emoji-regex": {
 					"version": "7.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
 					"dev": true
 				},
 				"end-of-stream": {
 					"version": "1.4.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+					"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 					"dev": true,
 					"requires": {
 						"once": "^1.4.0"
@@ -8694,7 +8783,8 @@
 				},
 				"ethereumjs-util": {
 					"version": "6.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+					"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
 					"dev": true,
 					"requires": {
 						"bn.js": "^4.11.0",
@@ -8708,7 +8798,8 @@
 				},
 				"ethjs-util": {
 					"version": "0.1.6",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+					"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
 					"dev": true,
 					"requires": {
 						"is-hex-prefixed": "1.0.0",
@@ -8717,7 +8808,8 @@
 				},
 				"evp_bytestokey": {
 					"version": "1.0.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+					"integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
 					"dev": true,
 					"requires": {
 						"md5.js": "^1.3.4",
@@ -8726,7 +8818,8 @@
 				},
 				"execa": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+					"integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
 					"dev": true,
 					"requires": {
 						"cross-spawn": "^6.0.0",
@@ -8740,12 +8833,14 @@
 				},
 				"file-uri-to-path": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+					"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 					"dev": true
 				},
 				"find-up": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
 					"dev": true,
 					"requires": {
 						"locate-path": "^3.0.0"
@@ -8753,12 +8848,14 @@
 				},
 				"get-caller-file": {
 					"version": "2.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
 				},
 				"get-stream": {
 					"version": "4.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+					"integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
 					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
@@ -8766,7 +8863,8 @@
 				},
 				"hash-base": {
 					"version": "3.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+					"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -8775,7 +8873,8 @@
 				},
 				"hash.js": {
 					"version": "1.1.7",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+					"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
@@ -8784,7 +8883,8 @@
 				},
 				"hmac-drbg": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+					"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
 					"dev": true,
 					"requires": {
 						"hash.js": "^1.0.3",
@@ -8794,37 +8894,44 @@
 				},
 				"inherits": {
 					"version": "2.0.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 					"dev": true
 				},
 				"invert-kv": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+					"integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
 					"dev": true
 				},
 				"is-hex-prefixed": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
+					"integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ=",
 					"dev": true
 				},
 				"is-stream": {
 					"version": "1.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+					"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
 					"dev": true
 				},
 				"isexe": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 					"dev": true
 				},
 				"keccak": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+					"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
 					"dev": true,
 					"requires": {
 						"bindings": "^1.2.1",
@@ -8835,7 +8942,8 @@
 				},
 				"lcid": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+					"integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
 					"dev": true,
 					"requires": {
 						"invert-kv": "^2.0.0"
@@ -8843,7 +8951,8 @@
 				},
 				"locate-path": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
 					"dev": true,
 					"requires": {
 						"p-locate": "^3.0.0",
@@ -8852,7 +8961,8 @@
 				},
 				"map-age-cleaner": {
 					"version": "0.1.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+					"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
 					"dev": true,
 					"requires": {
 						"p-defer": "^1.0.0"
@@ -8860,7 +8970,8 @@
 				},
 				"md5.js": {
 					"version": "1.3.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+					"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
 					"dev": true,
 					"requires": {
 						"hash-base": "^3.0.0",
@@ -8870,7 +8981,8 @@
 				},
 				"mem": {
 					"version": "4.3.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+					"integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
 					"dev": true,
 					"requires": {
 						"map-age-cleaner": "^0.1.1",
@@ -8880,32 +8992,38 @@
 				},
 				"mimic-fn": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+					"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 					"dev": true
 				},
 				"minimalistic-assert": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+					"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
 					"dev": true
 				},
 				"minimalistic-crypto-utils": {
 					"version": "1.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+					"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
 					"dev": true
 				},
 				"nan": {
 					"version": "2.14.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
 					"dev": true
 				},
 				"nice-try": {
 					"version": "1.0.5",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+					"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 					"dev": true
 				},
 				"npm-run-path": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+					"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 					"dev": true,
 					"requires": {
 						"path-key": "^2.0.0"
@@ -8913,7 +9031,8 @@
 				},
 				"once": {
 					"version": "1.4.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
 					"requires": {
 						"wrappy": "1"
@@ -8921,7 +9040,8 @@
 				},
 				"os-locale": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+					"integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
 					"dev": true,
 					"requires": {
 						"execa": "^1.0.0",
@@ -8931,22 +9051,26 @@
 				},
 				"p-defer": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+					"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
 					"dev": true
 				},
 				"p-finally": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+					"integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
 					"dev": true
 				},
 				"p-is-promise": {
 					"version": "2.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+					"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 					"dev": true
 				},
 				"p-limit": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+					"integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
 					"dev": true,
 					"requires": {
 						"p-try": "^2.0.0"
@@ -8954,7 +9078,8 @@
 				},
 				"p-locate": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
 						"p-limit": "^2.0.0"
@@ -8962,22 +9087,26 @@
 				},
 				"p-try": {
 					"version": "2.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
 				},
 				"path-exists": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"path-key": {
 					"version": "2.0.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+					"integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
 					"dev": true
 				},
 				"pump": {
 					"version": "3.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
@@ -8986,17 +9115,20 @@
 				},
 				"require-directory": {
 					"version": "2.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
 					"dev": true
 				},
 				"require-main-filename": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 					"dev": true
 				},
 				"ripemd160": {
 					"version": "2.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+					"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
 					"dev": true,
 					"requires": {
 						"hash-base": "^3.0.0",
@@ -9005,7 +9137,8 @@
 				},
 				"rlp": {
 					"version": "2.2.3",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.3.tgz",
+					"integrity": "sha512-l6YVrI7+d2vpW6D6rS05x2Xrmq8oW7v3pieZOJKBEdjuTF4Kz/iwk55Zyh1Zaz+KOB2kC8+2jZlp2u9L4tTzCQ==",
 					"dev": true,
 					"requires": {
 						"bn.js": "^4.11.1",
@@ -9014,12 +9147,14 @@
 				},
 				"safe-buffer": {
 					"version": "5.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+					"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
 					"dev": true
 				},
 				"secp256k1": {
 					"version": "3.7.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+					"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
 					"dev": true,
 					"requires": {
 						"bindings": "^1.5.0",
@@ -9034,17 +9169,20 @@
 				},
 				"semver": {
 					"version": "5.7.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"dev": true
 				},
 				"set-blocking": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"dev": true
 				},
 				"sha.js": {
 					"version": "2.4.11",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+					"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
 					"dev": true,
 					"requires": {
 						"inherits": "^2.0.1",
@@ -9053,7 +9191,8 @@
 				},
 				"shebang-command": {
 					"version": "1.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+					"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 					"dev": true,
 					"requires": {
 						"shebang-regex": "^1.0.0"
@@ -9061,22 +9200,26 @@
 				},
 				"shebang-regex": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
 					"dev": true
 				},
 				"signal-exit": {
 					"version": "3.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"source-map-support": {
 					"version": "0.5.12",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.12.tgz",
+					"integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
 					"dev": true,
 					"requires": {
 						"buffer-from": "^1.0.0",
@@ -9085,7 +9228,8 @@
 				},
 				"string-width": {
 					"version": "3.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+					"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
 					"dev": true,
 					"requires": {
 						"emoji-regex": "^7.0.1",
@@ -9095,7 +9239,8 @@
 				},
 				"strip-ansi": {
 					"version": "5.2.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+					"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^4.1.0"
@@ -9103,12 +9248,14 @@
 				},
 				"strip-eof": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+					"integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
 					"dev": true
 				},
 				"strip-hex-prefix": {
 					"version": "1.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz",
+					"integrity": "sha1-DF8VX+8RUTczd96du1iNoFUA428=",
 					"dev": true,
 					"requires": {
 						"is-hex-prefixed": "1.0.0"
@@ -9116,7 +9263,8 @@
 				},
 				"which": {
 					"version": "1.3.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
@@ -9124,12 +9272,14 @@
 				},
 				"which-module": {
 					"version": "2.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
 					"dev": true
 				},
 				"wrap-ansi": {
 					"version": "5.1.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.0",
@@ -9139,17 +9289,20 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"dev": true
 				},
 				"y18n": {
 					"version": "4.0.0",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+					"integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
 					"dev": true
 				},
 				"yargs": {
 					"version": "13.2.4",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+					"integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
 					"dev": true,
 					"requires": {
 						"cliui": "^5.0.0",
@@ -9167,7 +9320,8 @@
 				},
 				"yargs-parser": {
 					"version": "13.1.1",
-					"bundled": true,
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+					"integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",
@@ -9177,9 +9331,9 @@
 			}
 		},
 		"ganache-core": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.9.1.tgz",
-			"integrity": "sha512-AE6Z9mZEy8Z9NBjHBEAzTGX6OMhRypp03LRKBJUqV4dSVDD6L7iqUbZvjILBwSqRyZV4v+ASxI9Hm4MBWp2uwA==",
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/ganache-core/-/ganache-core-2.9.2.tgz",
+			"integrity": "sha512-+BHzLDpickuq/f147ryoHClzSG7P9DfiOfwntEHbXFbfsLvmGCbE3TiKwwWkcVoiBdkN8ybyElWE0QoYe3/LOA==",
 			"dev": true,
 			"requires": {
 				"abstract-leveldown": "3.0.0",
@@ -21949,14 +22103,12 @@
 							"integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
 							"dev": true,
 							"requires": {
-								"ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
 								"ethereumjs-util": "^5.1.1"
 							},
 							"dependencies": {
 								"ethereumjs-abi": {
 									"version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-									"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-									"dev": true,
+									"from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
 									"requires": {
 										"bn.js": "^4.11.8",
 										"ethereumjs-util": "^6.0.0"
@@ -21966,7 +22118,6 @@
 											"version": "6.2.0",
 											"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
 											"integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
-											"dev": true,
 											"requires": {
 												"@types/bn.js": "^4.11.3",
 												"bn.js": "^4.11.0",
@@ -21983,20 +22134,11 @@
 									"version": "2.1.0",
 									"resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
 									"integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
-									"dev": true,
 									"requires": {
 										"bindings": "^1.5.0",
 										"inherits": "^2.0.4",
 										"nan": "^2.14.0",
 										"safe-buffer": "^5.2.0"
-									},
-									"dependencies": {
-										"nan": {
-											"version": "2.14.0",
-											"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-											"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-											"dev": true
-										}
 									}
 								}
 							}
@@ -22153,6 +22295,11 @@
 									}
 								}
 							}
+						},
+						"nan": {
+							"version": "2.14.0",
+							"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+							"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
 						},
 						"ws": {
 							"version": "5.2.2",

--- a/packages/cli/src/commands/apm_cmds/publish.js
+++ b/packages/cli/src/commands/apm_cmds/publish.js
@@ -164,7 +164,6 @@ export const handler = async function({
     initialVersion,
     version,
     contract: contractAddress,
-    deployArtifacts,
   } = await runSetupTask({
     reporter,
     gasPrice,
@@ -210,7 +209,6 @@ export const handler = async function({
     initialVersion,
     version,
     contractAddress,
-    deployArtifacts,
   })
 
   // Output publish info

--- a/packages/cli/src/commands/apm_cmds/util/runPrepareForPublishTask.js
+++ b/packages/cli/src/commands/apm_cmds/util/runPrepareForPublishTask.js
@@ -1,6 +1,14 @@
 import tmp from 'tmp-promise'
 import TaskList from 'listr'
-import { APM_INITIAL_VERSIONS, apmPublishVersionIntent } from '@aragon/toolkit'
+import path from 'path'
+import fs from 'fs'
+import { promisify } from 'util'
+import { readJsonSync } from 'fs-extra'
+import {
+  APM_INITIAL_VERSIONS,
+  apmPublishVersionIntent,
+  generateApplicationArtifact,
+} from '@aragon/toolkit'
 //
 import listrOpts from '../../../helpers/listr-options'
 
@@ -8,7 +16,6 @@ import askToConfirm from '../../../lib/publish/askToConfirm'
 import { prepareFilesForPublishing } from '../../../lib/publish/preprareFiles'
 import {
   changeManifestForHttpServedFrom,
-  generateApplicationArtifact,
   writeApplicationArtifact,
   flattenCodeFileExists,
   generateFlattenedCode,
@@ -16,6 +23,7 @@ import {
   checkIfNewArticatIsIdentical,
   copyCurrentApplicationArtifacts,
 } from '../../../lib/apm/generateArtifact'
+const readFile = promisify(fs.readFile)
 
 /**
  * ctx mandatory output
@@ -54,7 +62,6 @@ export default async function runPrepareForPublishTask({
   initialVersion,
   version,
   contractAddress,
-  deployArtifacts,
 }) {
   return new TaskList(
     [
@@ -113,25 +120,34 @@ export default async function runPrepareForPublishTask({
           }
 
           async function invokeArtifactGeneration() {
-            const {
-              artifact,
-              missingArtifactVersions,
-            } = await generateApplicationArtifact(
-              web3,
+            // const {
+            //   artifact,
+            //   missingArtifactVersions,
+            // } = await generateApplicationArtifact(arapp)
+            // if (missingArtifactVersions.length) {
+            //   const missingVersionsList = missingArtifactVersions.join(', ')
+            //   return askToConfirm(
+            //     `Cannot find artifacts for versions ${missingVersionsList} in aragonPM.\nPlease make sure the package was published and your IPFS or HTTP server are running.\nContinue?`,
+            //     () => performArtifcatGeneration(artifact)
+            //   )
+            // } else {
+            //   return performArtifcatGeneration(artifact)
+            // }
+            const contractInterfacePath = path.resolve(
               cwd,
-              deployArtifacts,
-              arapp,
-              apmOptions
+              'build/contracts',
+              path.basename(contractPath, '.sol') + '.json'
             )
-            if (missingArtifactVersions.length) {
-              const missingVersionsList = missingArtifactVersions.join(', ')
-              return askToConfirm(
-                `Cannot find artifacts for versions ${missingVersionsList} in aragonPM.\nPlease make sure the package was published and your IPFS or HTTP server are running.\nContinue?`,
-                () => performArtifcatGeneration(artifact)
-              )
-            } else {
-              return performArtifcatGeneration(artifact)
-            }
+
+            const contractInterface = readJsonSync(contractInterfacePath)
+            const sourceCode = await readFile(contractPath, 'utf8')
+
+            const artifact = await generateApplicationArtifact(
+              arapp,
+              contractInterface.abi,
+              sourceCode
+            )
+            performArtifcatGeneration(artifact)
           }
 
           // If an artifact file exist we check it to reuse

--- a/packages/cli/src/commands/apm_cmds/util/runPrepareForPublishTask.js
+++ b/packages/cli/src/commands/apm_cmds/util/runPrepareForPublishTask.js
@@ -2,7 +2,6 @@ import tmp from 'tmp-promise'
 import TaskList from 'listr'
 import path from 'path'
 import fs from 'fs'
-import { promisify } from 'util'
 import { readJsonSync } from 'fs-extra'
 import {
   APM_INITIAL_VERSIONS,
@@ -23,7 +22,7 @@ import {
   checkIfNewArticatIsIdentical,
   copyCurrentApplicationArtifacts,
 } from '../../../lib/apm/generateArtifact'
-const readFile = promisify(fs.readFile)
+const readFile = fs.promises.readFile
 
 /**
  * ctx mandatory output
@@ -120,19 +119,6 @@ export default async function runPrepareForPublishTask({
           }
 
           async function invokeArtifactGeneration() {
-            // const {
-            //   artifact,
-            //   missingArtifactVersions,
-            // } = await generateApplicationArtifact(arapp)
-            // if (missingArtifactVersions.length) {
-            //   const missingVersionsList = missingArtifactVersions.join(', ')
-            //   return askToConfirm(
-            //     `Cannot find artifacts for versions ${missingVersionsList} in aragonPM.\nPlease make sure the package was published and your IPFS or HTTP server are running.\nContinue?`,
-            //     () => performArtifcatGeneration(artifact)
-            //   )
-            // } else {
-            //   return performArtifcatGeneration(artifact)
-            // }
             const contractInterfacePath = path.resolve(
               cwd,
               'build/contracts',

--- a/packages/cli/src/lib/environment/configEnvironment.js
+++ b/packages/cli/src/lib/environment/configEnvironment.js
@@ -111,7 +111,6 @@ export function configEnvironment({
   // (Todo): Are these mutations necessary?
   if (arapp) {
     arapp.appName = env.appName
-    arapp.env = env // TODO: Remove it's not used anymore
     arapp.environments = { [environment || 'default']: env } // only include the selected environment in the module
   }
 

--- a/packages/toolkit/npm-shrinkwrap.json
+++ b/packages/toolkit/npm-shrinkwrap.json
@@ -4625,11 +4625,11 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"eth-ens-namehash": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-1.0.2.tgz",
-			"integrity": "sha1-Bezda6wtf9e8XKhKmTxrrZ2k7bk=",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+			"integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
 			"requires": {
-				"idna-uts46": "^1.0.1",
+				"idna-uts46-hx": "^2.3.1",
 				"js-sha3": "^0.5.7"
 			}
 		},
@@ -4859,6 +4859,17 @@
 				"ethereum-ens-network-map": "^1.0.0",
 				"ethjs-contract": "^0.1.7",
 				"ethjs-query": "^0.2.4"
+			},
+			"dependencies": {
+				"eth-ens-namehash": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-1.0.2.tgz",
+					"integrity": "sha1-Bezda6wtf9e8XKhKmTxrrZ2k7bk=",
+					"requires": {
+						"idna-uts46": "^1.0.1",
+						"js-sha3": "^0.5.7"
+					}
+				}
 			}
 		},
 		"ethjs-filter": {

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -38,7 +38,9 @@
     "aragon-cli-wrapper": "^5.0.0-rc.22",
     "babel-eslint": "^10.0.3",
     "byte-size": "^6.2.0",
+    "eth-ens-namehash": "^2.0.8",
     "ethereum-ens": "^0.7.8",
+    "execa": "^3.0.0",
     "fs-extra": "^8.1.0",
     "get-folder-size": "^2.0.1",
     "go-platform": "^1.0.0",
@@ -48,7 +50,6 @@
     "ps-tree": "^1.2.0",
     "rxjs": "^6.5.3",
     "stringify-tree": "^1.0.2",
-    "execa": "^3.0.0",
     "web3": "^1.2.4",
     "web3-eth-abi": "^1.2.4",
     "web3-utils": "^1.2.4"

--- a/packages/toolkit/src/helpers/extractContractInfoToFile.js
+++ b/packages/toolkit/src/helpers/extractContractInfoToFile.js
@@ -1,9 +1,15 @@
+import fs from 'fs'
+import { promisify } from 'util'
 import { writeJson } from 'fs-extra'
 //
 import { extractContractInfo } from './solidity-extractor'
+const readFile = promisify(fs.readFile)
+
+// TODO: Move away from Toolkit
 
 export default async (contractPath, outputPath) => {
-  const contractInfo = await extractContractInfo(contractPath)
+  const sourceCode = await readFile(contractPath, 'utf8')
+  const contractInfo = await extractContractInfo(sourceCode)
 
   await writeJson(outputPath, contractInfo, { spaces: '\t' })
 }

--- a/packages/toolkit/src/helpers/extractContractInfoToFile.js
+++ b/packages/toolkit/src/helpers/extractContractInfoToFile.js
@@ -1,9 +1,8 @@
 import fs from 'fs'
-import { promisify } from 'util'
 import { writeJson } from 'fs-extra'
 //
 import { extractContractInfo } from './solidity-extractor'
-const readFile = promisify(fs.readFile)
+const readFile = fs.promises.readFile
 
 // TODO: Move away from Toolkit
 

--- a/packages/toolkit/src/helpers/generateArtifact.js
+++ b/packages/toolkit/src/helpers/generateArtifact.js
@@ -1,0 +1,93 @@
+import namehash from 'eth-ens-namehash'
+import { keccak256 } from 'web3-utils'
+import { encodeFunctionSignature } from 'web3-eth-abi'
+//
+import { SOLIDITY_FILE } from './constants'
+import { extractContractInfo } from './solidity-extractor'
+
+/**
+ * @typedef {Object} FunctionInfo
+ * @property {string} sig "functionName(address,unit)"
+ * @property {Object[]} roles
+ * @property {string} notice Multiline notice text
+ * @property {Object} [abi] Abi of the function
+ */
+
+/**
+ * @param {Object} environments
+ * @return {Object}
+ */
+const decorateEnvrionmentsWithAppId = environments => {
+  const decoratedEnvrionment = {}
+  for (const [key, value] of Object.entries(environments)) {
+    decoratedEnvrionment[key] = {
+      ...value,
+      appId: namehash.hash(value.appName),
+    }
+  }
+  return decoratedEnvrionment
+}
+
+/**
+ * Appends the abi of a function to the functions array
+ * @param {FunctionInfo[]} functions functions
+ * @param {Object[]} abi ABI
+ * @return {FunctionInfo[]} functions with appended ABI
+ */
+function decorateFunctionsWithAbi(functions, abi) {
+  const abiFunctions = abi.filter(elem => elem.type === 'function')
+  return functions.map(f => ({
+    ...f,
+    abi: abiFunctions.find(
+      functionAbi =>
+        encodeFunctionSignature(functionAbi) === encodeFunctionSignature(f.sig)
+    ),
+  }))
+}
+
+/**
+ * @param {Object} roles
+ * @return {Object}
+ */
+const getRoles = roles =>
+  roles.map(role => Object.assign(role, { bytes: keccak256(role.id) }))
+
+/**
+ * Construct artifact object
+ *
+ * @param {ArappConfigFile} arapp Arapp config file
+ * @param {Object[]} abi ABI
+ * @param {string} sourceCode Solidity file
+ * @return {Object} artifact
+ */
+export async function generateApplicationArtifact(arapp, abi, sourceCode) {
+  // Includes appId for each environemnt
+  const environments = decorateEnvrionmentsWithAppId(arapp.environments)
+
+  // Given a Solidity file, parses it and returns an object with the form:
+  // > {roles: [{ },...], functions: [{ },...]}
+  const { functions, roles } = await extractContractInfo(sourceCode)
+
+  // Includes abi for each function
+  // > [{ sig: , role: , notice: , abi: }]
+  const functionsWithAbi = decorateFunctionsWithAbi(functions, abi)
+
+  const arappRoles = getRoles(arapp.roles)
+
+  if (arappRoles !== roles) {
+    console.log(
+      'Warning: The roles defined on the arapp.json not match those on the contract file'
+    )
+  }
+
+  // TODO: Add deprectaedFunctions logic
+
+  return {
+    ...arapp,
+    flattenedCode: `./${SOLIDITY_FILE}`,
+    environments,
+    roles,
+    functions: functionsWithAbi,
+    abi,
+  }
+}

--- a/packages/toolkit/src/helpers/index.js
+++ b/packages/toolkit/src/helpers/index.js
@@ -1,6 +1,7 @@
 export * from './aragonjs-wrapper'
 export * from './constants'
 export * from './solidity-extractor'
+export * from './generateArtifact'
 export { default as defaultAPMName } from './default-apm'
 export { default as extractContractInfoToFile } from './extractContractInfoToFile'
 export { default as encodeInitPayload } from './encodeInitPayload'

--- a/packages/toolkit/src/helpers/solidity-extractor.js
+++ b/packages/toolkit/src/helpers/solidity-extractor.js
@@ -1,7 +1,4 @@
-import fs from 'fs'
-import { promisify } from 'util'
 import { keccak256 } from 'web3-utils'
-const readFile = promisify(fs.readFile)
 
 // See https://solidity.readthedocs.io/en/v0.4.24/abi-spec.html#types
 const SOLIDITY_SHORTHAND_TYPES_MAP = {
@@ -126,7 +123,7 @@ const extractRoles = async functionDescriptors => {
   }))
 }
 
-// Given the path to a Solidity file, parses it and returns an object with the form:
+// Given a Solidity file, parses it and returns an object with the form:
 /*
   roles: [
     {
@@ -146,9 +143,7 @@ const extractRoles = async functionDescriptors => {
     ...
   ]
 */
-export const extractContractInfo = async sourceCodePath => {
-  const sourceCode = await readFile(sourceCodePath, 'utf8')
-
+export const extractContractInfo = async sourceCode => {
   const functionDescriptors = await extractFunctions(sourceCode)
   const roleDescriptors = await extractRoles(functionDescriptors)
 

--- a/packages/toolkit/test/helpers/generateArtifact.test.js
+++ b/packages/toolkit/test/helpers/generateArtifact.test.js
@@ -1,0 +1,5 @@
+import test from 'ava'
+
+test('t', t => {
+  t.pass()
+})


### PR DESCRIPTION
# 🦅 Pull Request

Build on #1214 

Refactor generate artifact logic. Transform it into a pure function and move it to the toolkit. 
During refactor I notice there were a few keys that were not needed anymore (`env`, `appName`) and decided to use each environment to generate information like `appId`. 

Note: The `deployment` key was also removed following discussion about supporting a unique IPFS hash across environments. There were values nondeterministic.

Tasks to address on a new PR:

- Add test for pure function

- Add logic for `deprecatedFunctions` 