### PR TITLE
Use NodeJs 12 in Github publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 11
+        node-version: 12
         registry-url: https://registry.npmjs.org/
     - run: yarn install
     - run: yarn build


### PR DESCRIPTION
# 🦅 Pull Request Description

The Github publish workflow was using NodeJs 11. 

## Rational

We have deprecated support for NodeJs 11.
