### PR TITLE
Add @aragon/toolkit examples folder

### DIFF
--- a/packages/toolkit/examples/README.md
+++ b/packages/toolkit/examples/README.md
@@ -1,7 +1,7 @@
-aragonCLI Toolkit examples
+Aragon Toolkit examples
 ==========================
 
-This directory contains some useful scripts made with the aragonCLI Toolkit:
+This directory contains some useful scripts made with the Aragon Toolkit:
 * [Atomic payments](atomicPayments): Pay multiple people with just one vote.
 * [Mint and Burn](mintAndBurn): Mint and burn tokens for different holders with just one vote.
 * [Swap SAI to DAI](swapSaiToDai): Swap SAI in a Vault/Agent into DAI with just one vote.

--- a/packages/toolkit/examples/README.md
+++ b/packages/toolkit/examples/README.md
@@ -1,0 +1,8 @@
+aragonCLI Toolkit examples
+==========================
+
+This directory contains some useful scripts made with the aragonCLI Toolkit:
+* [Atomic payments](atomicPayments): Pay multiple people with just one vote.
+* [Mint and Burn](mintAndBurn): Mint and burn tokens for different holders with just one vote.
+* [Swap SAI to DAI](swapSaiToDai): Swap SAI in a Vault/Agent into DAI with just one vote.
+* [Permissions](permissions): Create, grant, and revoke many permissions with just one vote.

--- a/packages/toolkit/examples/atomicPayments/README.md
+++ b/packages/toolkit/examples/atomicPayments/README.md
@@ -1,0 +1,11 @@
+Encode payments
+===============
+
+Send multiple transactions with just one vote!
+
+## Usage
+1. Change `payments.json` data to include the addresses
+for your DAO, voting and finance apps and the list of
+payments you want make.
+2. Execute `node index.js` to run the command.
+3. If successful, open your DAO and vote in the new vote.

--- a/packages/toolkit/examples/atomicPayments/index.js
+++ b/packages/toolkit/examples/atomicPayments/index.js
@@ -1,0 +1,65 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeActCall, exec } = require('../../dist') // require('@aragon/toolkit')
+
+const {
+  daoAddress,
+  votingAddress,
+  financeAddress,
+  payments,
+  environment,
+} = require('./payments.json')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+async function main() {
+  // Encode a bunch of payments.
+  const newImmediatePaymentSignature =
+    'newImmediatePayment(address,address,uint256,string)'
+  const calldatum = await Promise.all(
+    payments.map(({ tokenAddress, receiverAddress, amount, receipt }) =>
+      encodeActCall(newImmediatePaymentSignature, [
+        tokenAddress,
+        receiverAddress,
+        amount,
+        receipt,
+      ])
+    )
+  )
+
+  const actions = calldatum.map(calldata => ({
+    to: financeAddress,
+    calldata,
+  }))
+
+  // Encode all actions into a single EVM script.
+  const script = encodeCallScript(actions)
+
+  const tx = await exec(
+    daoAddress,
+    votingAddress,
+    'newVote',
+    [script, 'Payments'],
+    () => {},
+    environment
+  )
+
+  const url =
+    environment === 'mainnet'
+      ? 'https://mainnet.aragon.org/'
+      : environment === 'rinkeby'
+      ? 'http://rinkeby.aragon.org/'
+      : 'http:localhost:3000/'
+
+  console.log(`
+Done! Transaction ${tx.receipt.transactionHash} executed
+Run aragon start, and go to
+
+  ${url}#/${daoAddress}/${votingAddress}
+
+to verify that the vote containing multiple votes was created.
+`)
+
+  process.exit()
+}
+
+main().catch(console.error)

--- a/packages/toolkit/examples/atomicPayments/payments.json
+++ b/packages/toolkit/examples/atomicPayments/payments.json
@@ -1,0 +1,20 @@
+{
+  "daoAddress": "0x592B213bf0176c1f3b2a6F5EfE632eAC4b5453EE",
+  "votingAddress": "0x790d73e8690042f37df0194c6e5835bf4d340638",
+  "financeAddress": "0x3ceec51601e17ac69f6acb10a214c9bb7a86ac24",
+  "environment": "mainnet",
+  "payments": [
+    {
+      "tokenAddress": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      "receiverAddress": "0x7c343AbB2b180732583a3134E4A9f6e138D320D2",
+      "amount": "450000000000000000000",
+      "receipt": "Milestone 3 - @paulo"
+    },
+    {
+      "tokenAddress": "0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359",
+      "receiverAddress": "0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065",
+      "amount": "450000000000000000000",
+      "receipt": "Milestone 3 - @sem"
+    }
+  ]
+}

--- a/packages/toolkit/examples/mintAndBurn/README.md
+++ b/packages/toolkit/examples/mintAndBurn/README.md
@@ -1,0 +1,10 @@
+Encode payments
+===============
+
+Do many token mints and burns in just one vote. Useful for reputation tokens.
+
+## Usage
+1. Change `assignations.json` data. Set up the DAO, voting and token manager
+apps, and the list of assignations you want do.
+2. Execute `node index.js` to run the command.
+3. On successful, open your DAO and see the new vote.

--- a/packages/toolkit/examples/mintAndBurn/assignations.json
+++ b/packages/toolkit/examples/mintAndBurn/assignations.json
@@ -1,0 +1,12 @@
+{
+  "daoAddress": "0xd6878C9974359CBB67e8583e7a6CAfB0fa20a286",
+  "tokenManagerAddress": "0x696e40ba67d890422421886633195013b62c9c44",
+  "votingAddress": "0xac104c988ff9c90dafc7754b2fb9072e25f93507",
+  "environment": "mainnet",
+  "mints": [
+    ["0x7c343AbB2b180732583a3134E4A9f6e138D320D2", "500000000000000000000"],
+    ["0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065", "500000000000000000000"]
+  ],
+  "burns": [
+  ]
+}

--- a/packages/toolkit/examples/mintAndBurn/index.js
+++ b/packages/toolkit/examples/mintAndBurn/index.js
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeActCall, exec } = require('../../dist') // require('@aragon/toolkit')
+
+const {
+  daoAddress,
+  tokenManagerAddress,
+  votingAddress,
+  mints,
+  burns,
+  environment,
+} = require('./assignations.json')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+async function main() {
+  // Encode a bunch of token mints and burns.
+  const mintSignature = 'mint(address,uint256)'
+  const burnSignature = 'burn(address,uint256)'
+  const calldatum = await Promise.all([
+    ...mints.map(([receiverAddress, amount]) =>
+      encodeActCall(mintSignature, [receiverAddress, amount])
+    ),
+    ...burns.map(([holderAddress, amount]) =>
+      encodeActCall(burnSignature, [holderAddress, amount])
+    ),
+  ])
+
+  const actions = calldatum.map(calldata => ({
+    to: tokenManagerAddress,
+    calldata,
+  }))
+
+  // Encode all actions into a single EVM script.
+  const script = encodeCallScript(actions)
+  const tx = await exec(
+    daoAddress,
+    votingAddress,
+    'newVote',
+    [script, 'Mints and Burns'],
+    () => {},
+    environment
+  )
+
+  const url =
+    environment === 'mainnet'
+      ? 'https://mainnet.aragon.org/'
+      : environment === 'rinkeby'
+      ? 'http://rinkeby.aragon.org/'
+      : 'http:localhost:3000/'
+
+  console.log(`
+Done! Transaction ${tx.receipt.transactionHash} executed
+Run aragon start, and go to
+
+  ${url}#/${daoAddress}/${votingAddress}
+
+to verify that the vote containing multiple votes was created.
+`)
+
+  process.exit()
+}
+
+main().catch(console.error)

--- a/packages/toolkit/examples/package.json
+++ b/packages/toolkit/examples/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "aragon-toolkit-examples",
+  "version": "0.0.1",
+  "description": "Documented examples of the aragonCLI toolkit tool",
+  "scripts": {
+    "lint": "eslint .",
+    "test": "echo \"Error: no test specified\""
+  },
+  "keywords": [
+    "aragon",
+    "aragoncli",
+    "aragon-toolkit",
+    "dao"
+  ],
+  "author": "David Llop",
+  "license": "GPL-3.0",
+  "dependencies": {
+    "@aragon/test-helpers": "^2.1.0",
+    "@aragon/toolkit": "^0.0.5",
+    "ethereumjs-abi": "^0.6.8",
+    "web3": "^1.2.5-rc.0"
+  }
+}

--- a/packages/toolkit/examples/permissions/README.md
+++ b/packages/toolkit/examples/permissions/README.md
@@ -1,0 +1,11 @@
+Encode permissions
+==================
+
+Create, grant, and revoke many permissions in just one vote.
+
+## Usage
+1. Change `permissions.json` data. Set up the DAO, voting and ACL apps, and the
+list of permissions you want to add or revoke in the form of
+`[entity, onApp, role]`.
+2. Execute `node index.js` to run the command.
+3. On successful, open your DAO and see the new vote.

--- a/packages/toolkit/examples/permissions/index.js
+++ b/packages/toolkit/examples/permissions/index.js
@@ -1,0 +1,69 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeActCall, exec } = require('../../dist') // require('@aragon/toolkit')
+const { keccak256 } = require('web3-utils')
+
+const {
+  daoAddress,
+  aclAddress,
+  votingAddress,
+  create,
+  grant,
+  revoke,
+  environment,
+} = require('./permissions.json')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+async function main() {
+  // Encode a bunch of acl changes.
+  const createSignature = 'createPermission(address,address,bytes32,address)'
+  const grantSignature = 'grantPermission(address,address,bytes32)'
+  const revokeSignature = 'revokePermission(address,address,bytes32)'
+  const calldatum = await Promise.all([
+    ...create.map(([entity, app, role, manager]) =>
+      encodeActCall(createSignature, [entity, app, keccak256(role), manager])
+    ),
+    ...grant.map(([entity, app, role]) =>
+      encodeActCall(grantSignature, [entity, app, keccak256(role)])
+    ),
+    ...revoke.map(([entity, app, role]) =>
+      encodeActCall(revokeSignature, [entity, app, keccak256(role)])
+    ),
+  ])
+
+  const actions = calldatum.map(calldata => ({
+    to: aclAddress,
+    calldata,
+  }))
+
+  // Encode all actions into a single EVM script.
+  const script = encodeCallScript(actions)
+
+  const tx = await exec(
+    daoAddress,
+    votingAddress,
+    'newVote',
+    [script, 'Change permissions'],
+    () => {},
+    environment
+  )
+  const url =
+    environment === 'mainnet'
+      ? 'https://mainnet.aragon.org/'
+      : environment === 'rinkeby'
+      ? 'http://rinkeby.aragon.org/'
+      : 'http:localhost:3000/'
+
+  console.log(`
+Done! Transaction ${tx.receipt.transactionHash} executed
+Run aragon start, and go to
+
+  ${url}#/${daoAddress}/${votingAddress}
+
+to verify that the vote containing multiple votes was created.
+`)
+
+  process.exit()
+}
+
+main().catch(console.error)

--- a/packages/toolkit/examples/permissions/permissions.json
+++ b/packages/toolkit/examples/permissions/permissions.json
@@ -1,0 +1,18 @@
+{
+  "daoAddress": "0x12b013C23F1918EaC4b5342117f0B202E048566C",
+  "aclAddress": "0xe60942b6809cbe8dc206ca91fd87c2e853c4cec5",
+  "votingAddress": "0x709e31ba29fb84000f20045590ec664bfc3cdc1d",
+  "environment": "rinkeby",
+  "create": [
+  ],
+  "grant": [
+    ["0xc893a50f947bdacb4ed66c895cdf545dedb93a9f", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "ADD_ENTRY_ROLE"],
+    ["0xc893a50f947bdacb4ed66c895cdf545dedb93a9f", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "REMOVE_ENTRY_ROLE"],
+    ["0xc893a50f947bdacb4ed66c895cdf545dedb93a9f", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "UPDATE_ENTRY_ROLE"]
+  ],
+  "revoke": [
+    ["0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "ADD_ENTRY_ROLE"],
+    ["0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "REMOVE_ENTRY_ROLE"],
+    ["0xDc2aDfA800a1ffA16078Ef8C1F251D50DcDa1065", "0xa22e672d489a96c7f5f50ade609ea8ae54e281a5", "UPDATE_ENTRY_ROLE"]
+  ]
+}

--- a/packages/toolkit/examples/swapSaiToDai/README.md
+++ b/packages/toolkit/examples/swapSaiToDai/README.md
@@ -1,0 +1,23 @@
+Swap SAI to DAI in just one transaction
+=======================================
+
+Swapping SAI to DAI needs two transactions, one to approve the migration contract to spend your SAIs, and another to actually migrate from SAI to DAI.
+
+We assume that the funds are already in an updated Agent app (**warning:** doing a swap with an agent app older than 11th September 2019 will cause the lose of funds because of the [Istanbul Fork](https://blog.aragon.org/istanbul-hard-fork-impact/)).
+
+Assuming that the funds are already in an new Agent app, we can migrate them with two transactions:
+
+```sh
+$ npx aragon dao act <agent> 0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359 "approve(address,uint256)" 0xc73e0383f3aff3215e6f04b0331d58cecf0ab849 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff --environment aragon:mainnet
+$ npx aragon dao act <agent> 0xc73e0383f3aff3215e6f04b0331d58cecf0ab849 "swapSaiToDai(uint256)" 1000000000000000000 --environment aragon:mainnet
+```
+
+We can encode those two transactions in just one EVM script using this tool. The syntax is as follows:
+
+```
+$ node index.js <dao> <voting> <agent> <amount>
+```
+
+The `amount` is the amount of SAIs you want to migrate and are inside the `agent`. SAIs have 18 decimals, so in order to migrate 1 SAI you have to pass it as 1000000000000000000 in the `amount` field.
+
+The script should have created a new vote in your DAO. Open the voting app to see it.

--- a/packages/toolkit/examples/swapSaiToDai/index.js
+++ b/packages/toolkit/examples/swapSaiToDai/index.js
@@ -1,0 +1,68 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { encodeCallScript } = require('@aragon/test-helpers/evmScript')
+const { encodeActCall, exec } = require('../../dist') // require('@aragon/toolkit')
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const [daoAddress, votingAddress, agentAddress, amount] = process.argv.slice(2)
+
+async function main() {
+  // Encode a bunch of payments.
+  const newApproveSignature = 'approve(address,uint256)'
+  const swapSaiToDaiSignature = 'swapSaiToDai(uint256)'
+  const forwardSignature = 'forward(bytes)'
+
+  const saiTokenAddress = '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'
+  const migrationContractAddress = '0xc73e0383F3Aff3215E6f04B0331D58CeCf0Ab849'
+  const uint256Max = `0x${'f'.repeat(64)}` // 0xfffff...
+
+  const script1 = encodeCallScript([
+    {
+      to: saiTokenAddress,
+      calldata: await encodeActCall(newApproveSignature, [
+        migrationContractAddress,
+        uint256Max,
+      ]),
+    },
+  ])
+
+  const script2 = encodeCallScript([
+    {
+      to: migrationContractAddress,
+      calldata: await encodeActCall(swapSaiToDaiSignature, [amount]),
+    },
+  ])
+
+  // Encode all actions into a single EVM script.
+  const script = encodeCallScript([
+    {
+      to: agentAddress,
+      calldata: await encodeActCall(forwardSignature, [script1]),
+    },
+    {
+      to: agentAddress,
+      calldata: await encodeActCall(forwardSignature, [script2]),
+    },
+  ])
+
+  const tx = await exec(
+    daoAddress,
+    votingAddress,
+    'newVote',
+    [script, 'Swap SAI to DAI'],
+    () => {},
+    'mainnet'
+  )
+
+  console.log(`
+Done! Transaction ${tx.receipt.transactionHash} executed
+Run aragon start, and go to
+
+  https//mainnet.aragon.org/#/${daoAddress}/${votingAddress}
+
+to verify that the vote containing multiple votes was created.
+`)
+
+  process.exit()
+}
+
+main().catch(console.error)


### PR DESCRIPTION
# 🦅 Pull Request Description

Added `atomicPayments`, `mintAndBurn`, `permissions`, and `swapSaiToDai` scripts to the aragon-toolkit examples folder.

## Rational

It is always good to document `@aragon/toolkit` with some real-life examples of its capabilities.

## 🚨 Test instructions

You can change the script parameters in their respective JSON files (read README to know how), and run the scripts using `node index.js`.

## ✔️ PR Todo

- [ ] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [ ] Update the relevant documentation
- [ ] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
