### PR TITLE
Use wsRpc in apm packages command

### DIFF
--- a/packages/cli/src/commands/apm_cmds/packages.js
+++ b/packages/cli/src/commands/apm_cmds/packages.js
@@ -3,6 +3,7 @@ import TaskList from 'listr'
 import { getApmRegistryPackages } from '@aragon/toolkit'
 //
 import { ensureWeb3 } from '../../helpers/web3-fallback'
+import Web3 from 'web3'
 
 export const command = 'packages [apmRegistry]'
 export const describe = 'List all packages in the registry'
@@ -19,8 +20,12 @@ export const handler = async function({
   apmRegistry,
   network,
   apm: apmOptions,
+  wsProvider
 }) {
-  const web3 = await ensureWeb3(network)
+  const web3 = wsProvider
+    ? new Web3(wsProvider)
+    : await ensureWeb3(network)
+
   let packages
 
   const tasks = new TaskList([

--- a/packages/cli/src/commands/apm_cmds/packages.js
+++ b/packages/cli/src/commands/apm_cmds/packages.js
@@ -20,11 +20,9 @@ export const handler = async function({
   apmRegistry,
   network,
   apm: apmOptions,
-  wsProvider
+  wsProvider,
 }) {
-  const web3 = wsProvider
-    ? new Web3(wsProvider)
-    : await ensureWeb3(network)
+  const web3 = wsProvider ? new Web3(wsProvider) : await ensureWeb3(network)
 
   let packages
 


### PR DESCRIPTION
# 🦅 Pull Request Description

- Use `wsProvider` variable in apm packages command
- Fix #1594 

## 🚨 Test instructions

`aragon apm packages --env aragon:mainnet --ws-rpc wss://mainnet.infura.io/ws/v3/...`


