### PR TITLE
Activate eslint rule no-anonymous-default-export

### DIFF
--- a/packages/toolkit/.eslintrc.yml
+++ b/packages/toolkit/.eslintrc.yml
@@ -1,0 +1,27 @@
+env:
+  es6: true
+  node: true
+
+plugins:
+  - '@typescript-eslint'
+extends:
+  - 'plugin:@typescript-eslint/recommended'
+  - 'standard'
+  - 'plugin:ava/recommended'
+  - 'plugin:prettier/recommended'
+  - 'prettier/@typescript-eslint'
+
+parser: '@typescript-eslint/parser'
+
+rules:
+  # Disable strict Typescript rules until the code is fully migrated
+  '@typescript-eslint/no-use-before-define': 'off'
+  '@typescript-eslint/no-unused-vars': 'off'
+  '@typescript-eslint/explicit-function-return-type': 'off'
+  '@typescript-eslint/no-empty-function': 'off'
+
+  # import helps make sure that ES6 export good practices are used
+  # Enforce self-descriptive export standards
+  'import/no-anonymous-default-export': 'error'
+  # 'import/no-dynamic-require': 'error'
+  # 'import/no-default-export': 'error'

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -80,7 +80,7 @@
     "eslint-config-prettier": "^6.7.0",
     "eslint-config-standard": "^14.1.0",
     "eslint-plugin-ava": "^10.0.0",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "eslint-plugin-promise": "^4.2.1",
@@ -138,29 +138,6 @@
           "istanbul"
         ]
       }
-    }
-  },
-  "eslintConfig": {
-    "env": {
-      "es6": true,
-      "node": true
-    },
-    "plugins": [
-      "@typescript-eslint"
-    ],
-    "extends": [
-      "plugin:@typescript-eslint/recommended",
-      "standard",
-      "plugin:ava/recommended",
-      "plugin:prettier/recommended",
-      "prettier/@typescript-eslint"
-    ],
-    "parser": "@typescript-eslint/parser",
-    "rules": {
-      "@typescript-eslint/no-use-before-define": "off",
-      "@typescript-eslint/no-unused-vars": "off",
-      "@typescript-eslint/explicit-function-return-type": "off",
-      "@typescript-eslint/no-empty-function": "off"
     }
   },
   "prettier": {

--- a/packages/toolkit/src/acl/acl.js
+++ b/packages/toolkit/src/acl/acl.js
@@ -5,7 +5,7 @@ import { abi as repoAbi } from '@aragon/abis/os/artifacts/Repo'
 //
 import { getRecommendedGasLimit } from '../util'
 
-export default web3 => {
+export default function acl(web3) {
   const getACL = async repoAddr => {
     const repo = new web3.eth.Contract(aragonAppAbi, repoAddr)
     const daoAddr = await repo.methods.kernel().call()

--- a/packages/toolkit/src/apm/getApmRegistryPackages.js
+++ b/packages/toolkit/src/apm/getApmRegistryPackages.js
@@ -8,11 +8,11 @@ import useApm from './useApm'
  * @param  {string} environment Envrionment
  * @returns {void}
  */
-export default async (
+export default async function getApmRegistryPackages(
   apmRegistryName,
   progressHandler = () => {},
   environment
-) => {
+) {
   const apm = await useApm(environment)
 
   progressHandler(1)

--- a/packages/toolkit/src/apm/getApmRepo.js
+++ b/packages/toolkit/src/apm/getApmRepo.js
@@ -11,11 +11,11 @@ import { DEFAULT_IPFS_TIMEOUT, LATEST_VERSION } from '../helpers/constants'
  * @param  {string} environment Envrionment
  * @returns {Object} Repo
  */
-export default async (
+export default async function getApmRepo(
   apmRepoName,
   apmRepoVersion = LATEST_VERSION,
   environment
-) => {
+) {
   const apm = await useApm(environment)
 
   apmRepoName = defaultAPMName(apmRepoName)

--- a/packages/toolkit/src/apm/grantNewVersionsPermission.js
+++ b/packages/toolkit/src/apm/grantNewVersionsPermission.js
@@ -2,12 +2,12 @@ import useApm from './useApm'
 import ACL from '../acl/acl'
 import { useEnvironment } from '../helpers/useEnvironment'
 
-export default async (
+export default async function grantNewVersionsPermission(
   grantees,
   apmRepoName,
   progressHandler = () => {},
   environment
-) => {
+) {
   const { web3, gasPrice } = useEnvironment(environment)
 
   if (grantees.length === 0) {

--- a/packages/toolkit/src/apm/useApm.js
+++ b/packages/toolkit/src/apm/useApm.js
@@ -7,7 +7,7 @@ import { useEnvironment } from '../helpers/useEnvironment'
  * @param  {string} environment Envrionment
  * @returns {Object} aragonPM object
  */
-export default async environment => {
+export default async function useApm(environment) {
   const { web3, apmOptions } = useEnvironment(environment)
 
   return aragonPM(web3, apmOptions)

--- a/packages/toolkit/src/dao/encodeActCall.js
+++ b/packages/toolkit/src/dao/encodeActCall.js
@@ -5,7 +5,7 @@ import abi from 'web3-eth-abi'
  * @param {string} signature Function signature
  * @param {any[]} params
  */
-export default (signature, params = []) => {
+export default function encodeActCall(signature, params = []) {
   const sigBytes = abi.encodeFunctionSignature(signature)
 
   const types = signature.replace(')', '').split('(')[1]

--- a/packages/toolkit/src/dao/exec.js
+++ b/packages/toolkit/src/dao/exec.js
@@ -12,7 +12,7 @@ import { useEnvironment } from '../helpers/useEnvironment'
  * @param {string} environment Environment
  * @returns {Promise<{ transactionPath, receipt }>} Transaction path and receipt
  */
-export default async function(
+export default async function daoExec(
   dao,
   app,
   method,

--- a/packages/toolkit/src/dao/new.js
+++ b/packages/toolkit/src/dao/new.js
@@ -14,7 +14,7 @@ import { useEnvironment } from '../helpers/useEnvironment'
  * @param {string} environment Environment
  * @param {Object} templateInstance Template instance
  */
-export default async function(
+export default async function newDao(
   templateName = 'bare-template',
   newInstanceArgs = [],
   newInstanceMethod = 'newInstance',

--- a/packages/toolkit/src/dao/utils/bare-template-abi.js
+++ b/packages/toolkit/src/dao/utils/bare-template-abi.js
@@ -1,4 +1,4 @@
-export default [
+const bareTemplateAbi = [
   {
     inputs: [
       {
@@ -111,3 +111,5 @@ export default [
     type: 'function',
   },
 ]
+
+export default bareTemplateAbi

--- a/packages/toolkit/src/helpers/default-apm.js
+++ b/packages/toolkit/src/helpers/default-apm.js
@@ -1,5 +1,6 @@
 import { DEFAULT_APM_REGISTRY } from './constants'
 
 // insert default apm if the provided name doesnt have the suffix
-export default name =>
-  name.split('.').length > 1 ? name : `${name}.${DEFAULT_APM_REGISTRY}`
+export default function getDefaultApmName(name) {
+  return name.split('.').length > 1 ? name : `${name}.${DEFAULT_APM_REGISTRY}`
+}

--- a/packages/toolkit/src/helpers/encodeInitPayload.js
+++ b/packages/toolkit/src/helpers/encodeInitPayload.js
@@ -1,6 +1,11 @@
 import { useEnvironment } from '../helpers/useEnvironment'
 
-export default (abi, initFunctionName, initArgs, environment) => {
+export default function encodeInitPayload(
+  abi,
+  initFunctionName,
+  initArgs,
+  environment
+) {
   const { web3 } = useEnvironment(environment)
 
   const methodABI = abi.find(method => method.name === initFunctionName)

--- a/packages/toolkit/src/helpers/extractContractInfoToFile.js
+++ b/packages/toolkit/src/helpers/extractContractInfoToFile.js
@@ -6,7 +6,10 @@ const readFile = fs.promises.readFile
 
 // TODO: Move away from Toolkit
 
-export default async (contractPath, outputPath) => {
+export default async function extractContractInfoToFile(
+  contractPath,
+  outputPath
+) {
   const sourceCode = await readFile(contractPath, 'utf8')
   const contractInfo = await extractContractInfo(sourceCode)
 

--- a/packages/toolkit/src/kernel/getAppKernel.js
+++ b/packages/toolkit/src/kernel/getAppKernel.js
@@ -10,7 +10,7 @@ import { useEnvironment } from '../helpers/useEnvironment'
  * @param  {string} environment Envrionment
  * @returns {Promise<string>} Kernel address
  */
-export default async (appAddress, environment) => {
+export default async function getAppKernel(appAddress, environment) {
   const { web3 } = useEnvironment(environment)
 
   const app = new web3.eth.Contract(aragonAppAbi, appAddress)


### PR DESCRIPTION
As discussed with the team, anonymous default exports add cognitive overhead which slows down development. 

I've started applying this rule which is only stylistic and requires no actual code changes. 

I support @macor161 recommendation to forbid default exports entirely until Typescript is adopted since it makes it harder to follow the code. See this article for reference https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/