### PR TITLE
chore: fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 version: 2
-update_configs:
+updates:
 - package-ecosystem: "npm"
   directory: "/"
   schedule:


### PR DESCRIPTION
Oops, used the wrong `updates` key before on updating to v2.