### PR TITLE
Add link to global options

### DIFF
--- a/docs/Apm-commands.md
+++ b/docs/Apm-commands.md
@@ -1,4 +1,4 @@
-The `aragon apm` commands are the easiest way to manage aragonPM repositories.
+The `aragon apm` commands are the easiest way to manage aragonPM repositories. All commands accept the [global options](https://github.com/aragon/aragon-cli/blob/master/docs/Intro.md#global-options).
 
 ## aragon apm packages
 

--- a/docs/Dao-commands.md
+++ b/docs/Dao-commands.md
@@ -1,4 +1,4 @@
-The `aragon dao` commands can be used for interacting with your DAO directly from the command line. These commands are also available directly using the `dao` alias.
+The `aragon dao` commands can be used for interacting with your DAO directly from the command line. These commands are also available directly using the `dao` alias. All commands accept the [global options](https://github.com/aragon/aragon-cli/blob/master/docs/Intro.md#global-options).
 
 > **Note**<br>
 > The default mnemonic of the Aragon CLI is the same for all users. If you are going to deploy a DAO to public networks it is highly recommended that you use your own web3 provider. Instructions on that can be found [here](https://hack.aragon.org/docs/guides-faq#set-a-private-key)

--- a/docs/Intro.md
+++ b/docs/Intro.md
@@ -97,7 +97,7 @@ Options that change the behaviour of the command:
 - `--gas-price`: Gas price in Gwei. Defaults to `2`.
 - `--use-frame`: Use Frame as a signing provider and web3 provider.
 - `--ens-registry`: Address of the ENS registry. This will be overwritten if the selected environment from your arapp.json includes a `registry` property.
-- `--pfs-gateway`: An URI to the IPFS Gateway to read files from. Defaults to `http://localhost:8080/ipfs`.
+- `--ipfs-gateway`: An URI to the IPFS Gateway to read files from. Defaults to `http://localhost:8080/ipfs`.
 - `--ipfs-rpc`: An URI to the IPFS node used to publish files. Defaults to `http://localhost:5001#default`.
 - `--cwd`: Project working directory.
 - `--debug`: Show more output to terminal.

--- a/docs/Ipfs-commands.md
+++ b/docs/Ipfs-commands.md
@@ -1,4 +1,4 @@
-The `aragon ipfs` commands can be used to start an IPFS node configured to pin the core Aragon components, inspect hashes, and propagate files to other nodes.
+The `aragon ipfs` commands can be used to start an IPFS node configured to pin the core Aragon components, inspect hashes, and propagate files to other nodes. All commands accept the [global options](https://github.com/aragon/aragon-cli/blob/master/docs/Intro.md#global-options).
 
 ## aragon ipfs
 

--- a/docs/Main-commands.md
+++ b/docs/Main-commands.md
@@ -1,4 +1,4 @@
-These are general purpose commands that will help you to set up and interact with your development environment.
+These are general purpose commands that will help you to set up and interact with your development environment. All commands accept the [global options](https://github.com/aragon/aragon-cli/blob/master/docs/Intro.md#global-options).
 
 ## aragon run
 


### PR DESCRIPTION
# 🦅 Pull Request Description

- Fixes https://github.com/aragon/hack/issues/232
- Add link to global options to every command page
- Fix `--ipfs-gateway` typo

## Rational

It turns out the the `--gas-price` option was already there but only in https://hack.aragon.org/docs/cli-intro#global-options, so it was a little bit difficult to find. I added a link to the global options to every command page.
