### PR TITLE
Don't insist on using Infura, recommend running one's own eth node

### DIFF
--- a/packages/cli/src/middleware/index.js
+++ b/packages/cli/src/middleware/index.js
@@ -61,7 +61,7 @@ export function configCliMiddleware(argv) {
     if (wsProvider?.connection?.url?.includes('eth.aragon.network')) {
       reporter.newLine()
       reporter.warning(
-        `The request may take a while because you are connecting to the default node (${wsProvider.connection.url}). For better performance, consider switching to your own ethereum node or Infura.`,
+        `The request may take a while because you are connecting to the default node (${wsProvider.connection.url}). For better performance, consider switching to your own Ethereum node or Infura.`,
         '\n'
       )
       reporter.info(

--- a/packages/cli/src/middleware/index.js
+++ b/packages/cli/src/middleware/index.js
@@ -61,13 +61,13 @@ export function configCliMiddleware(argv) {
     if (wsProvider?.connection?.url?.includes('eth.aragon.network')) {
       reporter.newLine()
       reporter.warning(
-        `You are connecting to the default node (${wsProvider.connection.url}) the request could take a while. Consider switching to Infura for better performance.`,
+        `You are connecting to the default node (${wsProvider.connection.url}) the request could take a while. Consider switching to your own ethereum node or Infura for better performance.`,
         '\n'
       )
       reporter.info(
         `You have the following options: 
-      1. Use the global option "--ws-rpc" with wss://mainnet.infura.io/ws/v3/<INFURA_KEY>
-      2. Set the "wsRPC" field on mainnet environment of the arapp.json with wss://mainnet.infura.io/ws/v3/<INFURA_KEY>`,
+      1. Use the global option "--ws-rpc"
+      2. Set the "wsRPC" field on mainnet environment of the arapp.json`,
         '\n'
       )
     }

--- a/packages/cli/src/middleware/index.js
+++ b/packages/cli/src/middleware/index.js
@@ -61,7 +61,7 @@ export function configCliMiddleware(argv) {
     if (wsProvider?.connection?.url?.includes('eth.aragon.network')) {
       reporter.newLine()
       reporter.warning(
-        `You are connecting to the default node (${wsProvider.connection.url}) the request could take a while. Consider switching to your own ethereum node or Infura for better performance.`,
+        `The request may take a while because you are connecting to the default node (${wsProvider.connection.url}). For better performance, consider switching to your own ethereum node or Infura.`,
         '\n'
       )
       reporter.info(

--- a/packages/cli/src/middleware/index.js
+++ b/packages/cli/src/middleware/index.js
@@ -66,7 +66,7 @@ export function configCliMiddleware(argv) {
       )
       reporter.info(
         `You have the following options: 
-      1. Use the global option "--ws-rpc"
+      1. Use the global option "--ws-rpc" (e.g. with wss://mainnet.infura.io/ws/v3/<INFURA_KEY> for Infura)
       2. Set the "wsRPC" field on mainnet environment of the arapp.json`,
         '\n'
       )


### PR DESCRIPTION
# 🦅 Pull Request Description

Changed the recommendations printed by CLI.

## Rational

Ethereum is P2P network, so it is important to remind users that they could run their own nodes instead of using centralized services like Infura.

## 🚨 Test instructions

N/A

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
