### PR TITLE
Use repo address instead of repo version on aragon apm packages

### DIFF
--- a/packages/cli/src/commands/apm_cmds/packages.js
+++ b/packages/cli/src/commands/apm_cmds/packages.js
@@ -63,11 +63,11 @@ export const handler = async function({
  */
 function displayPackages(packages) {
   const table = new Table({
-    head: ['App', 'Latest Version'],
+    head: ['App', 'Repo Address'],
   })
 
   packages.forEach(aPackage => {
-    const row = [aPackage.name, aPackage.version]
+    const row = [aPackage.name, aPackage.repo]
     table.push(row)
   })
 

--- a/packages/toolkit/src/apm/getApmRegistryPackages.js
+++ b/packages/toolkit/src/apm/getApmRegistryPackages.js
@@ -35,7 +35,7 @@ export default async (
       const args = event.returnValues
       return {
         name: args.name,
-        version: (await apm.getLatestVersion(args.id)).version,
+        repo: args.repo,
       }
     })
   )


### PR DESCRIPTION
# 🦅 Pull Request Description

Fix #1466 

Fetch all packages on the registry and show their repo address instead of their current version.