### PR TITLE
Removed prompt in caa for installing dependencies

### DIFF
--- a/packages/create-aragon-app/package.json
+++ b/packages/create-aragon-app/package.json
@@ -50,7 +50,6 @@
     "git-clone": "^0.1.0",
     "inquirer": "^7.0.4",
     "listr": "^0.14.3",
-    "listr-input": "^0.2.0",
     "listr-silent-renderer": "^1.1.1",
     "listr-update-renderer": "^0.5.0",
     "listr-verbose-renderer": "^0.6.0",

--- a/packages/create-aragon-app/src/commands/create-aragon-app.js
+++ b/packages/create-aragon-app/src/commands/create-aragon-app.js
@@ -1,5 +1,4 @@
 const TaskList = require('listr')
-const input = require('listr-input')
 const execa = require('execa')
 const inquirer = require('inquirer')
 const { promisify } = require('util')
@@ -145,21 +144,13 @@ exports.handler = async function({
         enabled: () => !templateUrl.includes('your-first-aragon-app'),
       },
       {
-        title: 'Install package dependencies?',
+        title: 'Installing package dependencies',
         enabled: () => install,
-        task: async (ctx, task) =>
-          input('Enter "yes" to run `npm install` now:', {
-            default: 'yes',
-            validate: wantsToInstallDeps =>
-              wantsToInstallDeps === 'yes' || wantsToInstallDeps === 'no',
-            done: async wantsToInstallDeps => {
-              if (wantsToInstallDeps === 'yes') {
-                task.output =
-                  'Installing package dependencies... (might take a couple of minutes)'
-                await installDeps(projectPath, task)
-              }
-            },
-          }),
+        task: async (ctx, task) => {
+          task.output =
+            'Installing package dependencies... (might take a couple of minutes)'
+          await installDeps(projectPath, task)
+        },
       },
       {
         title: 'Check IPFS',


### PR DESCRIPTION
Fix #1407 

The prompt felt weird and I fear that users may fail to notice it, resulting in the sensation that the program hanged.

This PR reverts the changes but does warn the user that the operation takes a few minutes.