### PR TITLE
Buidler plugin

### DIFF
--- a/packages/buidler/.prettierignore
+++ b/packages/buidler/.prettierignore
@@ -1,0 +1,6 @@
+cache/
+dist/
+typechain/
+buidler.config.ts
+# Temp, CounterApp contents
+app/

--- a/packages/buidler/.prettierrc
+++ b/packages/buidler/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "semi": false
+}

--- a/packages/buidler/buidler.config.ts
+++ b/packages/buidler/buidler.config.ts
@@ -20,19 +20,19 @@ const config: BuidlerConfig = {
       url: 'http://localhost:8545',
       accounts: [
         '0xa8a54b2d8197bc0b19bb8a084031be71835580a01e70a45a13babd16c9bc1563',
-        '0xce8e3bda3b44269c147747a373646393b1504bfcbb73fc9564f5d753d8116608',
-      ],
-    },
+        '0xce8e3bda3b44269c147747a373646393b1504bfcbb73fc9564f5d753d8116608'
+      ]
+    }
   },
   solc: {
-    version: '0.4.24',
+    version: '0.4.24'
   },
   aragon: {
     appServePort: 8001,
     clientServePort: 3000,
     appSrcPath: 'app/',
-    appBuildOutputPath: 'dist/',
-  },
+    appBuildOutputPath: 'dist/'
+  }
 };
 
 export default config;

--- a/packages/buidler/package.json
+++ b/packages/buidler/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "generate": "typechain --target truffle --outDir typechain 'artifacts/*.json'",
-    "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "lint": "tslint -c tslint.json --fix 'src/**/*.ts'",
     "test": "buidler test"
   },
   "dependencies": {
@@ -25,6 +25,7 @@
     "@types/chai": "^4.2.5",
     "@types/mocha": "^5.2.7",
     "@types/node": "^13.1.4",
+    "chalk": "^3.0.0",
     "chokidar": "^3.3.1",
     "eth-ens-namehash": "^2.0.8",
     "ethjs-ens": "^2.0.1",

--- a/packages/buidler/package.json
+++ b/packages/buidler/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "generate": "typechain --target truffle --outDir typechain 'artifacts/*.json'",
     "lint": "tslint -c tslint.json --fix 'src/**/*.ts'",
+    "prettier": "prettier --write '**/*.{ts,js,css,html}'",
     "test": "buidler test"
   },
   "dependencies": {
@@ -43,8 +44,7 @@
     "typescript": "^3.7.4",
     "web3": "^1.2.4"
   },
-  "prettier": {
-    "singleQuote": true,
-    "bracketSpacing": true
+  "devDependencies": {
+    "tslint-config-prettier": "^1.18.0"
   }
 }

--- a/packages/buidler/src/config.ts
+++ b/packages/buidler/src/config.ts
@@ -1,5 +1,5 @@
-import buidlerConfig from '../buidler.config';
-import { AragonConfig } from './types';
+import buidlerConfig from '../buidler.config'
+import { AragonConfig } from './types'
 
 /**
  * Tries to obtain values from buidler.config.ts or
@@ -7,12 +7,12 @@ import { AragonConfig } from './types';
  * @returns AragonConfig
  */
 export function getConfig(): AragonConfig {
-  const config = buidlerConfig.aragon;
+  const config = buidlerConfig.aragon
 
   return {
     appServePort: config.appServePort || 8001,
     clientServePort: config.clientServePort || 3000,
     appSrcPath: config.appSrcPath || 'app/',
-    appBuildOutputPath: config.appBuildOutputPath || 'dist/',
-  };
+    appBuildOutputPath: config.appBuildOutputPath || 'dist/'
+  }
 }

--- a/packages/buidler/src/tasks/start/start-task.ts
+++ b/packages/buidler/src/tasks/start/start-task.ts
@@ -9,8 +9,11 @@ import { deployImplementation } from './utils/backend/app';
 import { createProxy, updateProxy } from './utils/backend/proxy';
 import { createRepo, updateRepo } from './utils/backend/repo';
 import { setAllPermissionsOpenly } from './utils/backend/permissions';
-import { installAragonClientIfNeeded, startAragonClient } from './utils/frontend/client';
-import { buildAppFrontEnd, buildAppArtifacts, serveAppFrontEnd, watchAppFrontEnd } from './utils/frontend/build';
+import {
+  installAragonClientIfNeeded,
+  startAragonClient
+} from './utils/frontend/client';
+import { buildAppArtifacts, watchAppFrontEnd } from './utils/frontend/build';
 import { KernelInstance, RepoInstance } from '~/typechain';
 import { getAppId } from './utils/id';
 import { logBack } from './utils/logger';
@@ -91,12 +94,7 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
 async function startFrontend(daoAddress: string, appAddress: string): Promise<void> {
   await installAragonClientIfNeeded();
 
-  // Initial build.
-  await buildAppFrontEnd();
   await buildAppArtifacts();
-
-  // Serve app files.
-  serveAppFrontEnd();
 
   // Start Aragon client at the deployed address.
   const url: string = await startAragonClient(`${daoAddress}/${appAddress}`);

--- a/packages/buidler/src/tasks/start/start-task.ts
+++ b/packages/buidler/src/tasks/start/start-task.ts
@@ -17,6 +17,7 @@ import { buildAppArtifacts, watchAppFrontEnd } from './utils/frontend/build';
 import { KernelInstance, RepoInstance } from '~/typechain';
 import { getAppId } from './utils/id';
 import { logBack } from './utils/logger';
+import { readArapp } from './utils/arapp';
 
 /**
  * Main, composite, task. Calls startBackend, then startFrontend,
@@ -48,6 +49,9 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
 
   await bre.run(TASK_COMPILE);
 
+  // Read arapp.json
+  const arapp = readArapp();
+
   // Prepare a DAO and a Repo to hold the app.
   const dao: KernelInstance = await createDao();
   const repo: RepoInstance = await createRepo(appName, appId);
@@ -56,8 +60,7 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
   const implementation: Truffle.ContractInstance = await deployImplementation();
   const proxy: Truffle.ContractInstance = await createProxy(implementation, appId, dao);
   await updateRepo(repo, implementation);
-
-  await setAllPermissionsOpenly(dao, proxy);
+  await setAllPermissionsOpenly(dao, proxy, arapp);
 
   // Watch back-end files. Debounce for performance
   chokidar

--- a/packages/buidler/src/tasks/start/start-task.ts
+++ b/packages/buidler/src/tasks/start/start-task.ts
@@ -13,6 +13,7 @@ import { installAragonClientIfNeeded, startAragonClient } from './utils/frontend
 import { buildAppFrontEnd, buildAppArtifacts, serveAppFrontEnd, watchAppFrontEnd } from './utils/frontend/build';
 import { KernelInstance, RepoInstance } from '~/typechain';
 import { getAppId } from './utils/id';
+import { logBack } from './utils/logger';
 
 /**
  * Main, composite, task. Calls startBackend, then startFrontend,
@@ -70,11 +71,13 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
       await updateProxy(newImplementation, appId, dao);
     });
 
-  console.log(`App name: ${appName}`);
-  console.log(`App id: ${appId}`);
-  console.log(`DAO: ${dao.address}`);
-  console.log(`APMRegistry: ${repo.address}`);
-  console.log(`App proxy: ${proxy.address}`);
+  logBack(`
+  App name: ${appName}
+  App id: ${appId}
+  DAO: ${dao.address}
+  APMRegistry: ${repo.address}
+  App proxy: ${proxy.address}
+`);
 
   return { daoAddress: dao.address, appAddress: proxy.address };
 }

--- a/packages/buidler/src/tasks/start/start-task.ts
+++ b/packages/buidler/src/tasks/start/start-task.ts
@@ -1,23 +1,23 @@
-import path from 'path';
-import chokidar from 'chokidar';
-import { task } from '@nomiclabs/buidler/config';
-import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types';
-import { TruffleEnvironmentArtifacts } from '@nomiclabs/buidler-truffle5/src/artifacts';
-import { TASK_START, TASK_COMPILE } from '../task-names';
-import { createDao } from './utils/backend/dao';
-import { deployImplementation } from './utils/backend/app';
-import { createProxy, updateProxy } from './utils/backend/proxy';
-import { createRepo, updateRepo } from './utils/backend/repo';
-import { setAllPermissionsOpenly } from './utils/backend/permissions';
+import path from 'path'
+import chokidar from 'chokidar'
+import { task } from '@nomiclabs/buidler/config'
+import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
+import { TruffleEnvironmentArtifacts } from '@nomiclabs/buidler-truffle5/src/artifacts'
+import { TASK_START, TASK_COMPILE } from '../task-names'
+import { createDao } from './utils/backend/dao'
+import { deployImplementation } from './utils/backend/app'
+import { createProxy, updateProxy } from './utils/backend/proxy'
+import { createRepo, updateRepo } from './utils/backend/repo'
+import { setAllPermissionsOpenly } from './utils/backend/permissions'
 import {
   installAragonClientIfNeeded,
   startAragonClient
-} from './utils/frontend/client';
-import { buildAppArtifacts, watchAppFrontEnd } from './utils/frontend/build';
-import { KernelInstance, RepoInstance } from '~/typechain';
-import { getAppId } from './utils/id';
-import { logBack } from './utils/logger';
-import { readArapp } from './utils/arapp';
+} from './utils/frontend/client'
+import { buildAppArtifacts, watchAppFrontEnd } from './utils/frontend/build'
+import { KernelInstance, RepoInstance } from '~/typechain'
+import { getAppId } from './utils/id'
+import { logBack } from './utils/logger'
+import { readArapp } from './utils/arapp'
 
 /**
  * Main, composite, task. Calls startBackend, then startFrontend,
@@ -25,15 +25,15 @@ import { readArapp } from './utils/arapp';
  */
 task(TASK_START, 'Starts Aragon app development').setAction(
   async (params, bre: BuidlerRuntimeEnvironment) => {
-    console.log(`Starting...`);
+    console.log(`Starting...`)
 
-    const { daoAddress, appAddress }  = await startBackend(bre);
-    await startFrontend(daoAddress, appAddress);
+    const { daoAddress, appAddress } = await startBackend(bre)
+    await startFrontend(daoAddress, appAddress)
 
     // Unresolving promise to keep task open.
-    return new Promise(() => {});
-  },
-);
+    return new Promise(() => {})
+  }
+)
 
 /**
  * Starts the task's backend sub-tasks. Logic is contained in ./tasks/start/utils/backend/.
@@ -43,39 +43,45 @@ task(TASK_START, 'Starts Aragon app development').setAction(
  * @returns Promise<{ daoAddress: string, appAddress: string }> Dao and app address that can
  * be used with an Aragon client to view the app.
  */
-async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddress: string, appAddress: string }> {
-  const appName: string = 'counter';
-  const appId: string = getAppId(appName);
+async function startBackend(
+  bre: BuidlerRuntimeEnvironment
+): Promise<{ daoAddress: string; appAddress: string }> {
+  const appName: string = 'counter'
+  const appId: string = getAppId(appName)
 
-  await bre.run(TASK_COMPILE);
+  await bre.run(TASK_COMPILE)
 
   // Read arapp.json
-  const arapp = readArapp();
+  const arapp = readArapp()
 
   // Prepare a DAO and a Repo to hold the app.
-  const dao: KernelInstance = await createDao();
-  const repo: RepoInstance = await createRepo(appName, appId);
+  const dao: KernelInstance = await createDao()
+  const repo: RepoInstance = await createRepo(appName, appId)
 
   // Deploy first implementation and set it in the Repo and in a Proxy.
-  const implementation: Truffle.ContractInstance = await deployImplementation();
-  const proxy: Truffle.ContractInstance = await createProxy(implementation, appId, dao);
-  await updateRepo(repo, implementation);
-  await setAllPermissionsOpenly(dao, proxy, arapp);
+  const implementation: Truffle.ContractInstance = await deployImplementation()
+  const proxy: Truffle.ContractInstance = await createProxy(
+    implementation,
+    appId,
+    dao
+  )
+  await updateRepo(repo, implementation)
+  await setAllPermissionsOpenly(dao, proxy, arapp)
 
   // Watch back-end files. Debounce for performance
   chokidar
     .watch('./contracts/', {
-      awaitWriteFinish: { stabilityThreshold: 1000 },
+      awaitWriteFinish: { stabilityThreshold: 1000 }
     })
     .on('change', async () => {
-      console.log(`<<< Triggering backend build >>>`);
-      await bre.run(TASK_COMPILE);
+      console.log(`<<< Triggering backend build >>>`)
+      await bre.run(TASK_COMPILE)
 
       // Update implementation and set it in Repo and Proxy.
-      const newImplementation: Truffle.ContractInstance = await deployImplementation();
-      await updateRepo(repo, newImplementation);
-      await updateProxy(newImplementation, appId, dao);
-    });
+      const newImplementation: Truffle.ContractInstance = await deployImplementation()
+      await updateRepo(repo, newImplementation)
+      await updateProxy(newImplementation, appId, dao)
+    })
 
   logBack(`
   App name: ${appName}
@@ -83,9 +89,9 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
   DAO: ${dao.address}
   APMRegistry: ${repo.address}
   App proxy: ${proxy.address}
-`);
+`)
 
-  return { daoAddress: dao.address, appAddress: proxy.address };
+  return { daoAddress: dao.address, appAddress: proxy.address }
 }
 
 /**
@@ -94,17 +100,20 @@ async function startBackend(bre: BuidlerRuntimeEnvironment): Promise<{ daoAddres
  * Starts the Aragon client pointed at a Dao and an app, and watches for changes on the app's sources.
  * If changes are detected, the app's frontend is rebuilt.
  */
-async function startFrontend(daoAddress: string, appAddress: string): Promise<void> {
-  await installAragonClientIfNeeded();
+async function startFrontend(
+  daoAddress: string,
+  appAddress: string
+): Promise<void> {
+  await installAragonClientIfNeeded()
 
-  await buildAppArtifacts();
+  await buildAppArtifacts()
 
   // Start Aragon client at the deployed address.
-  const url: string = await startAragonClient(`${daoAddress}/${appAddress}`);
+  const url: string = await startAragonClient(`${daoAddress}/${appAddress}`)
   console.log(`You can now view the Aragon client in the browser.
  Local:  ${url}
-`);
+`)
 
   // Watch for changes to rebuild app.
-  await watchAppFrontEnd();
+  await watchAppFrontEnd()
 }

--- a/packages/buidler/src/tasks/start/utils/arapp.ts
+++ b/packages/buidler/src/tasks/start/utils/arapp.ts
@@ -1,18 +1,23 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { AragonAppJson } from '~/src/types';
+
+const arappPath: string = 'arapp.json';
+const contractsPath: string = './contracts';
+
+export function readArapp(): AragonAppJson {
+  return JSON.parse(fs.readFileSync(arappPath, 'utf-8'));
+}
 
 /**
  * Returns main contract path
  * @return "./contracts/Counter.sol"
  */
 export function getMainContractPath(): string {
-  const arappPath: string = 'arapp.json';
-  const contractsPath: string = './contracts';
-
   // Read the path from arapp.json.
   if (fs.existsSync(arappPath)) {
     const arapp: { path: string } = JSON.parse(
-      fs.readFileSync(arappPath, 'utf-8'),
+      fs.readFileSync(arappPath, 'utf-8')
     );
 
     return arapp.path;

--- a/packages/buidler/src/tasks/start/utils/arapp.ts
+++ b/packages/buidler/src/tasks/start/utils/arapp.ts
@@ -1,12 +1,12 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import { AragonAppJson } from '~/src/types';
+import * as fs from 'fs'
+import * as path from 'path'
+import { AragonAppJson } from '~/src/types'
 
-const arappPath: string = 'arapp.json';
-const contractsPath: string = './contracts';
+const arappPath: string = 'arapp.json'
+const contractsPath: string = './contracts'
 
 export function readArapp(): AragonAppJson {
-  return JSON.parse(fs.readFileSync(arappPath, 'utf-8'));
+  return JSON.parse(fs.readFileSync(arappPath, 'utf-8'))
 }
 
 /**
@@ -18,25 +18,25 @@ export function getMainContractPath(): string {
   if (fs.existsSync(arappPath)) {
     const arapp: { path: string } = JSON.parse(
       fs.readFileSync(arappPath, 'utf-8')
-    );
+    )
 
-    return arapp.path;
+    return arapp.path
   }
 
   // Try to guess contract path.
   if (fs.existsSync(contractsPath)) {
-    const contracts: string[] = fs.readdirSync(contractsPath);
+    const contracts: string[] = fs.readdirSync(contractsPath)
 
     const candidates: string[] = contracts.filter(
-      name => name.endsWith('.sol') || name !== 'Imports.sol',
-    );
+      name => name.endsWith('.sol') || name !== 'Imports.sol'
+    )
 
     if (candidates.length === 1) {
-      return path.join(contractsPath, candidates[0]);
+      return path.join(contractsPath, candidates[0])
     }
   }
 
-  throw Error(`Unable to find main contract path.`);
+  throw Error(`Unable to find main contract path.`)
 }
 
 /**
@@ -44,6 +44,6 @@ export function getMainContractPath(): string {
  * @return "Counter"
  */
 export function getMainContractName(): string {
-  const mainContractPath: string = getMainContractPath();
-  return path.parse(mainContractPath).name;
+  const mainContractPath: string = getMainContractPath()
+  return path.parse(mainContractPath).name
 }

--- a/packages/buidler/src/tasks/start/utils/backend/app.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/app.ts
@@ -1,16 +1,18 @@
-import { getMainContractName } from '../arapp';
+import { getMainContractName } from '../arapp'
 
 /**
  * Deploys the app's current contract.
  * @returns Promise<Truffle.Contract<any>> The deployed TruffleContract instance
  * for the app's main contract.
  */
-export async function deployImplementation(): Promise<Truffle.ContractInstance> {
-  const mainContractName: string = getMainContractName();
+export async function deployImplementation(): Promise<
+  Truffle.ContractInstance
+> {
+  const mainContractName: string = getMainContractName()
 
   // Deploy the main contract.
-  const App: Truffle.Contract<any> = artifacts.require(mainContractName);
-  const implementation: Truffle.ContractInstance = await App.new();
+  const App: Truffle.Contract<any> = artifacts.require(mainContractName)
+  const implementation: Truffle.ContractInstance = await App.new()
 
-  return implementation;
+  return implementation
 }

--- a/packages/buidler/src/tasks/start/utils/backend/dao.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/dao.ts
@@ -1,57 +1,69 @@
 import {
-  KernelContract, KernelInstance,
-  ACLContract, ACLInstance,
-  DAOFactoryContract, DAOFactoryInstance,
-  EVMScriptRegistryFactoryContract, EVMScriptRegistryFactoryInstance,
-} from '~/typechain';
+  KernelContract,
+  KernelInstance,
+  ACLContract,
+  ACLInstance,
+  DAOFactoryContract,
+  DAOFactoryInstance,
+  EVMScriptRegistryFactoryContract,
+  EVMScriptRegistryFactoryInstance
+} from '~/typechain'
 
 /**
  * Deploys a new DAO with direct/pure interaction with aragonOS.
  * @returns DAO's Kernel TruffleContract.
  */
 export async function createDao(): Promise<KernelInstance> {
-  const rootAccount: string = (await web3.eth.getAccounts())[0];
+  const rootAccount: string = (await web3.eth.getAccounts())[0]
 
   // Retrieve contract artifacts.
-  const Kernel: KernelContract = artifacts.require('Kernel');
-  const ACL: ACLContract = artifacts.require('ACL');
-  const DAOFactory: DAOFactoryContract = artifacts.require('DAOFactory');
-  const EVMScriptRegistryFactory: EVMScriptRegistryFactoryContract = artifacts.require('EVMScriptRegistryFactory');
+  const Kernel: KernelContract = artifacts.require('Kernel')
+  const ACL: ACLContract = artifacts.require('ACL')
+  const DAOFactory: DAOFactoryContract = artifacts.require('DAOFactory')
+  const EVMScriptRegistryFactory: EVMScriptRegistryFactoryContract = artifacts.require(
+    'EVMScriptRegistryFactory'
+  )
 
   // Deploy a DAOFactory.
-  const kernelBase: KernelInstance = await Kernel.new(true /*petrifyImmediately*/);
-  const aclBase: ACLInstance = await ACL.new();
-  const registryFactory: EVMScriptRegistryFactoryInstance = await EVMScriptRegistryFactory.new();
+  const kernelBase: KernelInstance = await Kernel.new(
+    true /*petrifyImmediately*/
+  )
+  const aclBase: ACLInstance = await ACL.new()
+  const registryFactory: EVMScriptRegistryFactoryInstance = await EVMScriptRegistryFactory.new()
   const daoFactory: DAOFactoryInstance = await DAOFactory.new(
     kernelBase.address,
     aclBase.address,
-    registryFactory.address,
-  );
+    registryFactory.address
+  )
 
   // Create a DAO instance using the factory.
-  const txResponse: Truffle.TransactionResponse = await daoFactory.newDAO(rootAccount);
+  const txResponse: Truffle.TransactionResponse = await daoFactory.newDAO(
+    rootAccount
+  )
 
   // Find the created DAO instance address from the transaction logs.
-  const logs: Truffle.TransactionLog[] = txResponse.logs;
-  const log: Truffle.TransactionLog | undefined = logs.find(l => l.event === 'DeployDAO');
+  const logs: Truffle.TransactionLog[] = txResponse.logs
+  const log: Truffle.TransactionLog | undefined = logs.find(
+    l => l.event === 'DeployDAO'
+  )
   if (!log) {
-    throw new Error('Error deploying new DAO. Unable to find DeployDAO log.');
+    throw new Error('Error deploying new DAO. Unable to find DeployDAO log.')
   }
-  const daoAddress: string = (log as Truffle.TransactionLog).args.dao;
+  const daoAddress: string = (log as Truffle.TransactionLog).args.dao
 
   // Use the DAO address to construct a full KernelInstance object.
-  const dao: KernelInstance = await Kernel.at(daoAddress);
+  const dao: KernelInstance = await Kernel.at(daoAddress)
 
   // Give rootAccount the ability to manage apps.
-  const aclAddress: string = await dao.acl();
-  const acl: ACLInstance = await ACL.at(aclAddress);
+  const aclAddress: string = await dao.acl()
+  const acl: ACLInstance = await ACL.at(aclAddress)
   await acl.createPermission(
     rootAccount,
     dao.address,
     await dao.APP_MANAGER_ROLE(),
     rootAccount,
-    { from: rootAccount },
-  );
+    { from: rootAccount }
+  )
 
-  return dao;
+  return dao
 }

--- a/packages/buidler/src/tasks/start/utils/backend/permissions.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/permissions.ts
@@ -1,8 +1,8 @@
-import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types';
-import { KernelInstance, ACLInstance } from '~/typechain';
-import { AragonAppJson } from '~/src/types';
+import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types'
+import { KernelInstance, ACLInstance } from '~/typechain'
+import { AragonAppJson } from '~/src/types'
 
-export const ANY_ADDRESS: string = '0xffffffffffffffffffffffffffffffffffffffff';
+export const ANY_ADDRESS: string = '0xffffffffffffffffffffffffffffffffffffffff'
 
 /**
  * Scans arapp.json, setting all permissions to ANY_ADDRESS.
@@ -12,15 +12,15 @@ export async function setAllPermissionsOpenly(
   app: any, // TODO: needs type
   arapp: AragonAppJson
 ): Promise<void> {
-  const rootAccount: string = (await web3.eth.getAccounts())[0];
+  const rootAccount: string = (await web3.eth.getAccounts())[0]
 
   // Retrieve ACL.
-  const aclAddress = await dao.acl();
-  const ACL = artifacts.require('ACL');
-  const acl = await ACL.at(aclAddress);
+  const aclAddress = await dao.acl()
+  const ACL = artifacts.require('ACL')
+  const acl = await ACL.at(aclAddress)
 
   for (const role of arapp.roles) {
-    const permission = await app[role.id]();
+    const permission = await app[role.id]()
     // Set permission to ANY_ADDRESS (max uint256), which is interpreted by
     // the ACL as giving such permission to all addresses.
     await acl.createPermission(
@@ -29,6 +29,6 @@ export async function setAllPermissionsOpenly(
       permission,
       rootAccount,
       { from: rootAccount }
-    );
+    )
   }
 }

--- a/packages/buidler/src/tasks/start/utils/backend/permissions.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/permissions.ts
@@ -1,5 +1,6 @@
 import { BuidlerRuntimeEnvironment } from '@nomiclabs/buidler/types';
 import { KernelInstance, ACLInstance } from '~/typechain';
+import { AragonAppJson } from '~/src/types';
 
 export const ANY_ADDRESS: string = '0xffffffffffffffffffffffffffffffffffffffff';
 
@@ -9,6 +10,7 @@ export const ANY_ADDRESS: string = '0xffffffffffffffffffffffffffffffffffffffff';
 export async function setAllPermissionsOpenly(
   dao: KernelInstance,
   app: any, // TODO: needs type
+  arapp: AragonAppJson
 ): Promise<void> {
   const rootAccount: string = (await web3.eth.getAccounts())[0];
 
@@ -17,28 +19,16 @@ export async function setAllPermissionsOpenly(
   const ACL = artifacts.require('ACL');
   const acl = await ACL.at(aclAddress);
 
-  // Set all permissions listed in arapp.json.
-  // TODO: Must be set dynamically.
-  await _setPermissionOpenly(acl, app, await app.INCREMENT_ROLE(), rootAccount);
-  await _setPermissionOpenly(acl, app, await app.DECREMENT_ROLE(), rootAccount);
-}
-
-/**
- * Set's the specified permission to ANY_ADDRESS.
- */
-async function _setPermissionOpenly(
-  acl: ACLInstance,
-  app: any, // TODO: needs type
-  permission: string,
-  rootAccount: string,
-) {
-  // Set permission to ANY_ADDRESS (max uint256), which is interpreted by
-  // the ACL as giving such permission to all addresses.
-  await acl.createPermission(
-    ANY_ADDRESS,
-    app.address,
-    permission,
-    rootAccount,
-    { from: rootAccount },
-  );
+  for (const role of arapp.roles) {
+    const permission = await app[role.id]();
+    // Set permission to ANY_ADDRESS (max uint256), which is interpreted by
+    // the ACL as giving such permission to all addresses.
+    await acl.createPermission(
+      ANY_ADDRESS,
+      app.address,
+      permission,
+      rootAccount,
+      { from: rootAccount }
+    );
+  }
 }

--- a/packages/buidler/src/tasks/start/utils/backend/proxy.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/proxy.ts
@@ -1,12 +1,13 @@
-import { getMainContractName } from '../arapp';
-import { KernelInstance } from '~/typechain';
-import { logBack } from '../logger';
+import { getMainContractName } from '../arapp'
+import { KernelInstance } from '~/typechain'
+import { logBack } from '../logger'
 
 interface InitializableApp extends Truffle.ContractInstance {
-  initialize: () => void;
+  initialize: () => void
 }
 
-const BASE_NAMESPACE: string = '0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f';
+const BASE_NAMESPACE: string =
+  '0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1fd01786bc26f35ac0f'
 
 /**
  * Creates a new app proxy using a Dao, and set's the specified implementation.
@@ -16,9 +17,9 @@ const BASE_NAMESPACE: string = '0xf1f3eb40f5bc1ad1344716ced8b8a0431d840b5783aea1
 export async function createProxy(
   implementation: Truffle.ContractInstance,
   appId: string,
-  dao: KernelInstance,
+  dao: KernelInstance
 ): Promise<Truffle.ContractInstance> {
-  const rootAccount: string = (await web3.eth.getAccounts())[0];
+  const rootAccount: string = (await web3.eth.getAccounts())[0]
 
   // Create a new app proxy with base implementation.
   const txResponse: Truffle.TransactionResponse = await dao.newAppInstance(
@@ -26,24 +27,28 @@ export async function createProxy(
     implementation.address,
     '0x',
     false,
-    { from: rootAccount },
-  );
+    { from: rootAccount }
+  )
 
   // Retrieve proxy address and wrap around abi.
-  const mainContractName: string = getMainContractName();
-  const App: Truffle.Contract<any> = artifacts.require(mainContractName);
-  const logs: Truffle.TransactionLog[] = txResponse.logs;
-  const log: Truffle.TransactionLog | undefined = logs.find(l => l.event === 'NewAppProxy');
+  const mainContractName: string = getMainContractName()
+  const App: Truffle.Contract<any> = artifacts.require(mainContractName)
+  const logs: Truffle.TransactionLog[] = txResponse.logs
+  const log: Truffle.TransactionLog | undefined = logs.find(
+    l => l.event === 'NewAppProxy'
+  )
   if (!log) {
-    throw new Error('Cannot find proxy address. Unable to find NewAppProxy log.');
+    throw new Error(
+      'Cannot find proxy address. Unable to find NewAppProxy log.'
+    )
   }
-  const proxyAddress: string = (log as Truffle.TransactionLog).args.proxy;
-  const proxy: InitializableApp = await App.at(proxyAddress);
+  const proxyAddress: string = (log as Truffle.TransactionLog).args.proxy
+  const proxy: InitializableApp = await App.at(proxyAddress)
 
   // Initialize the app.
-  await proxy.initialize();
+  await proxy.initialize()
 
-  return proxy;
+  return proxy
 }
 
 /**
@@ -52,12 +57,14 @@ export async function createProxy(
 export async function updateProxy(
   implementation: Truffle.ContractInstance,
   appId: string,
-  dao: KernelInstance,
+  dao: KernelInstance
 ): Promise<void> {
-  const rootAccount: string = (await web3.eth.getAccounts())[0];
+  const rootAccount: string = (await web3.eth.getAccounts())[0]
 
-  logBack(`Updating proxy implementation to: ${implementation.address}`);
+  logBack(`Updating proxy implementation to: ${implementation.address}`)
 
   // Set the new implementation in the Kernel.
-  await dao.setApp(BASE_NAMESPACE, appId, implementation.address, { from: rootAccount });
+  await dao.setApp(BASE_NAMESPACE, appId, implementation.address, {
+    from: rootAccount
+  })
 }

--- a/packages/buidler/src/tasks/start/utils/backend/proxy.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/proxy.ts
@@ -1,5 +1,6 @@
 import { getMainContractName } from '../arapp';
 import { KernelInstance } from '~/typechain';
+import { logBack } from '../logger';
 
 interface InitializableApp extends Truffle.ContractInstance {
   initialize: () => void;
@@ -55,7 +56,7 @@ export async function updateProxy(
 ): Promise<void> {
   const rootAccount: string = (await web3.eth.getAccounts())[0];
 
-  console.log(`Updating proxy implementation to: ${implementation.address}`);
+  logBack(`Updating proxy implementation to: ${implementation.address}`);
 
   // Set the new implementation in the Kernel.
   await dao.setApp(BASE_NAMESPACE, appId, implementation.address, { from: rootAccount });

--- a/packages/buidler/src/tasks/start/utils/backend/repo.ts
+++ b/packages/buidler/src/tasks/start/utils/backend/repo.ts
@@ -1,5 +1,5 @@
 import ENS from 'ethjs-ens';
-import { provider } from 'web3-core';
+import { Providers } from 'web3-core';
 import {
   RepoContract, RepoInstance,
   APMRegistryContract, APMRegistryInstance,
@@ -14,7 +14,10 @@ const APM_REGISTRY_ADDRESS: string = '0x32296d9f8fed89658668875dc73cacf87e8888b2
  * find one, creates a new repository for the app.
  * @returns Promise<RepoInstance> An APM repository for the app.
  */
-export async function createRepo(appName: string, appId: string): Promise<RepoInstance> {
+export async function createRepo(
+  appName: string,
+  appId: string
+): Promise<RepoInstance> {
   // Retrieve the Repo address from ens, or create the Repo if nothing is retrieved.
   let repoAddress: string | null = await _ensResolve(appId).catch(() => null);
   if (!repoAddress) {
@@ -83,7 +86,7 @@ async function _createRepo(appName: string): Promise<string> {
 async function _ensResolve(appId: string): Promise<string> {
   // Define options used by ENS.
   const opts: {
-    provider: provider,
+    provider: any;
     registryAddress: string,
   } = {
     provider: web3.currentProvider,

--- a/packages/buidler/src/tasks/start/utils/execa.ts
+++ b/packages/buidler/src/tasks/start/utils/execa.ts
@@ -1,17 +1,20 @@
 import execa from 'execa';
+import stream from 'stream';
+import util from 'util';
 
-/**
+/*
  * Note: This file should be split up as it grows
  * TODO: We shouldn't encourage monolithic utils files. Every util should be its own file.
  */
 
 /**
- * execa wrapper that pipes stdout and stderr to the parent process
+ * execa wrapper
+ * Pipes stdout and stderr to the parent process
  */
 export function execaPipe(
   file: string,
   args?: readonly string[],
-  options?: execa.Options,
+  options?: execa.Options
 ): execa.ExecaChildProcess {
   const subprocess: execa.ExecaChildProcess = execa(file, args, options);
 
@@ -23,4 +26,32 @@ export function execaPipe(
   }
 
   return subprocess;
+}
+
+/**
+ * execa wrapper
+ * Calls a logger on all stdout and stderr data events
+ */
+export function execaLogTo(logger: (data: string) => void) {
+  return (
+    file: string,
+    args: readonly string[],
+    options?: execa.Options
+  ): execa.ExecaChildProcess => {
+    const subprocess: execa.ExecaChildProcess = execa(file, args, options);
+
+    function dataCallback(bytes: any): void {
+      const data = Buffer.from(bytes, 'utf-8').toString();
+      logger(data);
+    }
+
+    if (subprocess.stdout) {
+      subprocess.stdout.on('data', dataCallback);
+    }
+    if (subprocess.stderr) {
+      subprocess.stderr.on('data', dataCallback);
+    }
+
+    return subprocess;
+  };
 }

--- a/packages/buidler/src/tasks/start/utils/execa.ts
+++ b/packages/buidler/src/tasks/start/utils/execa.ts
@@ -1,6 +1,6 @@
-import execa from 'execa';
-import stream from 'stream';
-import util from 'util';
+import execa from 'execa'
+import stream from 'stream'
+import util from 'util'
 
 /*
  * Note: This file should be split up as it grows
@@ -16,16 +16,16 @@ export function execaPipe(
   args?: readonly string[],
   options?: execa.Options
 ): execa.ExecaChildProcess {
-  const subprocess: execa.ExecaChildProcess = execa(file, args, options);
+  const subprocess: execa.ExecaChildProcess = execa(file, args, options)
 
   if (subprocess.stdout) {
-    subprocess.stdout.pipe(process.stdout);
+    subprocess.stdout.pipe(process.stdout)
   }
   if (subprocess.stderr) {
-    subprocess.stderr.pipe(process.stderr);
+    subprocess.stderr.pipe(process.stderr)
   }
 
-  return subprocess;
+  return subprocess
 }
 
 /**
@@ -38,20 +38,20 @@ export function execaLogTo(logger: (data: string) => void) {
     args: readonly string[],
     options?: execa.Options
   ): execa.ExecaChildProcess => {
-    const subprocess: execa.ExecaChildProcess = execa(file, args, options);
+    const subprocess: execa.ExecaChildProcess = execa(file, args, options)
 
     function dataCallback(bytes: any): void {
-      const data = Buffer.from(bytes, 'utf-8').toString();
-      logger(data);
+      const data = Buffer.from(bytes, 'utf-8').toString()
+      logger(data)
     }
 
     if (subprocess.stdout) {
-      subprocess.stdout.on('data', dataCallback);
+      subprocess.stdout.on('data', dataCallback)
     }
     if (subprocess.stderr) {
-      subprocess.stderr.on('data', dataCallback);
+      subprocess.stderr.on('data', dataCallback)
     }
 
-    return subprocess;
-  };
+    return subprocess
+  }
 }

--- a/packages/buidler/src/tasks/start/utils/frontend/build.ts
+++ b/packages/buidler/src/tasks/start/utils/frontend/build.ts
@@ -1,20 +1,20 @@
-import path from 'path';
-import fsExtra from 'fs-extra';
-import { execaLogTo } from '../execa';
-import { logFront } from '../logger';
-import { getConfig } from '~/src/config';
+import path from 'path'
+import fsExtra from 'fs-extra'
+import { execaLogTo } from '../execa'
+import { logFront } from '../logger'
+import { getConfig } from '~/src/config'
 
-export const manifestPath = 'manifest.json';
-export const artifactPath = 'artifact.json';
-export const arappPath = 'arapp.json';
+export const manifestPath = 'manifest.json'
+export const artifactPath = 'artifact.json'
+export const arappPath = 'arapp.json'
 
-const execa = execaLogTo(logFront);
+const execa = execaLogTo(logFront)
 
 /**
  * Watches the front-end with the customizable npm run script of the app
  */
 export async function watchAppFrontEnd(): Promise<void> {
-  await execa('npm', ['run', 'watch'], { cwd: getConfig().appSrcPath });
+  await execa('npm', ['run', 'watch'], { cwd: getConfig().appSrcPath })
 }
 
 /**
@@ -27,6 +27,6 @@ export async function buildAppArtifacts(): Promise<void> {
     await fsExtra.copy(
       filePath,
       path.join(getConfig().appBuildOutputPath as string, filePath)
-    );
+    )
   }
 }

--- a/packages/buidler/src/tasks/start/utils/frontend/build.ts
+++ b/packages/buidler/src/tasks/start/utils/frontend/build.ts
@@ -1,9 +1,6 @@
 import path from 'path';
-import fs from 'fs';
 import fsExtra from 'fs-extra';
-import liveServer from 'live-server';
-import { AragonConfig } from '~/src/types';
-import { execaPipe, execaLogTo } from '../execa';
+import { execaLogTo } from '../execa';
 import { logFront } from '../logger';
 import { getConfig } from '~/src/config';
 
@@ -14,29 +11,10 @@ export const arappPath = 'arapp.json';
 const execa = execaLogTo(logFront);
 
 /**
- * Builds the front-end with the customizable npm run script of the app
- */
-export async function buildAppFrontEnd(): Promise<void> {
-  await execa('npm', ['run', 'build'], { cwd: getConfig().appSrcPath });
-}
-
-/**
  * Watches the front-end with the customizable npm run script of the app
  */
 export async function watchAppFrontEnd(): Promise<void> {
   await execa('npm', ['run', 'watch'], { cwd: getConfig().appSrcPath });
-}
-
-export function serveAppFrontEnd(): void {
-  const config: AragonConfig = getConfig();
-
-  liveServer.start({
-    port: config.appServePort,
-    root: config.appBuildOutputPath,
-    open: false,
-    wait: 1000,
-    cors: true,
-  });
 }
 
 /**
@@ -46,6 +24,9 @@ export function serveAppFrontEnd(): void {
  */
 export async function buildAppArtifacts(): Promise<void> {
   for (const filePath of [manifestPath, artifactPath]) {
-    await fsExtra.copy(filePath, path.join(getConfig().appBuildOutputPath as string, filePath));
+    await fsExtra.copy(
+      filePath,
+      path.join(getConfig().appBuildOutputPath as string, filePath)
+    );
   }
 }

--- a/packages/buidler/src/tasks/start/utils/frontend/build.ts
+++ b/packages/buidler/src/tasks/start/utils/frontend/build.ts
@@ -3,25 +3,28 @@ import fs from 'fs';
 import fsExtra from 'fs-extra';
 import liveServer from 'live-server';
 import { AragonConfig } from '~/src/types';
-import { execaPipe } from '../execa';
+import { execaPipe, execaLogTo } from '../execa';
+import { logFront } from '../logger';
 import { getConfig } from '~/src/config';
 
 export const manifestPath = 'manifest.json';
 export const artifactPath = 'artifact.json';
 export const arappPath = 'arapp.json';
 
+const execa = execaLogTo(logFront);
+
 /**
  * Builds the front-end with the customizable npm run script of the app
  */
 export async function buildAppFrontEnd(): Promise<void> {
-  await execaPipe('npm', ['run', 'build'], { cwd: getConfig().appSrcPath });
+  await execa('npm', ['run', 'build'], { cwd: getConfig().appSrcPath });
 }
 
 /**
  * Watches the front-end with the customizable npm run script of the app
  */
 export async function watchAppFrontEnd(): Promise<void> {
-  await execaPipe('npm', ['run', 'watch'], { cwd: getConfig().appSrcPath });
+  await execa('npm', ['run', 'watch'], { cwd: getConfig().appSrcPath });
 }
 
 export function serveAppFrontEnd(): void {

--- a/packages/buidler/src/tasks/start/utils/frontend/client.ts
+++ b/packages/buidler/src/tasks/start/utils/frontend/client.ts
@@ -1,40 +1,40 @@
-import path from 'path';
-import fs from 'fs';
-import fsExtra from 'fs-extra';
-import os from 'os';
-import open from 'open';
-import { createStaticWebserver } from './webserver';
-import { execaPipe, execaLogTo } from '../execa';
-import { logFront } from '../logger';
-import { getConfig } from '~/src/config';
+import path from 'path'
+import fs from 'fs'
+import fsExtra from 'fs-extra'
+import os from 'os'
+import open from 'open'
+import { createStaticWebserver } from './webserver'
+import { execaPipe, execaLogTo } from '../execa'
+import { logFront } from '../logger'
+import { getConfig } from '~/src/config'
 
-const defaultRepo: string = 'https://github.com/aragon/aragon';
-const defaultVersion: string = '775edd606333a111eb2693df53900039722a95dc';
-const aragonBaseDir: string = path.join(os.homedir(), '.aragon');
+const defaultRepo: string = 'https://github.com/aragon/aragon'
+const defaultVersion: string = '775edd606333a111eb2693df53900039722a95dc'
+const aragonBaseDir: string = path.join(os.homedir(), '.aragon')
 
-const execa = execaLogTo(logFront);
+const execa = execaLogTo(logFront)
 
 export async function installAragonClientIfNeeded(
   repo: string = defaultRepo,
-  version: string = defaultVersion,
+  version: string = defaultVersion
 ): Promise<string> {
   // Determine client path.
-  const clientPath: string = _getClientPath(version);
+  const clientPath: string = _getClientPath(version)
 
   // Verify installation or install if needed.
   if (fs.existsSync(path.resolve(clientPath))) {
-    logFront('Using cached client version');
+    logFront('Using cached client version')
   } else {
-    fsExtra.ensureDirSync(clientPath, { recursive: true });
-    logFront(`Installing client version ${version} locally`);
-    const opts = { cwd: clientPath };
-    await execa('git', ['clone', '--', repo, clientPath]);
-    await execa('git', ['checkout', version], opts);
-    await execa('npm', ['install'], opts);
-    await execa('npm', ['run', 'build:local'], opts);
+    fsExtra.ensureDirSync(clientPath, { recursive: true })
+    logFront(`Installing client version ${version} locally`)
+    const opts = { cwd: clientPath }
+    await execa('git', ['clone', '--', repo, clientPath])
+    await execa('git', ['checkout', version], opts)
+    await execa('npm', ['install'], opts)
+    await execa('npm', ['run', 'build:local'], opts)
   }
 
-  return clientPath;
+  return clientPath
 }
 
 /**
@@ -45,23 +45,23 @@ export async function startAragonClient(
   subPath?: string,
   repo: string = defaultRepo,
   version: string = defaultVersion,
-  autoOpen: boolean = true,
+  autoOpen: boolean = true
 ): Promise<string> {
-  const port: number = getConfig().clientServePort as number;
-  const clientPath: string = _getClientPath(version);
+  const port: number = getConfig().clientServePort as number
+  const clientPath: string = _getClientPath(version)
 
-  logFront(`Starting client server at port ${port}`);
-  await createStaticWebserver(port, path.join(clientPath, 'build'));
+  logFront(`Starting client server at port ${port}`)
+  await createStaticWebserver(port, path.join(clientPath, 'build'))
 
-  const url = `http://localhost:${port}/#/${subPath}`;
+  const url = `http://localhost:${port}/#/${subPath}`
 
   if (autoOpen) {
-    await open(url);
+    await open(url)
   }
 
-  return url;
+  return url
 }
 
 function _getClientPath(version: string): string {
-  return path.join(aragonBaseDir, `client-${version}`);
+  return path.join(aragonBaseDir, `client-${version}`)
 }

--- a/packages/buidler/src/tasks/start/utils/frontend/webserver.ts
+++ b/packages/buidler/src/tasks/start/utils/frontend/webserver.ts
@@ -1,7 +1,7 @@
-import http from 'http';
-import url from 'url';
-import fs from 'fs';
-import path from 'path';
+import http from 'http'
+import url from 'url'
+import fs from 'fs'
+import path from 'path'
 
 // maps file extention to MIME typere
 const map: { [ext: string]: string } = {
@@ -16,8 +16,8 @@ const map: { [ext: string]: string } = {
   '.mp3': 'audio/mpeg',
   '.svg': 'image/svg+xml',
   '.pdf': 'application/pdf',
-  '.doc': 'application/msword',
-};
+  '.doc': 'application/msword'
+}
 
 /**
  * Creates a static files HTTP server
@@ -28,45 +28,45 @@ const map: { [ext: string]: string } = {
  */
 export function createStaticWebserver(
   port: number,
-  rootPath = '.',
+  rootPath = '.'
 ): Promise<void> {
   return new Promise(resolve => {
     http
       .createServer((req, res) => {
         // parse URL
-        const parsedUrl = url.parse(req.url || '');
+        const parsedUrl = url.parse(req.url || '')
         // extract URL path
-        const pathname = path.join(rootPath, parsedUrl.pathname || '');
+        const pathname = path.join(rootPath, parsedUrl.pathname || '')
         // based on the URL path, extract the file extention. e.g. .js, .doc, ...
-        const ext = path.parse(pathname).ext || '.html';
+        const ext = path.parse(pathname).ext || '.html'
 
         fs.exists(pathname, exist => {
           if (!exist) {
             // if the file is not found, return 404
-            res.statusCode = 404;
-            return res.end(`File ${pathname} not found!`);
+            res.statusCode = 404
+            return res.end(`File ${pathname} not found!`)
           }
 
           // if is a directory search for index file matching the extention
           const filepath = fs.statSync(pathname).isDirectory()
             ? path.join(pathname, 'index' + ext)
-            : pathname;
+            : pathname
 
           // read file from file system
           fs.readFile(filepath, (err, data) => {
             if (err) {
-              res.statusCode = 500;
-              res.end(`Error getting the file: ${err}.`);
+              res.statusCode = 500
+              res.end(`Error getting the file: ${err}.`)
             } else {
               // if the file is found, set Content-type and send data
-              res.setHeader('Content-type', map[ext] || 'text/plain');
-              res.end(data);
+              res.setHeader('Content-type', map[ext] || 'text/plain')
+              res.end(data)
             }
-          });
-        });
+          })
+        })
       })
       .listen(port, () => {
-        resolve();
-      });
-  });
+        resolve()
+      })
+  })
 }

--- a/packages/buidler/src/tasks/start/utils/id.ts
+++ b/packages/buidler/src/tasks/start/utils/id.ts
@@ -1,5 +1,8 @@
-import namehash from 'eth-ens-namehash';
+import namehash from 'eth-ens-namehash'
 
-export function getAppId(name: string, domain: string = 'aragonpm.eth'): string {
-  return namehash.hash(`${name}.${domain}`);
+export function getAppId(
+  name: string,
+  domain: string = 'aragonpm.eth'
+): string {
+  return namehash.hash(`${name}.${domain}`)
 }

--- a/packages/buidler/src/tasks/start/utils/logger.ts
+++ b/packages/buidler/src/tasks/start/utils/logger.ts
@@ -1,19 +1,19 @@
-import chalk from 'chalk';
+import chalk from 'chalk'
 
-const frontTag = chalk.yellow('front | ');
-const backTag = chalk.blue('back  | ');
+const frontTag = chalk.yellow('front | ')
+const backTag = chalk.blue('back  | ')
 
 function prependTag(lines: string, tag: string): string {
   return lines
     .split('\n')
     .map(line => tag + line)
-    .join('\n');
+    .join('\n')
 }
 
 export function logFront(data: string) {
-  console.log(prependTag(data, frontTag));
+  console.log(prependTag(data, frontTag))
 }
 
 export function logBack(data: string) {
-  console.log(prependTag(data, backTag));
+  console.log(prependTag(data, backTag))
 }

--- a/packages/buidler/src/tasks/start/utils/logger.ts
+++ b/packages/buidler/src/tasks/start/utils/logger.ts
@@ -1,0 +1,19 @@
+import chalk from 'chalk';
+
+const frontTag = chalk.yellow('front | ');
+const backTag = chalk.blue('back  | ');
+
+function prependTag(lines: string, tag: string): string {
+  return lines
+    .split('\n')
+    .map(line => tag + line)
+    .join('\n');
+}
+
+export function logFront(data: string) {
+  console.log(prependTag(data, frontTag));
+}
+
+export function logBack(data: string) {
+  console.log(prependTag(data, backTag));
+}

--- a/packages/buidler/src/tasks/task-names.ts
+++ b/packages/buidler/src/tasks/task-names.ts
@@ -1,6 +1,7 @@
 // Aragon plugin tasks.
-export const TASK_START: string = 'start';
+export const TASK_START: string = 'start'
 
 // Buidler built-in tasks.
-export const TASK_COMPILE: string = 'compile';
-export const TASK_FLATTEN_GET_FLATTENED_SOURCE: string = 'flatten:get-flattened-sources';
+export const TASK_COMPILE: string = 'compile'
+export const TASK_FLATTEN_GET_FLATTENED_SOURCE: string =
+  'flatten:get-flattened-sources'

--- a/packages/buidler/src/types.ts
+++ b/packages/buidler/src/types.ts
@@ -1,33 +1,33 @@
 export interface AragonConfig {
-  appServePort?: number;
-  clientServePort?: number;
-  appSrcPath?: string;
-  appBuildOutputPath?: string;
+  appServePort?: number
+  clientServePort?: number
+  appSrcPath?: string
+  appBuildOutputPath?: string
 }
 
 /**
  * arapp.json
  */
 export interface AragonAppJson {
-  roles: Role[];
-  environment: AragonEnvironments;
-  path: string;
+  roles: Role[]
+  environment: AragonEnvironments
+  path: string
 }
 
 interface Role {
-  name: string;
-  id: string;
-  params: any[];
-  bytes: string;
+  name: string
+  id: string
+  params: string[]
+  bytes: string
 }
 
 interface AragonEnvironments {
-  [environmentName: string]: AragonEnvironment;
+  [environmentName: string]: AragonEnvironment
 }
 
 interface AragonEnvironment {
-  network: string;
-  appName: string;
-  registry: string;
-  wsRPC: string;
+  network: string
+  appName: string
+  registry: string
+  wsRPC: string
 }

--- a/packages/buidler/src/types.ts
+++ b/packages/buidler/src/types.ts
@@ -4,3 +4,30 @@ export interface AragonConfig {
   appSrcPath?: string;
   appBuildOutputPath?: string;
 }
+
+/**
+ * arapp.json
+ */
+export interface AragonAppJson {
+  roles: Role[];
+  environment: AragonEnvironments;
+  path: string;
+}
+
+interface Role {
+  name: string;
+  id: string;
+  params: any[];
+  bytes: string;
+}
+
+interface AragonEnvironments {
+  [environmentName: string]: AragonEnvironment;
+}
+
+interface AragonEnvironment {
+  network: string;
+  appName: string;
+  registry: string;
+  wsRPC: string;
+}

--- a/packages/buidler/test/config.test.ts
+++ b/packages/buidler/test/config.test.ts
@@ -1,8 +1,8 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('config.ts', () => {
   // TODO: Make sure to test values not specified in buidler.config.ts falling back to their defauls
   // specified in config.ts.
 
-  it.skip('more tests needed');
-});
+  it.skip('more tests needed')
+})

--- a/packages/buidler/test/tasks/start/utils/arapp.test.ts
+++ b/packages/buidler/test/tasks/start/utils/arapp.test.ts
@@ -1,12 +1,19 @@
-import { assert } from 'chai';
-import { getMainContractName, getMainContractPath } from '~/src/tasks/start/utils/arapp';
+import { assert } from 'chai'
+import {
+  getMainContractName,
+  getMainContractPath
+} from '~/src/tasks/start/utils/arapp'
 
 describe('arapp.ts', () => {
   it('should retrieve the correct main contract path', () => {
-    assert.equal(getMainContractPath(), 'contracts/Counter.sol', 'Incorrect main contract path.');
-  });
+    assert.equal(
+      getMainContractPath(),
+      'contracts/Counter.sol',
+      'Incorrect main contract path.'
+    )
+  })
 
   it('should retrieve the correct main contract name', () => {
-    assert.equal(getMainContractName(), 'Counter');
-  });
-});
+    assert.equal(getMainContractName(), 'Counter')
+  })
+})

--- a/packages/buidler/test/tasks/start/utils/backend/app.test.ts
+++ b/packages/buidler/test/tasks/start/utils/backend/app.test.ts
@@ -1,17 +1,21 @@
-import { assert } from 'chai';
-import { isAddress } from '~/test/test-helpers/isAddress';
-import { deployImplementation } from '~/src/tasks/start/utils/backend/app';
+import { assert } from 'chai'
+import { isAddress } from '~/test/test-helpers/isAddress'
+import { deployImplementation } from '~/src/tasks/start/utils/backend/app'
 
 describe('app.ts', () => {
   describe('when deploying an implementation of an app', () => {
-    let implementation: Truffle.ContractInstance;
+    let implementation: Truffle.ContractInstance
 
     before('deploy an implementation of an app', async () => {
-      implementation = await deployImplementation();
-    });
+      implementation = await deployImplementation()
+    })
 
     it('deploys a contract with a valid address', async () => {
-      assert.equal(isAddress(implementation.address), true, 'Invalid contract address.');
-    });
-  });
-});
+      assert.equal(
+        isAddress(implementation.address),
+        true,
+        'Invalid contract address.'
+      )
+    })
+  })
+})

--- a/packages/buidler/test/tasks/start/utils/backend/dao.test.ts
+++ b/packages/buidler/test/tasks/start/utils/backend/dao.test.ts
@@ -1,28 +1,28 @@
-import { assert } from 'chai';
-import { createDao } from '~/src/tasks/start/utils/backend/dao';
-import { isAddress } from '~/test/test-helpers/isAddress';
-import { KernelInstance } from '~/typechain';
+import { assert } from 'chai'
+import { createDao } from '~/src/tasks/start/utils/backend/dao'
+import { isAddress } from '~/test/test-helpers/isAddress'
+import { KernelInstance } from '~/typechain'
 
 describe('dao.ts', () => {
   describe('when a dao is created', () => {
-    let dao: KernelInstance;
+    let dao: KernelInstance
 
     before('create a dao', async () => {
-      dao = await createDao();
-    });
+      dao = await createDao()
+    })
 
     it('deploys a dao with a valid address', () => {
-      assert.equal(isAddress(dao.address), true, 'Invalid contract address.');
-    });
+      assert.equal(isAddress(dao.address), true, 'Invalid contract address.')
+    })
 
     it('has a valid ACL', async () => {
-      assert.equal(isAddress(await dao.acl()), true, 'Invalid acl address.');
-    });
+      assert.equal(isAddress(await dao.acl()), true, 'Invalid acl address.')
+    })
 
     it('has been initialized', async () => {
-      assert.equal(await dao.hasInitialized(), true, 'DAO not initialized.');
-    });
-  });
+      assert.equal(await dao.hasInitialized(), true, 'DAO not initialized.')
+    })
+  })
 
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/tasks/start/utils/backend/permissions.test.ts
+++ b/packages/buidler/test/tasks/start/utils/backend/permissions.test.ts
@@ -1,46 +1,62 @@
-import { assert } from 'chai';
-import { createDao } from '~/src/tasks/start/utils/backend/dao';
-import { deployImplementation } from '~/src/tasks/start/utils/backend/app';
-import { createProxy } from '~/src/tasks/start/utils/backend/proxy';
-import { setAllPermissionsOpenly, ANY_ADDRESS } from '~/src/tasks/start/utils/backend/permissions';
-import { KernelInstance, ACLContract, ACLInstance, CounterInstance } from '~/typechain';
-import { getAppId } from '~/src/tasks/start/utils/id';
+import { assert } from 'chai'
+import { createDao } from '~/src/tasks/start/utils/backend/dao'
+import { deployImplementation } from '~/src/tasks/start/utils/backend/app'
+import { createProxy } from '~/src/tasks/start/utils/backend/proxy'
+import {
+  setAllPermissionsOpenly,
+  ANY_ADDRESS
+} from '~/src/tasks/start/utils/backend/permissions'
+import {
+  KernelInstance,
+  ACLContract,
+  ACLInstance,
+  CounterInstance
+} from '~/typechain'
+import { getAppId } from '~/src/tasks/start/utils/id'
 
 describe('permissions.ts', () => {
-  let dao: KernelInstance;
-  let acl: ACLInstance;
-  let app: CounterInstance;
+  let dao: KernelInstance
+  let acl: ACLInstance
+  let app: CounterInstance
 
   before('set up dao with app', async () => {
-    dao = await createDao();
+    dao = await createDao()
 
-    const ACL: ACLContract = artifacts.require('ACL');
-    acl = await ACL.at(await dao.acl());
+    const ACL: ACLContract = artifacts.require('ACL')
+    acl = await ACL.at(await dao.acl())
 
-    const implementation = await deployImplementation();
-    const appId = getAppId('counter');
-    app = await createProxy(implementation, appId, dao) as CounterInstance;
-  });
+    const implementation = await deployImplementation()
+    const appId = getAppId('counter')
+    app = (await createProxy(implementation, appId, dao)) as CounterInstance
+  })
 
   describe('when setAllPermissionsOpenly is called', () => {
     before('call setAllPermissionsOpenly', async () => {
-      await setAllPermissionsOpenly(dao, app);
-    });
+      await setAllPermissionsOpenly(dao, app)
+    })
 
     it('properly sets the INCREMENT_ROLE permission', async () => {
-      assert.equal(await acl.hasPermission(
-        ANY_ADDRESS,
-        app.address,
-        await app.INCREMENT_ROLE(),
-      ), true, 'Invalid permission.');
-    });
+      assert.equal(
+        await acl.hasPermission(
+          ANY_ADDRESS,
+          app.address,
+          await app.INCREMENT_ROLE()
+        ),
+        true,
+        'Invalid permission.'
+      )
+    })
 
     it('properly sets the DECREMENT_ROLE permission', async () => {
-      assert.equal(await acl.hasPermission(
-        ANY_ADDRESS,
-        app.address,
-        await app.DECREMENT_ROLE(),
-      ), true, 'Invalid permission.');
-    });
-  });
-});
+      assert.equal(
+        await acl.hasPermission(
+          ANY_ADDRESS,
+          app.address,
+          await app.DECREMENT_ROLE()
+        ),
+        true,
+        'Invalid permission.'
+      )
+    })
+  })
+})

--- a/packages/buidler/test/tasks/start/utils/backend/proxy.test.ts
+++ b/packages/buidler/test/tasks/start/utils/backend/proxy.test.ts
@@ -1,5 +1,5 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('proxy.ts', () => {
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/tasks/start/utils/backend/repo.test.ts
+++ b/packages/buidler/test/tasks/start/utils/backend/repo.test.ts
@@ -1,5 +1,5 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('repo.ts', () => {
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/tasks/start/utils/execa.test.ts
+++ b/packages/buidler/test/tasks/start/utils/execa.test.ts
@@ -1,24 +1,24 @@
-import { assert } from 'chai';
-import { execaPipe } from '~/src/tasks/start/utils/execa';
-import * as path from 'path';
+import { assert } from 'chai'
+import { execaPipe } from '~/src/tasks/start/utils/execa'
+import * as path from 'path'
 
 describe('execa.ts', () => {
   describe('when calling pwd', () => {
-    let res: any;
+    let res: any
 
     before('call pwd', async () => {
-      res = await execaPipe('pwd', ['-L', '-P'], {});
-    });
+      res = await execaPipe('pwd', ['-L', '-P'], {})
+    })
 
     it('should have printed console output with the expected path', async () => {
-      const dir = path.basename(res.stdout);
-      assert.equal(dir, 'buidler');
-    });
+      const dir = path.basename(res.stdout)
+      assert.equal(dir, 'buidler')
+    })
 
     it('should have ended with exit code 0', async () => {
-      assert.equal(res.exitCode, 0, 'Invalid exit code.');
-    });
+      assert.equal(res.exitCode, 0, 'Invalid exit code.')
+    })
 
-    it.skip('more tests needed', async () => {});
-  });
-});
+    it.skip('more tests needed', async () => {})
+  })
+})

--- a/packages/buidler/test/tasks/start/utils/frontend/build.test.ts
+++ b/packages/buidler/test/tasks/start/utils/frontend/build.test.ts
@@ -1,5 +1,5 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('build.ts', () => {
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/tasks/start/utils/frontend/client.test.ts
+++ b/packages/buidler/test/tasks/start/utils/frontend/client.test.ts
@@ -1,5 +1,5 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('client.ts', () => {
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/tasks/start/utils/frontend/webserver.test.ts
+++ b/packages/buidler/test/tasks/start/utils/frontend/webserver.test.ts
@@ -1,5 +1,5 @@
-import { assert } from 'chai';
+import { assert } from 'chai'
 
 describe('webserver.ts', () => {
-  it.skip('more tests needed', async () => {});
-});
+  it.skip('more tests needed', async () => {})
+})

--- a/packages/buidler/test/test-helpers/isAddress.ts
+++ b/packages/buidler/test/test-helpers/isAddress.ts
@@ -1,3 +1,3 @@
-import Web3Utils from 'web3-utils';
+import Web3Utils from 'web3-utils'
 
-export const isAddress = Web3Utils.isAddress;
+export const isAddress = Web3Utils.isAddress

--- a/packages/buidler/tslint.json
+++ b/packages/buidler/tslint.json
@@ -12,6 +12,6 @@
       "arrow-parens": [false],
       "object-literal-sort-keys": [false],
       "ordered-imports": [false]
-    },
+    "trailing-comma": [false]
     "rulesDirectory": []
 }

--- a/packages/buidler/tslint.json
+++ b/packages/buidler/tslint.json
@@ -1,17 +1,16 @@
 {
-    "defaultSeverity": "error",
-    "extends": [
-        "tslint:recommended"
-    ],
-    "jsRules": {},
-    "rules": {
-      "quotemark": [true, "single"],
-      "no-console": [false],
-      "no-empty": [false],
-      "interface-name": [false],
-      "arrow-parens": [false],
-      "object-literal-sort-keys": [false],
-      "ordered-imports": [false]
+  "defaultSeverity": "error",
+  "extends": ["tslint:recommended", "tslint-config-prettier"],
+  "jsRules": {},
+  "rules": {
+    "quotemark": [true, "single"],
+    "no-console": [false],
+    "no-empty": [false],
+    "interface-name": [false],
+    "arrow-parens": [false],
+    "object-literal-sort-keys": [false],
+    "ordered-imports": [false],
     "trailing-comma": [false]
-    "rulesDirectory": []
+  },
+  "rulesDirectory": []
 }


### PR DESCRIPTION
# 🦅 Pull Request

Progress the work for a working buidler plugin with the aragon command start
- Logging solution like the one used by docker-compose where the logs are prepended by a color coded tag of their origin (in our case `back` and `front`)
- Simplify front-end watching since we are using parcel's server with watch. I suggest we should add one more watcher to the `arapp.json` file and trigger the building of artifacts when:
  - `*.sol` source code changes
  - `arapp.json` changes
- Make setPermissions dynamic from arapp.json
- Setup prettier and run lint + prettier on all files
