### PR TITLE
Add option to prevent create-aragon-app to install dependencies

### DIFF
--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -61,6 +61,11 @@ exports.builder = yargs => {
         return tmpl
       },
     })
+    .option('install', {
+      description: 'Whether or not to install dependencies',
+      default: true,
+      boolean: true,
+    })
 }
 
 exports.handler = async function({
@@ -68,6 +73,7 @@ exports.handler = async function({
   name,
   template,
   path: dirPath,
+  install,
   silent,
   debug,
 }) {
@@ -140,6 +146,7 @@ exports.handler = async function({
       },
       {
         title: 'Install package dependencies?',
+        enabled: () => install,
         task: async (ctx, task) =>
           input('Enter "yes" to run `npm install` now:', {
             default: 'yes',

--- a/packages/create-aragon-app/test/create-app.test.js
+++ b/packages/create-aragon-app/test/create-app.test.js
@@ -27,6 +27,7 @@ test('should create a new aragon app based on the react boilerplate', async t =>
     'react',
     '--path',
     './.tmp',
+    '--no-install',
   ])
 
   const packageJson = await readJson(packageJsonPath)


### PR DESCRIPTION
# 🦅 Pull Request Description

Add option to prevent create-aragon-app to install dependencies during testing

## Rational

Tests hang doing create-aragon-app setup of a new project. We should run this test on a separate process once a day.

