### PR TITLE
Generate artifact's signatures from ABI when possible

### DIFF
--- a/packages/cli/src/commands/extract-functions.js
+++ b/packages/cli/src/commands/extract-functions.js
@@ -2,6 +2,7 @@ import path from 'path'
 import { blue } from 'chalk'
 import TaskList from 'listr'
 import { extractContractInfoToFile } from '@aragon/toolkit'
+import { exists, readJson } from 'fs-extra'
 
 export const command = 'extract-functions [contract]'
 export const describe = 'Extract function information from a Solidity file'
@@ -29,8 +30,23 @@ export const handler = async function ({ cwd, reporter, contract, output }) {
       task: async () => {
         const contractPath = path.resolve(cwd, contract)
         const filename = path.basename(contractPath).replace('.sol', '.json')
+        const contractArtifactPath = path.resolve(
+          cwd,
+          'build/contracts',
+          filename
+        )
+
+        if (!(await exists(contractArtifactPath))) {
+          throw new Error(`Could not find artifact ${contractArtifactPath}`)
+        }
+
+        const contractArtifact = await readJson(contractArtifactPath)
         outputPath = path.resolve(output, filename)
-        await extractContractInfoToFile(contractPath, outputPath)
+        await extractContractInfoToFile(
+          contractPath,
+          contractArtifact.abi,
+          outputPath
+        )
       },
     },
   ])

--- a/packages/toolkit/src/helpers/extractContractInfoToFile.js
+++ b/packages/toolkit/src/helpers/extractContractInfoToFile.js
@@ -4,9 +4,9 @@ import { extractContractInfo } from './solidity-extractor'
 
 // TODO: Move away from Toolkit
 
-export default async (contractPath, outputPath) => {
+export default async (contractPath, abi, outputPath) => {
   const sourceCode = await readFile(contractPath, 'utf8')
-  const contractInfo = await extractContractInfo(sourceCode)
+  const contractInfo = await extractContractInfo(sourceCode, abi)
 
   await writeJson(outputPath, contractInfo, { spaces: '\t' })
 }

--- a/packages/toolkit/src/helpers/generateArtifact.js
+++ b/packages/toolkit/src/helpers/generateArtifact.js
@@ -66,7 +66,7 @@ export async function generateApplicationArtifact(arapp, abi, sourceCode) {
 
   // Given a Solidity file, parses it and returns an object with the form:
   // > {roles: [{ },...], functions: [{ },...]}
-  const { functions, roles } = await extractContractInfo(sourceCode)
+  const { functions, roles } = await extractContractInfo(sourceCode, abi)
 
   // Includes abi for each function
   // > [{ sig: , role: , notice: , abi: }]

--- a/packages/toolkit/src/helpers/solidity-extractor.js
+++ b/packages/toolkit/src/helpers/solidity-extractor.js
@@ -29,7 +29,7 @@ const expandTypeForSignature = (type) => {
 
 // extracts function signature from function declaration
 const getSignature = (declaration, abi) => {
-  let [name, params=""] = declaration
+  const [name, params = ''] = declaration
     .match(/^\s*function ([^]*?)\)/m)[1]
     .split('(')
 
@@ -45,21 +45,22 @@ const getSignature = (declaration, abi) => {
   // If a single ABI node is found with function name and same number of parameters,
   // generate the signature from ABI. Otherwise, generate it from source.
   const functionAbis = abi
-    .filter(node => node.name === name)
-    .filter(node => node.inputs.length === trimmedParams.length)
+    .filter((node) => node.name === name)
+    .filter((node) => node.inputs.length === trimmedParams.length)
 
   if (functionAbis.length === 1) {
-    return `${functionAbis[0].name}(${functionAbis[0].inputs.map(input => input.type)})`
-  }
-  else {
+    return `${functionAbis[0].name}(${functionAbis[0].inputs.map(
+      (input) => input.type
+    )})`
+  } else {
     const types = trimmedParams
       .map((param) => param.split(' ').filter((s) => s.length > 0)[0])
       .map((type) => typeOrAddress(type))
       .map((type) => expandTypeForSignature(type))
       .join(',')
 
-      return `${name}(${types})`
-  }  
+    return `${name}(${types})`
+  }
 }
 
 const getNotice = (declaration) => {

--- a/packages/toolkit/test/helpers/contracts/VotingAggregator/VotingAggregator.sol
+++ b/packages/toolkit/test/helpers/contracts/VotingAggregator/VotingAggregator.sol
@@ -183,6 +183,16 @@ contract VotingAggregator is IERC20WithCheckpointing, IForwarder, IsContract, ER
     }
 
     /**
+     * Overloaded function
+     */
+    function disableSource(string _sourceAddr)
+        external
+        authP(MANAGE_POWER_SOURCE_ROLE, arr(uint256(0)))
+    {
+
+    }
+
+    /**
      * @notice Enable power source at `_sourceAddr`
      * @param _sourceAddr Power source's address
      */

--- a/packages/toolkit/test/helpers/contracts/VotingAggregator/VotingAggregator.sol
+++ b/packages/toolkit/test/helpers/contracts/VotingAggregator/VotingAggregator.sol
@@ -1,0 +1,367 @@
+/*
+ * SPDX-License-Identitifer:    GPL-3.0-or-later
+ */
+
+pragma solidity 0.4.24;
+
+import "@aragon/os/contracts/apps/AragonApp.sol";
+import "@aragon/os/contracts/common/IForwarder.sol";
+import "@aragon/os/contracts/common/IsContract.sol";
+import "@aragon/os/contracts/lib/math/SafeMath.sol";
+import "@aragon/os/contracts/lib/token/ERC20.sol";
+
+import "@aragonone/voting-connectors-contract-utils/contracts/Checkpointing.sol";
+import "@aragonone/voting-connectors-contract-utils/contracts/CheckpointingHelpers.sol";
+import "@aragonone/voting-connectors-contract-utils/contracts/ERC20ViewOnly.sol";
+import "@aragonone/voting-connectors-contract-utils/contracts/StaticInvoke.sol";
+import "@aragonone/voting-connectors-contract-utils/contracts/interfaces/IERC20WithCheckpointing.sol";
+
+import "./interfaces/IERC900History.sol";
+
+
+/**
+ * @title VotingAggregator
+ * @notice Voting power aggregator across many sources that provides a "view-only" checkpointed
+ *         ERC20 implementation.
+ */
+contract VotingAggregator is IERC20WithCheckpointing, IForwarder, IsContract, ERC20ViewOnly, AragonApp {
+    using SafeMath for uint256;
+    using StaticInvoke for address;
+    using Checkpointing for Checkpointing.History;
+    using CheckpointingHelpers for uint256;
+
+    /* Hardcoded constants to save gas
+    bytes32 public constant ADD_POWER_SOURCE_ROLE = keccak256("ADD_POWER_SOURCE_ROLE");
+    bytes32 public constant MANAGE_POWER_SOURCE_ROLE = keccak256("MANAGE_POWER_SOURCE_ROLE");
+    bytes32 public constant MANAGE_WEIGHTS_ROLE = keccak256("MANAGE_WEIGHTS_ROLE");
+    */
+    bytes32 public constant ADD_POWER_SOURCE_ROLE = 0x10f7c4af0b190fdd7eb73fa36b0e280d48dc6b8d355f89769b4f1a50a61d1929;
+    bytes32 public constant MANAGE_POWER_SOURCE_ROLE = 0x79ac9d2706bbe6bcdb60a65ba8145a498f6d506aaa455baa7675dff5779cb99f;
+    bytes32 public constant MANAGE_WEIGHTS_ROLE = 0xa36fcade8375289791865312a33263fdc82d07e097c13524c9d6436c0de396ff;
+
+    // Arbitrary number, but having anything close to this number would most likely be unwieldy.
+    // Note the primary protection this provides is to ensure that one cannot continue adding
+    // sources to break gas limits even with all sources disabled.
+    uint256 internal constant MAX_SOURCES = 20;
+    uint192 internal constant SOURCE_ENABLED_VALUE = 1;
+    uint192 internal constant SOURCE_DISABLED_VALUE = 0;
+
+    string private constant ERROR_NO_POWER_SOURCE = "VA_NO_POWER_SOURCE";
+    string private constant ERROR_POWER_SOURCE_TYPE_INVALID = "VA_POWER_SOURCE_TYPE_INVALID";
+    string private constant ERROR_POWER_SOURCE_INVALID = "VA_POWER_SOURCE_INVALID";
+    string private constant ERROR_POWER_SOURCE_ALREADY_ADDED = "VA_POWER_SOURCE_ALREADY_ADDED";
+    string private constant ERROR_TOO_MANY_POWER_SOURCES = "VA_TOO_MANY_POWER_SOURCES";
+    string private constant ERROR_ZERO_WEIGHT = "VA_ZERO_WEIGHT";
+    string private constant ERROR_SAME_WEIGHT = "VA_SAME_WEIGHT";
+    string private constant ERROR_SOURCE_NOT_ENABLED = "VA_SOURCE_NOT_ENABLED";
+    string private constant ERROR_SOURCE_NOT_DISABLED = "VA_SOURCE_NOT_DISABLED";
+    string private constant ERROR_CAN_NOT_FORWARD = "VA_CAN_NOT_FORWARD";
+    string private constant ERROR_SOURCE_CALL_FAILED = "VA_SOURCE_CALL_FAILED";
+    string private constant ERROR_INVALID_CALL_OR_SELECTOR = "VA_INVALID_CALL_OR_SELECTOR";
+
+    enum PowerSourceType {
+        Invalid,
+        ERC20WithCheckpointing,
+        ERC900
+    }
+
+    enum CallType {
+        BalanceOfAt,
+        TotalSupplyAt
+    }
+
+    struct PowerSource {
+        PowerSourceType sourceType;
+        Checkpointing.History enabledHistory;
+        Checkpointing.History weightHistory;
+    }
+
+    string public name;
+    string public symbol;
+    uint8 public decimals;
+
+    mapping (address => PowerSource) internal powerSourceDetails;
+    address[] public powerSources;
+
+    event AddPowerSource(address indexed sourceAddress, PowerSourceType sourceType, uint256 weight);
+    event ChangePowerSourceWeight(address indexed sourceAddress, uint256 newWeight);
+    event DisablePowerSource(address indexed sourceAddress);
+    event EnablePowerSource(address indexed sourceAddress);
+
+    modifier sourceExists(address _sourceAddr) {
+        require(_powerSourceExists(_sourceAddr), ERROR_NO_POWER_SOURCE);
+        _;
+    }
+
+    /**
+     * @notice Create a new voting power aggregator
+     * @param _name The aggregator's display name
+     * @param _symbol The aggregator's display symbol
+     * @param _decimals The aggregator's display decimal units
+     */
+    function initialize(string _name, string _symbol, uint8 _decimals) external onlyInit {
+        initialized();
+
+        name = _name;
+        symbol = _symbol;
+        decimals = _decimals;
+    }
+
+    /**
+     * @notice Add a new power source (`_sourceAddr`) with `_weight` weight
+     * @param _sourceAddr Address of the power source
+     * @param _sourceType Interface type of the power source
+     * @param _weight Weight to assign to the source
+     */
+    function addPowerSource(address _sourceAddr, PowerSourceType _sourceType, uint256 _weight)
+        external
+        authP(ADD_POWER_SOURCE_ROLE, arr(_sourceAddr, _weight))
+    {
+        // Sanity check arguments
+        require(
+            _sourceType == PowerSourceType.ERC20WithCheckpointing || _sourceType == PowerSourceType.ERC900,
+            ERROR_POWER_SOURCE_TYPE_INVALID
+        );
+        require(_weight > 0, ERROR_ZERO_WEIGHT);
+        require(_sanityCheckSource(_sourceAddr, _sourceType), ERROR_POWER_SOURCE_INVALID);
+
+        // Ensure internal consistency
+        require(!_powerSourceExists(_sourceAddr), ERROR_POWER_SOURCE_ALREADY_ADDED);
+        require(powerSources.length < MAX_SOURCES, ERROR_TOO_MANY_POWER_SOURCES);
+
+        // Add source
+        powerSources.push(_sourceAddr);
+
+        PowerSource storage source = powerSourceDetails[_sourceAddr];
+        source.sourceType = _sourceType;
+
+        // Start enabled and weight history
+        source.enabledHistory.addCheckpoint(getBlockNumber64(), SOURCE_ENABLED_VALUE);
+        source.weightHistory.addCheckpoint(getBlockNumber64(), _weight.toUint192Value());
+
+        emit AddPowerSource(_sourceAddr, _sourceType, _weight);
+    }
+
+    /**
+     * @notice Change weight of power source at `_sourceAddr` to `_weight`
+     * @param _sourceAddr Power source's address
+     * @param _weight New weight to assign
+     */
+    function changeSourceWeight(address _sourceAddr, uint256 _weight)
+        external
+        authP(MANAGE_WEIGHTS_ROLE, arr(_weight, powerSourceDetails[_sourceAddr].weightHistory.latestValue()))
+        sourceExists(_sourceAddr)
+    {
+        require(_weight > 0, ERROR_ZERO_WEIGHT);
+
+        Checkpointing.History storage weightHistory = powerSourceDetails[_sourceAddr].weightHistory;
+        require(weightHistory.latestValue() != _weight, ERROR_SAME_WEIGHT);
+
+        weightHistory.addCheckpoint(getBlockNumber64(), _weight.toUint192Value());
+
+        emit ChangePowerSourceWeight(_sourceAddr, _weight);
+    }
+
+    /**
+     * @notice Disable power source at `_sourceAddr`
+     * @param _sourceAddr Power source's address
+     */
+    function disableSource(address _sourceAddr)
+        external
+        authP(MANAGE_POWER_SOURCE_ROLE, arr(uint256(0)))
+        sourceExists(_sourceAddr)
+    {
+        Checkpointing.History storage enabledHistory = powerSourceDetails[_sourceAddr].enabledHistory;
+        require(
+            enabledHistory.latestValue() == uint256(SOURCE_ENABLED_VALUE),
+            ERROR_SOURCE_NOT_ENABLED
+        );
+
+        enabledHistory.addCheckpoint(getBlockNumber64(), SOURCE_DISABLED_VALUE);
+
+        emit DisablePowerSource(_sourceAddr);
+    }
+
+    /**
+     * @notice Enable power source at `_sourceAddr`
+     * @param _sourceAddr Power source's address
+     */
+    function enableSource(address _sourceAddr)
+        external
+        sourceExists(_sourceAddr)
+        authP(MANAGE_POWER_SOURCE_ROLE, arr(uint256(1)))
+    {
+        Checkpointing.History storage enabledHistory = powerSourceDetails[_sourceAddr].enabledHistory;
+        require(
+            enabledHistory.latestValue() == uint256(SOURCE_DISABLED_VALUE),
+            ERROR_SOURCE_NOT_DISABLED
+        );
+
+        enabledHistory.addCheckpoint(getBlockNumber64(), SOURCE_ENABLED_VALUE);
+
+        emit EnablePowerSource(_sourceAddr);
+    }
+
+    // ERC20 fns - note that this token is a non-transferrable "view-only" implementation.
+    // Users should only be changing balances by changing their balances in the underlying tokens.
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function balanceOf(address _owner) public view returns (uint256) {
+        return balanceOfAt(_owner, getBlockNumber());
+    }
+
+    function totalSupply() public view returns (uint256) {
+        return totalSupplyAt(getBlockNumber());
+    }
+
+    // Checkpointed fns
+    // These functions do **NOT** revert if the app is uninitialized to stay compatible with normal ERC20s.
+
+    function balanceOfAt(address _owner, uint256 _blockNumber) public view returns (uint256) {
+        return _aggregateAt(_blockNumber, CallType.BalanceOfAt, abi.encode(_owner, _blockNumber));
+    }
+
+    function totalSupplyAt(uint256 _blockNumber) public view returns (uint256) {
+        return _aggregateAt(_blockNumber, CallType.TotalSupplyAt, abi.encode(_blockNumber));
+    }
+
+    // Forwarding fns
+
+    /**
+    * @notice Tells whether the VotingAggregator app is a forwarder or not
+    * @dev IForwarder interface conformance
+    * @return Always true
+    */
+    function isForwarder() public pure returns (bool) {
+        return true;
+    }
+
+    /**
+     * @notice Execute desired action if you have voting power
+     * @dev IForwarder interface conformance
+     * @param _evmScript Script being executed
+     */
+    function forward(bytes _evmScript) public {
+        require(canForward(msg.sender, _evmScript), ERROR_CAN_NOT_FORWARD);
+        bytes memory input = new bytes(0);
+
+        // No blacklist needed as this contract should not hold any tokens from its sources
+        runScript(_evmScript, input, new address[](0));
+    }
+
+    /**
+    * @notice Tells whether `_sender` can forward actions or not
+    * @dev IForwarder interface conformance
+    * @param _sender Address of the account intending to forward an action
+    * @return True if the given address can forward actions, false otherwise
+    */
+    function canForward(address _sender, bytes) public view returns (bool) {
+        return hasInitialized() && balanceOf(_sender) > 0;
+    }
+
+    // Getter fns
+
+    /**
+     * @dev Return information about a power source
+     * @param _sourceAddr Power source's address
+     * @return Power source type
+     * @return Whether power source is enabled
+     * @return Power source weight
+     */
+    function getPowerSourceDetails(address _sourceAddr)
+        public
+        view
+        sourceExists(_sourceAddr)
+        returns (
+            PowerSourceType sourceType,
+            bool enabled,
+            uint256 weight
+        )
+    {
+        PowerSource storage source = powerSourceDetails[_sourceAddr];
+
+        sourceType = source.sourceType;
+        enabled = source.enabledHistory.latestValue() == uint256(SOURCE_ENABLED_VALUE);
+        weight = source.weightHistory.latestValue();
+    }
+
+    /**
+     * @dev Return number of added power sources
+     * @return Number of added power sources
+     */
+    function getPowerSourcesLength() public view isInitialized returns (uint256) {
+        return powerSources.length;
+    }
+
+    // Internal fns
+
+    function _aggregateAt(uint256 _blockNumber, CallType _callType, bytes memory _paramdata) internal view returns (uint256) {
+        uint64 _blockNumberUint64 = _blockNumber.toUint64Time();
+
+        uint256 aggregate = 0;
+        for (uint256 i = 0; i < powerSources.length; i++) {
+            address sourceAddr = powerSources[i];
+            PowerSource storage source = powerSourceDetails[sourceAddr];
+
+            if (source.enabledHistory.getValueAt(_blockNumberUint64) == uint256(SOURCE_ENABLED_VALUE)) {
+                bytes memory invokeData = abi.encodePacked(_selectorFor(_callType, source.sourceType), _paramdata);
+                (bool success, uint256 value) = sourceAddr.staticInvoke(invokeData);
+                require(success, ERROR_SOURCE_CALL_FAILED);
+
+                uint256 weight = source.weightHistory.getValueAt(_blockNumberUint64);
+                aggregate = aggregate.add(weight.mul(value));
+            }
+        }
+
+        return aggregate;
+    }
+
+    function _powerSourceExists(address _sourceAddr) internal view returns (bool) {
+        // All attached power sources must have a valid source type
+        return powerSourceDetails[_sourceAddr].sourceType != PowerSourceType.Invalid;
+    }
+
+    function _selectorFor(CallType _callType, PowerSourceType _sourceType) internal pure returns (bytes4) {
+        if (_sourceType == PowerSourceType.ERC20WithCheckpointing) {
+            if (_callType == CallType.BalanceOfAt) {
+                return IERC20WithCheckpointing(0).balanceOfAt.selector;
+            }
+            if (_callType == CallType.TotalSupplyAt) {
+                return IERC20WithCheckpointing(0).totalSupplyAt.selector;
+            }
+        }
+
+        if (_sourceType == PowerSourceType.ERC900) {
+            if (_callType == CallType.BalanceOfAt) {
+                return IERC900History(0).totalStakedForAt.selector;
+            }
+            if (_callType == CallType.TotalSupplyAt) {
+                return IERC900History(0).totalStakedAt.selector;
+            }
+        }
+
+        revert(ERROR_INVALID_CALL_OR_SELECTOR);
+    }
+
+    // Private functions
+    function _sanityCheckSource(address _sourceAddr, PowerSourceType _sourceType) private view returns (bool) {
+        if (!isContract(_sourceAddr)) {
+            return false;
+        }
+
+        // Sanity check that the source and its declared type work for at least the current block
+        bytes memory balanceOfCalldata = abi.encodePacked(
+            _selectorFor(CallType.BalanceOfAt, _sourceType),
+            abi.encode(this, getBlockNumber())
+        );
+        (bool balanceOfSuccess,) = _sourceAddr.staticInvoke(balanceOfCalldata);
+
+        bytes memory totalSupplyCalldata = abi.encodePacked(
+            _selectorFor(CallType.TotalSupplyAt, _sourceType),
+            abi.encode(getBlockNumber())
+        );
+        (bool totalSupplySuccess,) = _sourceAddr.staticInvoke(totalSupplyCalldata);
+
+        return balanceOfSuccess && totalSupplySuccess;
+    }
+}

--- a/packages/toolkit/test/helpers/contracts/VotingAggregator/abi.json
+++ b/packages/toolkit/test/helpers/contracts/VotingAggregator/abi.json
@@ -613,6 +613,20 @@
             "inputs": [
                 {
                     "name": "_sourceAddr",
+                    "type": "string"
+                }
+            ],
+            "name": "disableSource",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
                     "type": "address"
                 }
             ],

--- a/packages/toolkit/test/helpers/contracts/VotingAggregator/abi.json
+++ b/packages/toolkit/test/helpers/contracts/VotingAggregator/abi.json
@@ -1,0 +1,793 @@
+{
+    "abi": [
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "name",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "hasInitialized",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "approve",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transferFrom",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_script",
+                    "type": "bytes"
+                }
+            ],
+            "name": "getEVMScriptExecutor",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "decimals",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint8"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getRecoveryVault",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "MANAGE_POWER_SOURCE_ROLE",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "MANAGE_WEIGHTS_ROLE",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "ADD_POWER_SOURCE_ROLE",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "token",
+                    "type": "address"
+                }
+            ],
+            "name": "allowRecoverability",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "appId",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bytes32"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getInitializationBlock",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "symbol",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "string"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_token",
+                    "type": "address"
+                }
+            ],
+            "name": "transferToVault",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "powerSources",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_sender",
+                    "type": "address"
+                },
+                {
+                    "name": "_role",
+                    "type": "bytes32"
+                },
+                {
+                    "name": "_params",
+                    "type": "uint256[]"
+                }
+            ],
+            "name": "canPerform",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getEVMScriptRegistry",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "name": "transfer",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "kernel",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "address"
+                }
+            ],
+            "name": "allowance",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isPetrified",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sourceAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "sourceType",
+                    "type": "uint8"
+                },
+                {
+                    "indexed": false,
+                    "name": "weight",
+                    "type": "uint256"
+                }
+            ],
+            "name": "AddPowerSource",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sourceAddress",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "newWeight",
+                    "type": "uint256"
+                }
+            ],
+            "name": "ChangePowerSourceWeight",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sourceAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "DisablePowerSource",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "sourceAddress",
+                    "type": "address"
+                }
+            ],
+            "name": "EnablePowerSource",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "executor",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "script",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "input",
+                    "type": "bytes"
+                },
+                {
+                    "indexed": false,
+                    "name": "returnData",
+                    "type": "bytes"
+                }
+            ],
+            "name": "ScriptResult",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "vault",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "token",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "amount",
+                    "type": "uint256"
+                }
+            ],
+            "name": "RecoverToVault",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "from",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Transfer",
+            "type": "event"
+        },
+        {
+            "anonymous": false,
+            "inputs": [
+                {
+                    "indexed": true,
+                    "name": "owner",
+                    "type": "address"
+                },
+                {
+                    "indexed": true,
+                    "name": "spender",
+                    "type": "address"
+                },
+                {
+                    "indexed": false,
+                    "name": "value",
+                    "type": "uint256"
+                }
+            ],
+            "name": "Approval",
+            "type": "event"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_name",
+                    "type": "string"
+                },
+                {
+                    "name": "_symbol",
+                    "type": "string"
+                },
+                {
+                    "name": "_decimals",
+                    "type": "uint8"
+                }
+            ],
+            "name": "initialize",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
+                    "type": "address"
+                },
+                {
+                    "name": "_sourceType",
+                    "type": "uint8"
+                },
+                {
+                    "name": "_weight",
+                    "type": "uint256"
+                }
+            ],
+            "name": "addPowerSource",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
+                    "type": "address"
+                },
+                {
+                    "name": "_weight",
+                    "type": "uint256"
+                }
+            ],
+            "name": "changeSourceWeight",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
+                    "type": "address"
+                }
+            ],
+            "name": "disableSource",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
+                    "type": "address"
+                }
+            ],
+            "name": "enableSource",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_owner",
+                    "type": "address"
+                }
+            ],
+            "name": "balanceOf",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "totalSupply",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_owner",
+                    "type": "address"
+                },
+                {
+                    "name": "_blockNumber",
+                    "type": "uint256"
+                }
+            ],
+            "name": "balanceOfAt",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_blockNumber",
+                    "type": "uint256"
+                }
+            ],
+            "name": "totalSupplyAt",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "isForwarder",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "pure",
+            "type": "function"
+        },
+        {
+            "constant": false,
+            "inputs": [
+                {
+                    "name": "_evmScript",
+                    "type": "bytes"
+                }
+            ],
+            "name": "forward",
+            "outputs": [],
+            "payable": false,
+            "stateMutability": "nonpayable",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_sender",
+                    "type": "address"
+                },
+                {
+                    "name": "",
+                    "type": "bytes"
+                }
+            ],
+            "name": "canForward",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "bool"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [
+                {
+                    "name": "_sourceAddr",
+                    "type": "address"
+                }
+            ],
+            "name": "getPowerSourceDetails",
+            "outputs": [
+                {
+                    "name": "sourceType",
+                    "type": "uint8"
+                },
+                {
+                    "name": "enabled",
+                    "type": "bool"
+                },
+                {
+                    "name": "weight",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        },
+        {
+            "constant": true,
+            "inputs": [],
+            "name": "getPowerSourcesLength",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256"
+                }
+            ],
+            "payable": false,
+            "stateMutability": "view",
+            "type": "function"
+        }
+    ]
+}

--- a/packages/toolkit/test/helpers/contracts/VotingAggregator/arapp.json
+++ b/packages/toolkit/test/helpers/contracts/VotingAggregator/arapp.json
@@ -1,0 +1,59 @@
+{
+    "environments": {
+      "default": {
+        "appName": "voting-aggregator.open.aragonpm.eth",
+        "network": "rpc"
+      },
+      "mainnet": {
+        "appName": "voting-aggregator.hatch.aragonpm.eth",
+        "network": "mainnet",
+        "registry": "0x314159265dd8dbb310642f98f50c066173c1259b",
+        "wsRPC": "wss://mainnet.eth.aragon.network/ws"
+      },
+      "rinkeby": {
+        "appName": "voting-aggregator.hatch.aragonpm.eth",
+        "network": "rinkeby",
+        "registry": "0x98Df287B6C145399Aaa709692c8D308357bC085D",
+        "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+      },
+      "ropsten": {
+        "appName": "voting-aggregator.hatch.aragonpm.eth",
+        "network": "ropsten",
+        "registry": "0x6afe2cacee211ea9179992f89dc61ff25c61e923",
+        "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+      },
+      "staging": {
+        "appName": "voting-aggregator.hatch.aragonpm.eth",
+        "network": "rinkeby",
+        "registry": "0xfe03625ea880a8cba336f9b5ad6e15b0a3b5a939",
+        "wsRPC": "wss://rinkeby.eth.aragon.network/ws"
+      }
+    },
+    "roles": [
+      {
+        "name": "Add new power sources",
+        "id": "ADD_POWER_SOURCE_ROLE",
+        "params": [
+          "Source address",
+          "Source weight"
+        ]
+      },
+      {
+        "name": "Manage power sources",
+        "id": "MANAGE_POWER_SOURCE_ROLE ",
+        "params": [
+          "Enabling source"
+        ]
+      },
+      {
+        "name": "Manage power source weights",
+        "id": "MANAGE_WEIGHTS_ROLE",
+        "params": [
+          "New weight",
+          "Old weight"
+        ]
+      }
+    ],
+    "path": "contracts/VotingAggregator.sol"
+  }
+  

--- a/packages/toolkit/test/helpers/extractContractInfoToFile.test.js
+++ b/packages/toolkit/test/helpers/extractContractInfoToFile.test.js
@@ -28,7 +28,7 @@ test.before('create a temp directory and resolve paths', (t) => {
 })
 
 test.before('call extractContractInfoToFile function', async (t) => {
-  await extractContractInfoToFile(contractPath, outputPath)
+  await extractContractInfoToFile(contractPath, [], outputPath)
 })
 
 test('generates output', (t) => {

--- a/packages/toolkit/test/helpers/generateArtifact.test.js
+++ b/packages/toolkit/test/helpers/generateArtifact.test.js
@@ -1,4 +1,4 @@
-import test, { beforeEach, before } from 'ava'
+import test, { before } from 'ava'
 import fs from 'fs-extra'
 import path from 'path'
 
@@ -9,27 +9,47 @@ import arapp from './contracts/VotingAggregator/arapp'
 var votingAggregatorSource
 
 before(async (t) => {
-  votingAggregatorSource = await fs.readFile(path.join(__dirname, './contracts/VotingAggregator/VotingAggregator.sol'), 'utf8')
+  votingAggregatorSource = await fs.readFile(
+    path.join(__dirname, './contracts/VotingAggregator/VotingAggregator.sol'),
+    'utf8'
+  )
 })
 
 test('Converts enums to the appropriate uint', async (t) => {
-  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
-  const addPowerSourceFunc = artifact.functions.find(func => func.sig.includes('addPowerSource('))
+  const artifact = await generateApplicationArtifact(
+    arapp,
+    abi,
+    votingAggregatorSource
+  )
+  const addPowerSourceFunc = artifact.functions.find((func) =>
+    func.sig.includes('addPowerSource(')
+  )
 
   t.deepEqual(addPowerSourceFunc.sig, 'addPowerSource(address,uint8,uint256)')
 })
 
 test('Handles string and uint correctly', async (t) => {
-  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
-  const initializeFunc = artifact.functions.find(func => func.sig.includes('initialize('))
+  const artifact = await generateApplicationArtifact(
+    arapp,
+    abi,
+    votingAggregatorSource
+  )
+  const initializeFunc = artifact.functions.find((func) =>
+    func.sig.includes('initialize(')
+  )
 
   t.deepEqual(initializeFunc.sig, 'initialize(string,string,uint8)')
 })
 
 test('Supports overloaded functions', async (t) => {
-  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
-  const disableSourceFunc = artifact.functions.find(func => func.sig.includes('disableSource('))
+  const artifact = await generateApplicationArtifact(
+    arapp,
+    abi,
+    votingAggregatorSource
+  )
+  const disableSourceFunc = artifact.functions.find((func) =>
+    func.sig.includes('disableSource(')
+  )
 
   t.deepEqual(disableSourceFunc.sig, 'disableSource(address)')
 })
-

--- a/packages/toolkit/test/helpers/generateArtifact.test.js
+++ b/packages/toolkit/test/helpers/generateArtifact.test.js
@@ -1,5 +1,17 @@
 import test from 'ava'
+import fs from 'fs-extra'
+import path from 'path'
 
-test('t', (t) => {
-  t.pass()
+import { generateApplicationArtifact } from '../../src/helpers/generateArtifact'
+import { abi } from './contracts/VotingAggregator/abi'
+import arapp from './contracts/VotingAggregator/arapp'
+
+
+test('Converts enums to the appropriate uint', async (t) => {
+  const source = await fs.readFile(path.join(__dirname, './contracts/VotingAggregator/VotingAggregator.sol'), 'utf8')
+
+  const artifact = await generateApplicationArtifact(arapp, abi, source)
+  const addPowerSourceFunc = artifact.functions.find(func => func.sig.includes('addPowerSource('))
+
+  t.deepEqual(addPowerSourceFunc.sig, 'addPowerSource(address,uint8,uint256)')
 })

--- a/packages/toolkit/test/helpers/generateArtifact.test.js
+++ b/packages/toolkit/test/helpers/generateArtifact.test.js
@@ -1,4 +1,4 @@
-import test from 'ava'
+import test, { beforeEach, before } from 'ava'
 import fs from 'fs-extra'
 import path from 'path'
 
@@ -6,12 +6,30 @@ import { generateApplicationArtifact } from '../../src/helpers/generateArtifact'
 import { abi } from './contracts/VotingAggregator/abi'
 import arapp from './contracts/VotingAggregator/arapp'
 
+var votingAggregatorSource
+
+before(async (t) => {
+  votingAggregatorSource = await fs.readFile(path.join(__dirname, './contracts/VotingAggregator/VotingAggregator.sol'), 'utf8')
+})
 
 test('Converts enums to the appropriate uint', async (t) => {
-  const source = await fs.readFile(path.join(__dirname, './contracts/VotingAggregator/VotingAggregator.sol'), 'utf8')
-
-  const artifact = await generateApplicationArtifact(arapp, abi, source)
+  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
   const addPowerSourceFunc = artifact.functions.find(func => func.sig.includes('addPowerSource('))
 
   t.deepEqual(addPowerSourceFunc.sig, 'addPowerSource(address,uint8,uint256)')
 })
+
+test('Handles string and uint correctly', async (t) => {
+  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
+  const initializeFunc = artifact.functions.find(func => func.sig.includes('initialize('))
+
+  t.deepEqual(initializeFunc.sig, 'initialize(string,string,uint8)')
+})
+
+test('Supports overloaded functions', async (t) => {
+  const artifact = await generateApplicationArtifact(arapp, abi, votingAggregatorSource)
+  const disableSourceFunc = artifact.functions.find(func => func.sig.includes('disableSource('))
+
+  t.deepEqual(disableSourceFunc.sig, 'disableSource(address)')
+})
+


### PR DESCRIPTION
# 🦅 Pull Request Description

- Fixes #1673  

## Rational

The artifact generator previously converted any unknown types (e.g. `PowerSourceType`) to `address`, which works for contracts but not enums. In this PR, we attempt to get ABI nodes matching the function name and number of parameters. If a single node is found, it generates the signature with it, otherwise it still uses the manual logic. Generating the artifact from the AST instead of the source would be even better but this should at least fix the enum signatures in most cases.


## 🚨 Test instructions

`aragon apm publish major --artifact-only` in voting-aggregator app.

## ✔️ PR Todo

- [x] Include links to related issues/PRs
- [x] Update unit tests for this change
- [x] Update the relevant documentation
- [x] Clear dependencies on other modules that have to be released before merging this

