### PR TITLE
Remove mkdirp and bump @aragon/cli to 7.1.4

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -79,7 +79,6 @@
     "listr-silent-renderer": "^1.1.1",
     "listr-update-renderer": "^0.5.0",
     "listr-verbose-renderer": "^0.6.0",
-    "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
     "open": "^7.0.0",
     "public-ip": "^4.0.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aragon/cli",
-  "version": "7.1.3",
+  "version": "7.1.4",
   "description": "Aragon command-line tools",
   "main": "./dist/toolkit.js",
   "bin": {

--- a/packages/cli/src/commands/devchain_cmds/start.js
+++ b/packages/cli/src/commands/devchain_cmds/start.js
@@ -3,7 +3,7 @@ import ncp from 'ncp'
 import os from 'os'
 import path from 'path'
 import rimraf from 'rimraf'
-import mkdirp from 'mkdirp'
+import { mkdirp } from 'fs-extra'
 import fs from 'fs'
 import Web3 from 'web3'
 import { blue, red, green, yellow } from 'chalk'
@@ -76,7 +76,6 @@ export const task = async function ({
   debug,
 }) {
   const removeDir = promisify(rimraf)
-  const mkDir = promisify(mkdirp)
   const recursiveCopy = promisify(ncp)
 
   const snapshotPath = path.join(
@@ -111,7 +110,7 @@ export const task = async function ({
         title: 'Setting up a new chain from latest Aragon snapshot',
         task: async (ctx, task) => {
           await removeDir(snapshotPath)
-          await mkDir(path.resolve(snapshotPath, '..'))
+          await mkdirp(path.resolve(snapshotPath, '..'))
           const snapshot = getAragonGanacheFiles()
           await recursiveCopy(snapshot, snapshotPath)
         },


### PR DESCRIPTION
# 🦅 Pull Request Description

- Replace `mkdirp` with `fsExtra.mkdirp`
- Bump @aragon/cli to 7.1.4
