### PR TITLE
Fixed issue with apm packages command

### DIFF
--- a/packages/cli/src/commands/apm_cmds/packages.js
+++ b/packages/cli/src/commands/apm_cmds/packages.js
@@ -66,13 +66,13 @@ export const handler = async function ({
  */
 function displayPackages(packages) {
   const table = new Table({
-    head: ['App', 'Repo Address'],
+    head: ['App', 'Latest Version'],
   })
-
+  
   packages.forEach((aPackage) => {
-    const row = [aPackage.name, aPackage.repo]
+    const row = [aPackage.name, aPackage.version]
     table.push(row)
   })
-
+ 
   console.log('\n', table.toString())
 }

--- a/packages/cli/src/commands/apm_cmds/packages.js
+++ b/packages/cli/src/commands/apm_cmds/packages.js
@@ -68,11 +68,9 @@ function displayPackages(packages) {
   const table = new Table({
     head: ['App', 'Latest Version'],
   })
-  
   packages.forEach((aPackage) => {
     const row = [aPackage.name, aPackage.version]
     table.push(row)
   })
- 
   console.log('\n', table.toString())
 }


### PR DESCRIPTION
# 🦅 Pull Request Description

This PR is related to #1824 and does get merged into the QA PR called ``issue-1050/update-tests ``

## Rational

The `packages object` was returning `name` and `version` properties, before the fix the table was trying to fetch a `repo` property that wasn't being returned by the object and this was causing the error.

## ✔️ PR Todo

This command (`aragon apm packages`) is still failing on Rinkeby. This is another issue that has to be fixed by someone with access to the aragonpm.eth registry: https://github.com/aragon/aragon-cli/issues/1824#issuecomment-789476637

