### PR TITLE
Skip IPFS installation for buidler boilerplate in create-aragon-app

### DIFF
--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -91,7 +91,10 @@ exports.handler = async function({
     template = 'react'
   }
 
+  let requiresIPFS = true
+
   if (template === 'buidler') {
+    requiresIPFS = false
     console.log(
       `Warning: You are using the experimental "${template}" boilerplate.`
     )
@@ -140,6 +143,7 @@ exports.handler = async function({
       },
       {
         title: 'Check IPFS',
+        enabled: () => requiresIPFS,
         task: async (ctx, task) => {
           try {
             ctx.ipfsMissing = false
@@ -151,7 +155,7 @@ exports.handler = async function({
       },
       {
         title: 'Installing IPFS',
-        enabled: ctx => ctx.ipfsMissing,
+        enabled: ctx => requiresIPFS && ctx.ipfsMissing,
         task: async (ctx, task) => {
           await execa(
             'npx',
@@ -165,7 +169,7 @@ exports.handler = async function({
   )
 
   return tasks.run().then(() => {
-    reporter.success(`Created new application ${name} in ${basename}
+    reporter.success(`Created new application ${name} in path ./${basename}/
 
 Start your Aragon app by typing:
 


### PR DESCRIPTION
Fix #1313