### PR TITLE
Challenge: makes this work with the current setup

### DIFF
--- a/packages/toolkit/npm-shrinkwrap.json
+++ b/packages/toolkit/npm-shrinkwrap.json
@@ -2740,6 +2740,12 @@
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
     },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -26059,6 +26065,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.5.tgz",
+      "integrity": "sha512-c3sIjNUow0+8swNwVpqoH4YCShKNFkMaw6oH1mNS2haDZQqkeZFlHS3dhoeEbKKmJB4vXpJucU6oH75aDYeE9g==",
+      "dev": true
+    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -30497,6 +30509,43 @@
         }
       }
     },
+    "ts-node": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
+      "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+      "dev": true,
+      "requires": {
+        "arg": "^4.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.6",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.16",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -31656,6 +31705,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     }
   }
 }

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -90,6 +90,7 @@
     "prettier": "^1.19.1",
     "proxyquire": "^2.1.3",
     "sinon": "^7.5.0",
+    "ts-node": "^8.6.2",
     "typedoc": "^0.15.4",
     "typescript": "^3.7.3"
   },
@@ -97,7 +98,9 @@
     "node": ">=10.0.0"
   },
   "ava": {
+    "compileEnhancements": false,
     "require": [
+      "ts-node/register",
       "./test/register.js"
     ],
     "files": [

--- a/packages/toolkit/test/node/noop.test.ts
+++ b/packages/toolkit/test/node/noop.test.ts
@@ -2,5 +2,7 @@ import test from 'ava'
 import { noop } from '../../src'
 
 test('noop() returns undefined', t => {
-  t.is(noop(), undefined)
+  /* eslint-disable-next-line @typescript-eslint/no-inferrable-types */
+  const undefinedVar: undefined = undefined
+  t.is(noop(), undefinedVar)
 })

--- a/packages/toolkit/test/node/noop.test.ts
+++ b/packages/toolkit/test/node/noop.test.ts
@@ -6,3 +6,12 @@ test('noop() returns undefined', t => {
   const undefinedVar: undefined = undefined
   t.is(noop(), undefinedVar)
 })
+
+test('types are working', t => {
+  interface Person {
+    name: string
+    lastName: string
+  }
+  const person: Person = { name: 'Joe', lastName: 'Doe' }
+  t.is(person.name, 'Joe')
+})


### PR DESCRIPTION
# 🦅 Pull Request Description

Current Typescript setup does not support using Typescript syntax in the `.test.ts` as showcased by the change in this PR. This is a very important feature since it strengthens tests and ensures automatically that mock data is up to the date with the current types.

 I'm opening this PR as a "challenge" to make it work in the current setup before considering other options. @0x6431346e stressed the importance of keeping the previous setup with Babel, also for performance reasons.

To try locally just do 

```
npm test
```

which in my environment results in:

```
lion@:~/aragon/aragon-cli/packages/toolkit$ npm test

> @aragon/toolkit@0.0.5 test aragon/aragon-cli/packages/toolkit
> ava --verbose


  ✖ Couldn't find any files to test

  ✖ Internal error
  SyntaxError: aragon/aragon-cli/packages/toolkit/test/node/noop.test.ts: Unexpected token (5:20)
  
    3 | 
    4 | test('noop() returns undefined', t => {
  > 5 |   const undefinedVar: undefined = undefined
      |                     ^
    6 |   t.is(noop(), undefinedVar)
    7 | })
    8 | 
  SyntaxError: aragon/aragon-cli/packages/toolkit/test/node/noop.test.ts: Unexpected token (5:20)
  
    3 | 
    4 | test('noop() returns undefined', t => {
  > 5 |   const undefinedVar: undefined = undefined
      |                     ^
    6 |   t.is(noop(), undefinedVar)
    7 | })
    8 | 
      at Parser.raise (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:7017:17)
      at Parser.unexpected (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:8395:16)
      at Parser.parseVar (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:11343:18)
      at Parser.parseVarStatement (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:11158:10)
      at Parser.parseStatementContent (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:10757:21)
      at Parser.parseStatement (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:10690:17)
      at Parser.parseBlockOrModuleBlockBody (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:11264:25)
      at Parser.parseBlockBody (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:11251:10)
      at Parser.parseBlock (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:11235:10)
      at Parser.parseFunctionBody (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:10252:24)
      at Parser.parseArrowExpression (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:10209:10)
      at Parser.parseExprAtom (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:9547:18)
      at Parser.parseExprSubscripts (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:9259:23)
      at Parser.parseMaybeUnary (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:9239:21)
      at Parser.parseExprOps (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:9109:23)
      at Parser.parseMaybeConditional (aragon/aragon-cli/packages/toolkit/node_modules/@babel/parser/lib/index.js:9082:23)

```