### PR TITLE
chore: update to dependabot v2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,7 +1,0 @@
-# This is an example with only required properties:
-version: 1
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"
-    target_branch: master

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+update_configs:
+- package-ecosystem: "npm"
+  directory: "/"
+  schedule:
+    interval: "monthly"
+    time: "15:00"
+  target-branch: master

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 
 # Tools
 lerna-debug.log
+*/*/typechain
 
 # Extra
 packages/cli/src/knownRoles.json


### PR DESCRIPTION
Updates the dependabot configuration to [v2](https://docs.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file).

Also updates its frequency to be monthly, sending updates only at 15:00 UTC on the first day of each month.