### PR TITLE
Updated source code to remove the deprecated go-ipfs version

### DIFF
--- a/packages/toolkit/src/ipfs/constants.js
+++ b/packages/toolkit/src/ipfs/constants.js
@@ -18,5 +18,7 @@ export const DEFAULT_DAEMON_ARGS = ['--migrate']
 export const NO_INSTALLATION_MSG =
   'IPFS is not installed. Use `aragon ipfs install` before proceeding.'
 
-export const GO_IMPL_DIST_VERSION = '0.4.22'
+// version 0.4.22 is deprecated
+// Either update it, or remove it completely to install latest stable version
+// export const GO_IMPL_DIST_VERSION = '0.4.22'
 export const GO_IMPL_DIST_URL = 'https://dist.ipfs.io'

--- a/packages/toolkit/src/ipfs/install.js
+++ b/packages/toolkit/src/ipfs/install.js
@@ -1,12 +1,11 @@
 import execa from 'execa'
 //
 import { noop, getNodePackageManager } from '../node'
-import { GO_IMPL_DIST_URL, GO_IMPL_DIST_VERSION } from './constants'
+import { GO_IMPL_DIST_URL } from './constants'
 
 export const installGoIpfs = async (
   local,
   location,
-  distVersion = GO_IMPL_DIST_VERSION,
   distUrl = GO_IMPL_DIST_URL,
   options = {}
 ) => {
@@ -29,7 +28,7 @@ export const installGoIpfs = async (
   }
   const npmArgs = [
     'install',
-    `go-ipfs@${distVersion}`,
+    'go-ipfs',
     local ? '--save' : '--global',
   ]
 
@@ -45,7 +44,7 @@ export const installGoIpfs = async (
   } catch (err) {
     if (err.stderr && err.stderr.includes('No matching version found')) {
       throw new Error(
-        `NPM cannot find version ${distVersion}. For more versions see: http://npmjs.com/package/go-ipfs?activeTab=versions`
+        `NPM cannot find the latest version. For more versions see: http://npmjs.com/package/go-ipfs?activeTab=versions`
       )
     } else {
       throw new Error(err)


### PR DESCRIPTION
# 🦅 Pull Request Description  
This pull request is a solution to the bug stated in the [issue 1833](https://github.com/aragon/aragon-cli/issues/1833). `npm run pretest` doesn't work as it gives deprecated go-ipfs error.
<!-- Pull request description and links to related issues -->
## Rational
As of now, the source code in master branch is hard-coded to use 0.4.22 version of go-ipfs which is already giving the deprecation error. My updated code doesn't look for version specific go-ipfs. It downloads the LTS version of go-ipfs and thus even if any of the version gets deprecated, it won't affect aragon-cli as it will then work on the latest version.
<!-- Please explain the reasoning behind your changed -->

## 🚨 Test instructions
The testing is pretty straight-forward, clone the branch locally, run the commands `yarn install`, `yarn run build`, `yarn run pretest`. `yarn run pretest` should successfully install the go-ipfs which can then be used to run `yarn test`.
<!-- In case it is difficult or not straightforward to test this change,
please provide test instructions! -->

## ✔️ PR Todo

- [ ] Include links to related issues/PRs
- [ ] Update unit tests for this change
- [ ] Update the relevant documentation
- [ ] Clear dependencies on other modules that have to be released before merging this

<!--
Thank you for contributing! 

To help us review this change in a timely manner, please make sure to read and follow the 
[CONTRIBUTING](https://github.com/aragon/aragon-cli/blob/master/CONTRIBUTING.md) guidelines.
-->
