### PR TITLE
Use wsRpc in dao apps command

### DIFF
--- a/packages/cli/src/commands/dao_cmds/apps.js
+++ b/packages/cli/src/commands/dao_cmds/apps.js
@@ -1,6 +1,7 @@
 import TaskList from 'listr'
 import Table from 'cli-table'
 import { blue, green, white } from 'chalk'
+import Web3 from 'web3'
 import {
   getDaoAddress,
   getInstalledApps,
@@ -115,7 +116,7 @@ export const handler = async function({
         task: async (ctx, task) => {
           appsWithoutPermissions = (
             await getAllApps(daoAddress, {
-              web3,
+              web3: new Web3(wsProvider || web3.currentProvider)
             })
           ).filter(
             ({ proxyAddress }) =>

--- a/packages/cli/src/commands/dao_cmds/apps.js
+++ b/packages/cli/src/commands/dao_cmds/apps.js
@@ -116,7 +116,7 @@ export const handler = async function({
         task: async (ctx, task) => {
           appsWithoutPermissions = (
             await getAllApps(daoAddress, {
-              web3: new Web3(wsProvider || web3.currentProvider)
+              web3: new Web3(wsProvider || web3.currentProvider),
             })
           ).filter(
             ({ proxyAddress }) =>


### PR DESCRIPTION
# 🦅 Pull Request Description

- Fixes #1577 

## Rational

The wsRpc provider wasn't used to fetch permissionless apps.
